### PR TITLE
adding healthcheck to podman-compose

### DIFF
--- a/podman-compose-ui.yml
+++ b/podman-compose-ui.yml
@@ -15,3 +15,9 @@ services:
       - ./policies:/zap/policies:Z
       - ./webswing:/zap/webswing_custom:Z
     entrypoint: /zap/scripts/entrypoint_ui.sh
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8090/"]
+      interval: 1m30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -13,3 +13,9 @@ services:
       - ./results:/zap/results:Z
       - ./policies:/zap/policies:Z
     entrypoint: /zap/scripts/entrypoint.sh
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8090/"]
+      interval: 1m30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s


### PR DESCRIPTION
This allows to separately check the status of RapiDAST from a separate command, such as :

```
$ podman-compose -f ./podman-compose-ui.yml ps
['podman', '--version', '']
using podman version: 4.2.1
podman ps -a --filter label=io.podman.compose.project=rapidast
CONTAINER ID  IMAGE                                                   COMMAND     CREATED         STATUS                       PORTS                                               NAMES
18eef7aefb78  quay.io/redhatproductsecurity/rapidast-base-zap:latest              16 minutes ago  Up 16 minutes ago (healthy)  127.0.0.1:8081->8080/tcp, 127.0.0.1:8091->8090/tcp  zaproxy
exit code: 0
```