### PR TITLE
[ZapPodman] avoid PurePath.is_relative_to

### DIFF
--- a/scanners/zap/tests/test_setup_podman.py
+++ b/scanners/zap/tests/test_setup_podman.py
@@ -13,7 +13,9 @@ CONFIG_TEMPLATE_LONG = "config/config-template-long.yaml"
 def test_config():
     return configmodel.RapidastConfigModel()
 
+
 ## Testing files and paths ##
+
 
 def test_path_translation_host_2_container(test_config):
     test_zap = ZapPodman(config=test_config)
@@ -21,14 +23,13 @@ def test_path_translation_host_2_container(test_config):
     test_zap._add_volume("/a/s/d/f/g", "/h/j/k/l")
     test_zap._add_volume("/z/x/c/v", "/b/n/m")
 
-    assert( test_zap._paths_h2c("/a/s/d/f/g/subdir/myfile") == "/h/j/k/l/subdir/myfile")
+    assert test_zap._paths_h2c("/a/s/d/f/g/subdir/myfile") == "/h/j/k/l/subdir/myfile"
 
-    assert( test_zap._paths_c2h("/b//n/m/subdir/myfile") == "/z/x/c/v/subdir/myfile")
-
-
+    assert test_zap._paths_c2h("/b//n/m/subdir/myfile") == "/z/x/c/v/subdir/myfile"
 
 
 ## Testing Authentication methods ##
+
 
 def test_setup_authentication_no_auth_configured(test_config):
     print(test_config.get("general"))

--- a/scanners/zap/tests/test_setup_podman.py
+++ b/scanners/zap/tests/test_setup_podman.py
@@ -13,6 +13,22 @@ CONFIG_TEMPLATE_LONG = "config/config-template-long.yaml"
 def test_config():
     return configmodel.RapidastConfigModel()
 
+## Testing files and paths ##
+
+def test_path_translation_host_2_container(test_config):
+    test_zap = ZapPodman(config=test_config)
+    test_zap._add_volume("/q/w/e/r/t", "/y/u/i/o/p")
+    test_zap._add_volume("/a/s/d/f/g", "/h/j/k/l")
+    test_zap._add_volume("/z/x/c/v", "/b/n/m")
+
+    assert( test_zap._paths_h2c("/a/s/d/f/g/subdir/myfile") == "/h/j/k/l/subdir/myfile")
+
+    assert( test_zap._paths_c2h("/b//n/m/subdir/myfile") == "/z/x/c/v/subdir/myfile")
+
+
+
+
+## Testing Authentication methods ##
 
 def test_setup_authentication_no_auth_configured(test_config):
     print(test_config.get("general"))

--- a/scanners/zap/zap_podman.py
+++ b/scanners/zap/zap_podman.py
@@ -262,7 +262,9 @@ class ZapPodman(Zap):
         for h, c in self.volume_map.items():
             # force resolution to make sure we work with absolute paths
             h = PosixPath(h).resolve()
-            if path.is_relative_to(h):
+
+            # PurePath.is_relative_to() was added in python 3.9, so we have to use `parents` for now
+            if h == path or h in path.parents:
                 # match! replace the host path by the container path
                 path = PurePosixPath(c, path.relative_to(h))
                 return str(path)
@@ -279,7 +281,9 @@ class ZapPodman(Zap):
         path = PurePosixPath(path)
         for h, c in self.volume_map.items():
             c = PurePosixPath(c)
-            if path.is_relative_to(c):
+
+            # PurePath.is_relative_to() was added in python 3.9 only, so we have to use `parents` for now
+            if c == path or c in path.parents:
                 # match! replace the container path by the host path
                 path = PosixPath(h, path.relative_to(c))
                 return str(path)


### PR DESCRIPTION
PurePath.is_relative_to() was added in python 3.9 only. Try to keep compatibility with older versions by using Path.parents instead.

Also added corresponding pytest for these 2 functions.