### PR TITLE
Retrieve API_KEY from .env

### DIFF
--- a/scripts/gen_zap_script/cli.py
+++ b/scripts/gen_zap_script/cli.py
@@ -249,7 +249,7 @@ if __name__ == "__main__":
                 )
             )
         zap_options["proxies"] = rapidast_config["general"]["localProxy"]
-        zap_options["apikey"] = rapidast_config["general"]["apiKey"]
+        zap_options["apikey"] = os.getenv("API_KEY")
 
     if args.delete_existing:
         logger.info("Deleting previously generated scripts")


### PR DESCRIPTION
The issue is that config/config.yaml no longer has a "apiKey" under
"general" but the ZAP script generator is looking for it. This patch has
it pull from the environment instead.