### PR TITLE
Revised URL Scanning

### DIFF
--- a/config/config-template-local.yaml
+++ b/config/config-template-local.yaml
@@ -1,10 +1,14 @@
 general:
   serviceName: 'demo1'
-  resultDir: '/results/'
+  resultDir: '/results'
   appDir: '/zap'
   localProxy: {"http": "http://127.0.0.1:8090", "https": "http://127.0.0.1:8090"}
   sessionName: 'session1'
   shutdownOnceFinished: False
+
+urlscan:
+  urlScan: True
+  urlScanDir: '/scripts'
 
 openapi:
   # import the OpenAPI definitions from an url will only work for public API

--- a/scripts/apis_scan.py
+++ b/scripts/apis_scan.py
@@ -334,7 +334,7 @@ def wait_for_passive_scanner():
 
 def generate_report(scan_timestamp):
     report = appDir + workDir + serviceName + "-report-" + scan_timestamp + ".xml"
-    f = open(report, "w+")
+    f = open(report, "w")
     f.write(zap.core.xmlreport())
 
     f.close()

--- a/scripts/apis_scan.py
+++ b/scripts/apis_scan.py
@@ -173,7 +173,6 @@ def importurls(filepath):
 def get_APIs():
     if urlScan:
         url_list_path = f"/zap{urlScanDir}/urlScan.config"
-        print(url_list_path)
         logging.info("Scanning from URL List")
         importurls(url_list_path)
     elif oasImportFromUrl:
@@ -262,7 +261,6 @@ def start_active_scanner():
     if urlScan:
         urls = zap.core.urls()
         url_list_path = f"/zap{urlScanDir}/urlScan.config"
-        print(urls)
         with open(url_list_path, 'r', encoding='UTF-8') as file:
             while (line := file.readline().rstrip()):
                 scan_id = zap.ascan.scan(

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -32,6 +32,13 @@ if "openapi" in config:
     else:
         oasDir = config["openapi"]["directory"]
 
+if "urlscan" in config:
+    urlScanDir = config['urlscan']['urlScanDir']
+    urlScan = config['urlscan']['urlScan']
+else:
+    urlScanDir = None
+    UrlScan = False
+
 
 contextName = config["scan"]["contextName"]
 target = config["scan"]["target"]

--- a/scripts/urlScan.config
+++ b/scripts/urlScan.config
@@ -1,0 +1,1 @@
+https://petstore.swagger.io/v2/pet/findByStatus?status=available


### PR DESCRIPTION
Changes have been made from the previous PR to try and create a better URL scanning ability. We have switched over to logging, added in checks for the scan ID succeeding (though that can be adjusted) and fixed an issues where ZAP would cut URLs into segments scanning each segment (IE: for example.com/api/v1/checkthis it would scan: example.com & example.com/api and example.com/api/v1 individually vs the intended URL). The temp fix for this was ensuring we are scanning only what is in the URL file. There was lots of feedback on the last PR, everything should have been adjusted off of that feedback but if I missed anything please let me know!