### PR TITLE
increase default logging to INFO by default

### DIFF
--- a/scripts/apis_scan.py
+++ b/scripts/apis_scan.py
@@ -300,11 +300,13 @@ def generate_report(scan_timestamp):
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description='Connect to ZAP and launch a scan based on config.yaml')
-    parser.add_argument('--debug', action='count', default=0, help='Show debugging output')
-    parser.add_argument('destination', metavar='N',
-                                help=f"Directory of the report, relative to {resultDir}")
+    parser.add_argument('--log-level', dest='loglevel', 
+            choices=["debug","info","warning","error","critical"], 
+            default="info", help='Level of verbosity')
+    parser.add_argument('destination', metavar='NAME',
+            help=f"Directory of the report, relative to {resultDir}")
 
-    logging.basicConfig(level=logging.DEBUG if parser.parse_args().debug else logging.INFO)
+    logging.basicConfig(level=parser.parse_args().loglevel.upper())
 
     workDir = resultDir + parser.parse_args().destination + "/"
 

--- a/scripts/apis_scan.py
+++ b/scripts/apis_scan.py
@@ -5,6 +5,7 @@ import time
 import logging
 from datetime import datetime
 from zapv2 import ZAPv2
+import argparse
 
 from config import *
 
@@ -298,7 +299,14 @@ def generate_report(scan_timestamp):
 
 if __name__ == "__main__":
 
-    workDir = resultDir + sys.argv[1] + "/"
+    parser = argparse.ArgumentParser(description='Connect to ZAP and launch a scan based on config.yaml')
+    parser.add_argument('--debug', action='count', default=0, help='Show debugging output')
+    parser.add_argument('destination', metavar='N',
+                                help=f"Directory of the report, relative to {resultDir}")
+
+    logging.basicConfig(level=logging.DEBUG if parser.parse_args().debug else logging.INFO)
+
+    workDir = resultDir + parser.parse_args().destination + "/"
 
     try:
         zap = ZAPv2(proxies=localProxy, apikey=apiKey)


### PR DESCRIPTION
- added a CLI argument parser
- increased default logging level to INFO
  + by default, `logging` logs at WARN only
- added `--debug` to show debug logs

Comments welcome!
I think adding a parser will make it easier to add CLI options