### PR TITLE
OpenAPI import URL: retry up to 3 times on error

### DIFF
--- a/scripts/apis_scan.py
+++ b/scripts/apis_scan.py
@@ -168,7 +168,14 @@ def get_APIs():
         logging.info("Importing API from URL: " + oasUrl)
 
         try:
-            zap.openapi.import_url(oasUrl, target)
+            count = 1
+            while count <= 3:
+                ret = zap.openapi.import_url(oasUrl, target)
+                if ret == []:
+                    break
+                logging.warning(f"ZAP import OpenAPI {oasUrl} failed (returned '{ret}'). It may be due to bad authentication. Attempt {count}/3")
+                count = count + 1
+                time.sleep(3)
         except Exception as e:
             raise RuntimeError(
                 "Something went wrong while importing OpenAPI: " + str(e)


### PR DESCRIPTION
Sometimes, when using OAuth2 token authentication, the download of the OAS URL fails. This is because the request is sent with `Authorization: Bearer null` , which may be rejected by the server.

I suspect that this is because the token is requested asynchronously, and at the time of importing the OAS, the process has not finished yet.

I did not find a clean way around it. This patch is inspired by how RapidPT works around this : if the import fails, it sleeps for a few seconds and try again (up to 3 attempts, but in my tests, the second attempt will always succeed).