### PR TITLE
Podman compose results user owned

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,10 @@ drwxr-xr-x. 7 fedora fedora  140 Dec 13 08:11 sessions
 
 ```
 $ podman-compose -f podman-compose.yml up
-$ podman unshare chown 1000 ./results (podman bind volumes as container root while the app runs as container zap user)
+```
+On older podman versions (before 3.1.0), you will need to manually make the `./result` directory writable to the `zap` user. This can be done with the following command :
+```
+$ podman unshare chown 1000 ./results
 ```
 
 #### Launch a scan
@@ -92,7 +95,10 @@ This is taking advantage of ZAP's webswing feature. See https://www.zaproxy.org/
 #### Run a container
 ```
 $ podman-compose -f podman-compose-ui.yml up
-$ podman unshare chown 1000 ./results (podman bind volumes as container root while the app runs as container zap user)
+```
+On older podman versions (before 3.1.0), you will need to manually make the `./result` directory writable to the `zap` user. This can be done with the following command :
+```
+$ podman unshare chown 1000 ./results
 ```
 After the step, it is necessary to navigate to the GUI via http://127.0.0.1:8081/zap to start an actual ZAP instance. 
 

--- a/podman-compose-ui.yml
+++ b/podman-compose-ui.yml
@@ -12,7 +12,7 @@ services:
     volumes:
       - ./scripts:/zap/scripts:Z
       - ./config:/zap/config:Z
-      - ./results:/zap/results:Z
+      - ./results:/zap/results:Z,U
       - ./policies:/zap/policies:Z
       - ./webswing:/zap/webswing_custom:Z
     command:

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -11,7 +11,7 @@ services:
     volumes:
       - ./scripts:/zap/scripts:Z
       - ./config:/zap/config:Z
-      - ./results:/zap/results:Z
+      - ./results:/zap/results:Z,U
       - ./policies:/zap/policies:Z
     command:
       - /bin/bash


### PR DESCRIPTION
    Podman 3.1.0 and above support the "U" flag to change ownership of
    volumes.
    This makes the `unshare chown` unecessary when using podman >= 3.1
    IIUC, it does not affect older versions, which will simply ignore the
    unknown flag.