### PR TITLE
add-bearer-token.js: only when there is a token

### DIFF
--- a/scripts/add-bearer-token.js
+++ b/scripts/add-bearer-token.js
@@ -14,13 +14,20 @@
 var HttpSender = Java.type("org.parosproxy.paros.network.HttpSender");
 var ScriptVars = Java.type("org.zaproxy.zap.extension.script.ScriptVars");
 
-function sendingRequest(msg, initiator, helper) {
-  // add Authorization header to all request in scope except the authorization request itself
-  if (initiator !== HttpSender.AUTHENTICATION_INITIATOR && msg.isInScope()) {
-    msg.getRequestHeader().setHeader("Authorization", "Bearer " + ScriptVars.getGlobalVar("access_token"));
-  }
+function logger() {
+    //print('[' + this['zap.script.name'] + '] ' + arguments[0]);
+}
 
-  return msg;
+function sendingRequest(msg, initiator, helper) {
+    logger("{sendingRequest}: called");
+    // add Authorization header (when it exists) to all request in scope except the authorization request itself
+    var bearer = ScriptVars.getGlobalVar("access_token");
+    if (initiator !== HttpSender.AUTHENTICATION_INITIATOR && msg.isInScope() && bearer ) {
+        logger("{sendingRequest}: Adding bearer to Authorization header");
+        msg.getRequestHeader().setHeader("Authorization", "Bearer " + bearer);
+    }
+
+    return msg;
 }
 
 function responseReceived(msg, initiator, helper) {}


### PR DESCRIPTION
Prevents the add-bearer-token.js to add a null token (e.g.: when no user have authenticated yet).
Otherwise, the script was sending a null bearer token, and server may return "invalid" while the request would have worked, if anonymous.

This change makes "forced user" mode more optional.

Currently, if "forced user" mode is disabled, some requests sent without a bearer token available, leading to an invalid request. Anonymous request is better than an invalid one, e.g.: to retrieve the openapi from a URL.

This commit would be a prerequisite to using Automation Framework, where the openapi job currently does not support user authentication and "forced user" mode does not seem to be available.

Other minor improvement: a logger() function to enable/disable logging with a quick comment/uncomment (currently disabled. simply uncomment the print line in logger() to enable debugging).

related task: PSSECDEV-1862