### PR TITLE
Add containerfile and entrypoint script

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,16 @@
+FROM owasp/zap2docker-stable:latest
+USER root
+RUN pip install jinja2
+
+RUN chgrp -R 0 /zap && \
+    chmod -R g=u /zap
+
+RUN chgrp -R 0 /home/zap && \
+    chmod -R g=u /home/zap 
+USER zap
+COPY scripts /zap/scripts
+COPY policies /zap/policies
+COPY entrypoint.sh .
+
+ENTRYPOINT ["entrypoint.sh"]
+CMD ["tmp"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# This MUST be the same as resultDir in config.yaml
+RESULT_DIR=results
+
+# Create rundir
+RUNDIR=$RESULT_DIR/$1
+mkdir $RUNDIR
+
+
+# Run in backgound to make sure we move on to following instructions
+zap.sh -cmd -addonupdate && zap.sh -daemon -port 8090 -config api.key=cnmeemn7jp7ijd8rl5u14q40v8 -config database.newsession=3 -config database.newsessionprompt=false -addoninstall ascanrulesBeta &
+
+# sleep to give ZAP a chance to get set up
+sleep 45
+
+python scripts/gen-zap-script/cli.py --rapidast-config=./config/config.yaml --delete
+python scripts/gen-zap-script/cli.py --rapidast-config=./config/config.yaml --from-yaml scripts/gen-zap-script/rules/software_version_revealed.yaml --load-and-enable
+
+
+# Run scan
+python scripts/apis_scan.py $1


### PR DESCRIPTION
This adds a containerfile that bundles scripts and policies be used to run RapiDAST as a job on OCP/k8s