### PR TITLE
fix the results folder permission issue

### DIFF
--- a/podman-compose-ui.yml
+++ b/podman-compose-ui.yml
@@ -11,7 +11,7 @@ services:
     volumes:
       - ./scripts:/zap/scripts:Z
       - ./config:/zap/config:Z
-      - ./results:/zap/results:Z,U
+      - ./results:/zap/results:Z
       - ./policies:/zap/policies:Z
       - ./webswing:/zap/webswing_custom:Z
     entrypoint: /zap/scripts/entrypoint_ui.sh

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -10,6 +10,6 @@ services:
     volumes:
       - ./scripts:/zap/scripts:Z
       - ./config:/zap/config:Z
-      - ./results:/zap/results:Z,U
+      - ./results:/zap/results:Z
       - ./policies:/zap/policies:Z
     entrypoint: /zap/scripts/entrypoint.sh


### PR DESCRIPTION
fix adding 'U' ends up changing the results folder's permission to an arbitrary userID, which prevents a localhost user from accesing the folder