### PR TITLE
Remove "unshare" mode on volume mount

### DIFF
--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -10,6 +10,6 @@ services:
     volumes:
       - ./scripts:/zap/scripts:Z
       - ./config:/zap/config:Z
-      - ./results:/zap/results:Z,U
+      - ./results:/zap/results:Z
       - ./policies:/zap/policies:Z
     entrypoint: /zap/scripts/entrypoint.sh


### PR DESCRIPTION
The results directory should not have the "U" unshare mode. The reason
is that the ./test/scan-example-with-podman.sh script intends to create
a child directory in results. "U" here removes ownership from the EUID
too early, and it's not the right directory to unshare anyway. We want
to unshare the child. This patch reverts the addition of "U" mode on the
results mount.