### PR TITLE
URL Scanning Ability.

### DIFF
--- a/config/config-template-local.yaml
+++ b/config/config-template-local.yaml
@@ -7,6 +7,8 @@ general:
   shutdownOnceFinished: False
 
 openapi:
+  urlScan: True
+  urlScanDir: '/scripts'
   importFromUrl: True
   url: "http://localhost:9001/openapi.yaml"
 

--- a/scripts/apis_scan.py
+++ b/scripts/apis_scan.py
@@ -4,6 +4,8 @@ import sys
 import time
 import logging
 from datetime import datetime
+
+import six
 from zapv2 import ZAPv2
 
 from config import *
@@ -161,8 +163,19 @@ def enable_passive_scanner():
     zap.pscan.enable_all_scanners()
     zap.pscan.disable_scanners(disabledPassiveScan)
 
+def importurls(filepath):
+    """
+    Imports URLs (one per line) from the file with the given file system path.
+    This component is optional and therefore the API will only work if it is installed
+    """
+    return six.next(six.itervalues(zap._request(zap.base + 'exim/action/importUrls',
+                                                         {'filePath': filepath})))
 
 def get_APIs():
+    if urlScan:
+        url_list_path = "/zap" + urlScanDir + "/" + "urlScan.config"
+        print ("Scanning from URL List")
+        importurls(url_list_path)
     if oasImportFromUrl:
         logging.info("Importing API from URL: " + oasUrl)
 
@@ -229,16 +242,29 @@ def start_active_scanner():
     zap.ascan.set_option_thread_per_host(20)
     # Launch Active scan with the configured policy on the target url and
     # recursively scan every site node
-    scan_id = zap.ascan.scan(
-        url=target,
-        recurse=True,
-        inscopeonly=True,
-        scanpolicyname=scanPolicyName,
-        method=None,
-        postdata=True,
-        contextid=context_id,
-    )
-
+    scan_id = None
+    if urlScan:
+        urls = zap.core.urls()
+        print(urls)
+        for u in urls:
+            scan_id = zap.ascan.scan(
+                url=u,
+                recurse=True,
+                inscopeonly=True,
+                scanpolicyname=scanPolicyName,
+                method=None,
+                postdata=True,
+                contextid=context_id)
+    else:
+        scan_id = zap.ascan.scan(
+            url=target,
+            recurse=True,
+            inscopeonly=True,
+            scanpolicyname=scanPolicyName,
+            method=None,
+            postdata=True,
+            contextid=context_id,
+        )
     try:
         int(scan_id)
     except ValueError:

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -26,6 +26,8 @@ else:
     useProxyChain = False
 
 if "openapi" in config:
+    urlScanDir = config['openapi']['urlScanDir']
+    urlScan = config['openapi']['urlScan']
     oasImportFromUrl = config["openapi"]["importFromUrl"]
     if oasImportFromUrl:
         oasUrl = config["openapi"]["url"]


### PR DESCRIPTION
Adding the ability to scan from URLs specified in a URL Scan config file that does not have an OAS definition. Note that the reason the importurls method has been added here is because the zap python API project currently does not support exim (the new ZAP addon for importing urls) and only makes use of the deprecated importurls addon. I've added support for exim imports instead in the new method.