### PR TITLE
Adding docker compose files and parameterized token authentication script

### DIFF
--- a/config/config-template-local.yaml
+++ b/config/config-template-local.yaml
@@ -87,6 +87,10 @@ scan:
   #HttpSenderScriptEngine: 'Oracle Nashorn'
   #HttpSenderScriptFilePath: 'scripts/add-bearer-token.js'
   #HttpSenderScriptDescription: 'add bearer token to each HTTP request'
+  #HTTPParams: {} # Any parameters you want to use in your authentication script, use in script with key, values that change at runtime 
+  ## For OpenShift: {"cookieName": 'openshift-session-token', "cookieVal": 'sha256~**'}
+  ## See [example](../scripts/add-token-cookie-param.js) of how to obtain these values in script
+
 
 #### UPSTREAM PROXY ####
 proxy:

--- a/operator/README.md
+++ b/operator/README.md
@@ -182,6 +182,21 @@ spec:
 
 Most of the application specific scan configuration exists under `spec.config`. This is itself YAML syntax included here as a multiline string. This is the same configuration used in the core RapiDAST project [here](https://github.com/RedHatProductSecurity/rapidast/blob/development/config/config-template-local.yaml)
 
+#### Authentication Config Options
+
+For authentication from within an OpenShift cluster, use below as your authentication type/configuration 
+Add your specific token as the cookieVal that can be obtained via 'Copy login command' menu in the console
+
+```
+authMethod: null
+useHttpSenderScript: True
+HttpSenderScriptName: 'add-cookie'
+HttpSenderScriptEngine: 'Oracle Nashorn'
+HttpSenderScriptFilePath: 'scripts/add-token-cookie-param.js'
+HttpSenderScriptDescription: 'add a cookie to each HTTP request'
+HTTPParams: {"cookieName": 'openshift-session-token', "cookieVal": 'sha256~***'}
+```
+
 #### Operator Config Options
 
 There are additional config options specific to the operator.

--- a/runenv-docker-ui.sh
+++ b/runenv-docker-ui.sh
@@ -1,0 +1,4 @@
+docker-compose down zaproxy_action
+docker-compose down zaproxy
+docker-compose down zaproxy_ui
+docker-compose up zaproxy_ui

--- a/runenv-docker.sh
+++ b/runenv-docker.sh
@@ -1,0 +1,4 @@
+docker-compose down zaproxy_action
+docker-compose down zaproxy
+docker-compose down zaproxy_ui
+docker-compose up zaproxy

--- a/scripts/add-token-cookie-param.js
+++ b/scripts/add-token-cookie-param.js
@@ -1,0 +1,72 @@
+// The sendingRequest and responseReceived functions will be called for all requests/responses sent/received by ZAP, 
+// including automated tools (e.g. active scanner, fuzzer, ...)
+
+// Note that new HttpSender scripts will initially be disabled
+// Right click the script in the Scripts tree and select "enable"  
+
+// 'initiator' is the component the initiated the request:
+// 		1	PROXY_INITIATOR
+// 		2	ACTIVE_SCANNER_INITIATOR
+// 		3	SPIDER_INITIATOR
+// 		4	FUZZER_INITIATOR
+// 		5	AUTHENTICATION_INITIATOR
+// 		6	MANUAL_REQUEST_INITIATOR
+// 		7	CHECK_FOR_UPDATES_INITIATOR
+// 		8	BEAN_SHELL_INITIATOR
+// 		9	ACCESS_CONTROL_SCANNER_INITIATOR
+// 		10	AJAX_SPIDER_INITIATOR
+// For the latest list of values see the HttpSender class:
+// https://github.com/zaproxy/zaproxy/blob/main/zap/src/main/java/org/parosproxy/paros/network/HttpSender.java
+// 'helper' just has one method at the moment: helper.getHttpSender() which returns the HttpSender 
+// instance used to send the request.
+//
+// New requests can be made like this:
+// msg2 = msg.cloneAll() // msg2 can then be safely changed as required without affecting msg
+// helper.getHttpSender().sendAndReceive(msg2, false);
+// print('msg2 response=' + msg2.getResponseHeader().getStatusCode())
+
+function sendingRequest(msg, initiator, helper) {
+	
+    //  print('sendingRequest called for url=' + msg.getRequestHeader().getURI().toString())
+    var cookies = msg.getCookieParams();
+    //  print ("Cookies before update: " + cookies);
+
+    var updatedCookies = modifyCookies(cookies);
+     
+    msg.setCookieParams(updatedCookies);
+}
+
+var COOKIE_TYPE   = org.parosproxy.paros.network.HtmlParameter.Type.cookie;
+// cookieVal will be replaced with a token that can be obtained via 'Copy login command' menu in the console
+// cookieVal will be replaced with a token that can be obtained via 'Copy login command' menu in the console
+var params = {
+    cookieName: org.zaproxy.zap.extension.script.ScriptVars.getScriptVar(this.context, "cookieName"),
+    cookieVal: org.zaproxy.zap.extension.script.ScriptVars.getScriptVar(this.context, "cookieVal")
+};
+
+function modifyCookies(cookies) {
+    var hasAccessToken = 0
+    var iterator = cookies.iterator();
+    while(iterator.hasNext() || hasAccessToken == 0) {
+        var cookie = iterator.next();
+        if(params.cookieName && params.cookieVal) {
+            // print('cookie name: ' + str(params.cookieName))
+            if (cookie.getName().equals(params.cookieName)) {                                                                                                                               
+                cookie.setValue(params.cookieVal)
+                hasAccessToken = 1          
+            }  
+        }
+    }
+    if(hasAccessToken==0){
+        var HtmlParameter = Java.type('org.parosproxy.paros.network.HtmlParameter')
+        var newCookie = new HtmlParameter(COOKIE_TYPE, params.cookieName, params.cookieVal);
+
+        cookies.add(newCookie)
+    }
+    return cookies;
+}
+
+function responseReceived(msg, initiator, helper) {
+	// Debugging can be done using println like this
+	// print('responseReceived called for url=' + msg.getRequestHeader().getURI().toString())
+}

--- a/scripts/add-token-cookie-param.js
+++ b/scripts/add-token-cookie-param.js
@@ -38,7 +38,6 @@ function sendingRequest(msg, initiator, helper) {
 
 var COOKIE_TYPE   = org.parosproxy.paros.network.HtmlParameter.Type.cookie;
 // cookieVal will be replaced with a token that can be obtained via 'Copy login command' menu in the console
-// cookieVal will be replaced with a token that can be obtained via 'Copy login command' menu in the console
 var params = {
     cookieName: org.zaproxy.zap.extension.script.ScriptVars.getScriptVar(this.context, "cookieName"),
     cookieVal: org.zaproxy.zap.extension.script.ScriptVars.getScriptVar(this.context, "cookieVal")
@@ -47,7 +46,7 @@ var params = {
 function modifyCookies(cookies) {
     var hasAccessToken = 0
     var iterator = cookies.iterator();
-    while(iterator.hasNext() || hasAccessToken == 0) {
+    while(iterator.hasNext() && hasAccessToken == 0) {
         var cookie = iterator.next();
         if(params.cookieName && params.cookieVal) {
             // print('cookie name: ' + str(params.cookieName))

--- a/scripts/apis_scan.py
+++ b/scripts/apis_scan.py
@@ -4,7 +4,6 @@ import logging
 import os
 import time
 from datetime import datetime
-
 from zapv2 import ZAPv2
 
 try:
@@ -37,6 +36,7 @@ def create_session(session_name):
 
 
 def enable_httpsender_script():
+        
     script = zap.script
     script.remove(scriptname=config.HTTP_SENDER_SCRIPT_NAME)
     logging.info(
@@ -51,6 +51,13 @@ def enable_httpsender_script():
             scriptdescription=config.HTTP_SENDER_SCRIPT_DESCRIPTION,
         )
     )
+
+     # If the script requires cookie parameter
+    if config.HTTP_SENDER_SCRIPT_PARAMS != "":
+        for k, v in config.HTTP_SENDER_SCRIPT_PARAMS.items():
+            ret = script.set_script_var(config.HTTP_SENDER_SCRIPT_NAME, k, v)
+            logging.info(f"httpsenderscript: set Variable '{k}' to value '{v}', returned: {ret}")
+
     logging.info(
         "Enable httpsender script: "
         + config.HTTP_SENDER_SCRIPT_NAME

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -103,6 +103,7 @@ if "scan" in config:
         HTTP_SENDER_SCRIPT_ENGINE = config["scan"]["HttpSenderScriptEngine"]
         HTTP_SENDER_SCRIPT_FILE_PATH = config["scan"]["HttpSenderScriptFilePath"]
         HTTP_SENDER_SCRIPT_DESCRIPTION = config["scan"]["HttpSenderScriptDescription"]
+        HTTP_SENDER_SCRIPT_PARAMS = config["scan"].get("HTTPParams","")
     else:
         USE_HTTP_SENDER_SCRIPT = False
 


### PR DESCRIPTION
- Adding a docker version for starting the zaproxy tool 
- Adding a parameterized http authentication script to be able to pass the parameters from the config where it wont be pushed to any repo accidentally 

For openshift console runs: 
```
HttpSenderScriptFilePath: 'scripts/add-token-cookie-param.js'
HttpSenderScriptDescription: 'add a cookie to each HTTP request'
HTTPParams: {"cookieName": 'openshift-session-token', "cookieVal": 'sha256~**'}
```
