### PR TITLE
Introducing a new podman wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,6 @@ Its core engine is OWASP ZAP Proxy (https://owasp.org/www-project-zap/). Taking 
 
 * podman or docker is required.
 * podman-compose or docker-compose is required.
-* Pull the OWASP ZAP docker image
-```
-$ podman pull docker.io/owasp/zap2docker-stable
-$ docker pull docker.io/owasp/zap2docker-stable
-```
 
 If you're wanting to run on kubernetes or OpenShift cluster you can also install using OLM or helm, see more information on this [README.md](operator/README.md)
 
@@ -104,7 +99,7 @@ zaproxy container must be running (either runenv.sh or runenv-ui.sh)
 5. zaproxy container must be running (either runenv.sh or runenv-ui.sh)
 
 ```
-$ ./runenv.sh
+$ ./podman-wrapper.sh
 ```
 
 
@@ -114,11 +109,14 @@ $ ./runenv-docker.sh
 ```
 
 6. Launch a scan in the project root directory,
+
 ```
 $ test/scan-example-with-podman.sh <dir_to_store_results>
+```
 
 *OR*
 
+```
 $ test/scan-example-with-docker.sh <dir_to_store_results>
 ```
 
@@ -151,60 +149,52 @@ HTML report saved in: /zap/results/testrun/demo1-report-20220722-033427.html
 
 # Usage
 
-While the following examples are shown based on podman, the same commands can be replaced with docker and docker-compose.
-
-## for podman users only
-
-You will need to make the host's `./result` directory writable to the `zap` user in the container. This can be done with the following command. For docker users, this is not necessary.
-```
-$ podman unshare chown 1000 ./results
-
-$ docker unshare chown 1000 ./results
-```
-
-See [this](https://docs.podman.io/en/latest/markdown/podman-unshare.1.html) for more information on `podman unshare`.
-
 ## Run as daemon
 
 ### Run a container
 
 ```
-$ podman-compose -f podman-compose.yml up
+$ ./podman-wrapper.sh
 ```
+
+**OR**
 
 ```
 $ docker-compose zaproxy up
 ```
 
-On older podman versions (before 3.1.0), you will need to manually make the `./result` directory writable to the `zap` user. This can be done with the following command. For docker users, this is not necessary.
-```
-$ podman unshare chown 1000 ./results
-$ docker unshare chown 1000 ./results
-```
-
 
 
 ### Launch a scan
+
 ```
 $ podman exec zaproxy python /zap/scripts/apis_scan.py <dirname_to_be_created_under_results_dir>
 ```
 
 ### Stopping Environments
-```
-$ podman-compose -f podman-compose.yml down
 
-$ docker-compose down
 ```
-
-#Run with GUI (useful for debugging)
-This is taking advantage of ZAP's webswing feature. See https://www.zaproxy.org/docs/docker/webswing/. Note that any commercial organization that uses Webswing for non-evaluation purposes needs to have a valid commercial license of Webswing. See https://www.webswing.org/licensing for licensing information. 
-
-### Run a container
+$ ./podman-wrapper.sh -s
 ```
-$ podman-compose -f podman-compose-ui.yml up
 
 **OR**
 
+```
+$ docker-compose down
+```
+
+# Run with GUI (useful for debugging)
+This is taking advantage of ZAP's webswing feature. See https://www.zaproxy.org/docs/docker/webswing/. Note that any commercial organization that uses Webswing for non-evaluation purposes needs to have a valid commercial license of Webswing. See https://www.webswing.org/licensing for licensing information. 
+
+### Run a container
+
+```
+$ ./podman-wrapper.sh -w
+```
+
+**OR**
+
+```
 $ docker-compose zaproxy_ui up
 ```
 
@@ -215,14 +205,23 @@ After the step, it is necessary to navigate to the GUI via http://127.0.0.1:8081
 ### Launch a scan
 ```
 $ podman exec zaproxy python /zap/scripts/apis_scan.py <dirname_to_be_created_under_results_dir>
+```
 
+**OR**
+
+```
 $ docker exec zaproxy python /zap/scripts/apis_scan.py <dirname_to_be_created_under_results_dir>
 ```
 
 ### Stopping Environments
 ```
-$ podman-compose -f podman-compose-ui.yml down
+$ ./podman-wrapper.sh -sw
+```
+(note: `s` stands for *stop*, `w` for *WebUI*)
 
+**OR**
+
+```
 $ docker-compose down
 ```
 
@@ -240,9 +239,14 @@ $ docker exec zaproxy python scripts/gen_zap_script/cli.py --from-yaml scripts/g
 ```
 
 ### Example: Delete existing custom rules
+
 ```
 $ podman exec zaproxy python scripts/gen_zap_script/cli.py --rapidast-config=<config-file> --delete
+```
 
+**OR**
+
+```
 $ docker exec zaproxy python scripts/gen_zap_script/cli.py --rapidast-config=<config-file> --delete
 ```
 

--- a/podman-wrapper.sh
+++ b/podman-wrapper.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 
 ## Functions
 

--- a/podman-wrapper.sh
+++ b/podman-wrapper.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/bash
+
+## Functions
+
+function show_help() {
+    cat <<EOD
+$0 [-w | -f <compose>] [-c <CMD> | -s] [-d] [-D 0-2] [-h]
+Run RapiDAST in a podman using the "podman-compose" command.
+Options:
+    -c <command> 
+        Command to pass to podman-compose (default: 'up' to start the container)
+
+    -s  Stop the container. 
+        This is a shortcut for '-c down'
+
+    -d  Runs in detach mode
+        The command will return, and podman will run in the background
+
+    -w  Runs the WebUI. 
+        Note: if you do, you will have to connect to it before being able to start a scan
+        This is a shortcut for '-f podman-compose-ui.yml'
+
+    -f <compose.yaml>
+        Run another podman-compose file (default: podman-compose.yml)
+
+    -D <0-2>
+        Debug mode: verbose output
+
+    -h  Show this help
+
+Examples:
+    Both commands will start in the background a RapiDAST server in "WebUI" mode, and exit:
+$0 -wd
+$0 -f podman-compose-ui.yml -d
+
+    Both commands will stop the container
+$0 -s
+$0 -c down
+EOD
+    exit 0
+}
+function debug() {
+    if [ $RAPIDAST_DEBUG -gt 0 ]; then
+        echo -e "RAPIDAST_DEBUG: " $* >&2
+    fi
+}
+
+# DEFAULT OPTIONS (using default assign in case user wants to override values)
+: "${RAPIDAST_COMPOSE:=podman-compose.yml}"
+: "${RAPIDAST_COMMAND:=up}"
+: "${RAPIDAST_DEBUG:=0}"
+
+# NOTE/HACK: $RAPIDAST_MOREOPTS is not initialized on purpose so that users can add their own options to podman-compose, e.g.:
+# (there is no simple way to do this using 'getopts')
+# RAPIDAST_MOREOPTS="--quiet-pull" ./start_server_in_podman.s -wd 
+
+
+while getopts "hD:f:wdc:s" opt; do
+    case $opt in
+    D) 
+        RAPIDAST_DEBUG="$(( OPTARG ))";;
+    h) 
+        show_help;;
+    f) 
+        RAPIDAST_COMPOSE="$OPTARG";;
+    w) 
+        RAPIDAST_COMPOSE="podman-compose-ui.yml";;
+    d) 
+        RAPIDAST_MOREOPTS="$RAPIDAST_MOREOPTS --detach";;
+    c)
+        RAPIDAST_COMMAND="$OPTARG";;
+    s)
+        RAPIDAST_COMMAND="down"
+
+    esac
+done
+shift "$((OPTIND-1))"
+
+if [ $RAPIDAST_DEBUG -ge 2 ]; then
+    set -x
+fi
+
+# Checks/verifications, etc.
+if ! which podman-compose 2> /dev/null; then
+    echo "[ERROR] no 'podman-compose' in PATH. Exiting"
+    exit 1
+fi
+
+if [ "$RAPIDAST_COMMAND" == "up" ]; then
+    # This *must* correspond to the UID/GID of the `zap` user in the container. 
+    # The user is created with the command `useradd`, and thus may change in the future but is not likely to happen
+    runas_UID=1000
+    runas_GID=1000
+
+    # Source of the idea for the hack: 
+    # https://github.com/containers/podman/blob/main/troubleshooting.md#39-podman-run-fails-with-error-unrecognized-namespace-mode-keep-iduid1000gid1000-passed
+
+    # Get the size of the mapping allowed to the user
+    # The following commands look into /etc/subuid & /etc/subgid for figure out the size of the user's subUID mapping
+    # but podman has a building mechanism to make the calculation easier.
+    subuidSize=$(( $(podman info --format "{{ range .Host.IDMappings.UIDMap }}+{{.Size }}{{end }}" ) - 1 ))
+    subgidSize=$(( $(podman info --format "{{ range  .Host.IDMappings.GIDMap }}+{{.Size }}{{end }}" ) - 1 ))
+
+    # UIDs remap such that current host user is mapped as $runas_UID inside the container, and identical for GID
+    #
+    # we use a default assign in case a user wants to pass additional run arguments by pre-assigning RAPIDAST_RUNARGS
+    RAPIDAST_RUNARGS+=" --uidmap 0:1:$runas_UID  --uidmap $runas_UID:0:1  --uidmap $(($runas_UID+1)):$(($runas_UID+1)):$(($subuidSize-$runas_UID))"
+    RAPIDAST_RUNARGS+=" --gidmap 0:1:$runas_GID  --gidmap $runas_GID:0:1  --gidmap $(($runas_GID+1)):$(($runas_GID+1)):$(($subgidSize-$runas_GID))"
+    RAPIDAST_RUNARGS="--podman-run-args=$RAPIDAST_RUNARGS"
+
+fi
+
+podman-compose -f "$RAPIDAST_COMPOSE" ${RAPIDAST_RUNARGS:+"$RAPIDAST_RUNARGS"} "$RAPIDAST_COMMAND" $RAPIDAST_MOREOPTS

--- a/runenv-ui.sh
+++ b/runenv-ui.sh
@@ -1,3 +1,4 @@
+echo "DEPRECATED. use ./podman-wrapper.sh"
 podman-compose -f podman-compose.yml down
 podman-compose -f podman-compose-ui.yml down
 podman-compose -f podman-compose-ui.yml up

--- a/runenv.sh
+++ b/runenv.sh
@@ -1,3 +1,4 @@
+echo "DEPRECATED. use ./podman-wrapper.sh"
 podman-compose -f podman-compose.yml down
 podman-compose -f podman-compose-ui.yml down
 podman-compose -f podman-compose.yml up


### PR DESCRIPTION
The main reason for the wrapper is to avoid the need to run `unshare`, by formatting a defined user mapping, such that the `zap` user maps the host user. This way ZAP can write in the `./results` share without needing to change ownership.

source:
https://github.com/containers/podman/blob/main/troubleshooting.md#39-podman-run-fails-with-error-unrecognized-namespace-mode-keep-iduid1000gid1000-passed In very recent podman version, this hack can be simplified.

This change is backward compatible : nothing prevents the user to use any old methods for starting RapiDAST.

Note:
Unlike `runenv.sh`, this script does *not* attempt to stop the container in case it is already running. The reasoning is : if RapiDAST is currently undergoing a looooong scan, a user probably prefers the new command to fail, rather than cancelling the current scan. However, we could improve that.

Other minor changes:
In README.md:
- removed the reference to `[podman|docker] pull`, as it refers to a different image, and afaik, will be done by the compose command
- updated with the new command, removed references to unshare
- few minor readability/consistency update

In runenv.sh / runenv-ui.sh: echo "deprecated" message