### PR TITLE
Zap local

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,20 @@ options:
                         useful for debugging purpose).
 ```
 
+### Choosing the execution environment
+
+It is possible to choose the method to spawn a scanner using `scanners.<name>.container.type` configuration.
+Currently accepted value to choose among :
++ `podman`:
+    - Select the image to load from `scanner.<name>.container.image` (sensible default are provided for each scanner)
++ `local`:
+    - The scanner is run localy, no container used
+    - The scanner needs to be pre-installed on the host
+    - __Warning__: without a container layer, RapiDAST may modify the host's file system, such as the tools configuration to fit its needs
+
+
+The user can set `general.container.type` to set this type for each scanners at once.
+
 ### Scanners
 
 #### ZAP
@@ -164,8 +178,8 @@ org.zaproxy.zap.extension.openapi.converter.swagger.SwaggerException: Failed to 
 ## Caveats
 
 * Currently, RapiDAST does not clean up the temporary data when there is an error. The data may include:
-    + a `/tmp/rapidast_zap_*/` directory
-    + a podman container which name starts with `rapidast_zap_`
+    + a `/tmp/rapidast_*/` directory
+    + a podman container which name starts with `rapidast_`
 
 This is to help with debugging the error. Once confirmed, it is necessary to manually remove them.
 

--- a/rapidast.py
+++ b/rapidast.py
@@ -110,7 +110,7 @@ if __name__ == "__main__":
         )
 
         class_ = scanners.str_to_scanner(
-            name, config.get(f"scanner.{name}.container.type", default="podman")
+            name, config.get(f"scanners.{name}.container.type", default="podman")
         )
 
         # Part 1: create a instance based on configuration

--- a/scanners/__init__.py
+++ b/scanners/__init__.py
@@ -30,7 +30,7 @@ class RapidastScanner:
 # For example : str_to_scanner("zap", "podman") will load `scanners/zap/zap_podman.py`
 def str_to_scanner(name, method):
     mod = importlib.import_module(f"scanners.{name}.{name}_{method}")
-    class_ = getattr(mod, mod.className)
+    class_ = getattr(mod, mod.CLASSNAME)
     return class_
 
 

--- a/scanners/__init__.py
+++ b/scanners/__init__.py
@@ -3,6 +3,7 @@ from enum import Enum
 from pprint import pformat
 
 import configmodel
+from .path_translators import PathMaps
 
 
 class State(Enum):
@@ -18,6 +19,8 @@ class RapidastScanner:
     def __init__(self, config):
         self.config = config
         self.state = State.UNCONFIGURED
+
+        self.path_map = PathMaps()
 
     def __repr__(self):
         return pformat(vars(self), indent=4, width=1)

--- a/scanners/path_translators.py
+++ b/scanners/path_translators.py
@@ -1,0 +1,65 @@
+# This module provides a helper for keeping track of path translations between the "container" view and the "host" view
+from collections import namedtuple
+from pathlib import PosixPath
+from pathlib import PurePosixPath
+
+PathMap = namedtuple("PathMap", ["host", "container"])
+
+
+class PathMaps:
+    def __init__(self):
+        self.paths = {}  # ID => ("host", "container")
+
+    def add(self, id_, host, container):
+        self.paths[id_] = PathMap(host, container)
+
+    def get(self, id_):
+        return self.paths[id_]
+
+    def list_container_paths(self):
+        return [x.container for x in self.paths]
+
+    def list_host_paths(self):
+        return [x.host for x in self.paths]
+
+    def list_ids(self):
+        return self.paths.keys()
+
+    def host_2_container(self, path):
+        """Given a path on the host, find out what will be its path in the container, based on mapping
+        WARNING: no support for subvolumes. we would need to find the "best match"
+        """
+        path = PosixPath(path).resolve()
+        for mapping in self.paths.values():
+            # force resolution to make sure we work with absolute paths
+            host = PosixPath(mapping.host).resolve()
+
+            # PurePath.is_relative_to() was added in python 3.9, so we have to use `parents` for now
+            if host == path or host in path.parents:
+                # match! replace the host path by the container path
+                path = PurePosixPath(mapping.container, path.relative_to(host))
+                return str(path)
+
+        raise RuntimeError(
+            f"host_2_container(): unable to find a host path for path {path}",
+            f"host path list: {self.list_host_paths()}",
+        )
+
+    def container_2_host(self, path):
+        """Given a path on the container, find out what will be its path in the host, based on mapping
+        WARNING: no support for subvolumes. we would need to find the "best match"
+        """
+        path = PurePosixPath(path)
+        for mapping in self.paths.values():
+            container = PurePosixPath(mapping.container)
+
+            # PurePath.is_relative_to() was added in python 3.9 only, so we have to use `parents` for now
+            if container == path or container in path.parents:
+                # match! replace the container path by the host path
+                path = PosixPath(mapping.host, path.relative_to(container))
+                return str(path)
+
+        raise RuntimeError(
+            f"container_2_host(): unable to find a container path for path {path}",
+            f"container map list: {self.list_container_paths()}",
+        )

--- a/scanners/zap/tests/test_setup_podman.py
+++ b/scanners/zap/tests/test_setup_podman.py
@@ -14,19 +14,6 @@ def test_config():
     return configmodel.RapidastConfigModel()
 
 
-## Testing files and paths ##
-
-
-def test_path_translation_host_2_container(test_config):
-    test_zap = ZapPodman(config=test_config)
-    test_zap._add_volume("/q/w/e/r/t", "/y/u/i/o/p")
-    test_zap._add_volume("/a/s/d/f/g", "/h/j/k/l")
-    test_zap._add_volume("/z/x/c/v", "/b/n/m")
-
-    assert test_zap._paths_h2c("/a/s/d/f/g/subdir/myfile") == "/h/j/k/l/subdir/myfile"
-    assert test_zap._paths_c2h("/b//n/m/subdir/myfile") == "/z/x/c/v/subdir/myfile"
-
-
 ## Testing Authentication methods ##
 
 

--- a/scanners/zap/zap_local.py
+++ b/scanners/zap/zap_local.py
@@ -1,0 +1,172 @@
+import logging
+import os
+import pprint
+import shutil
+import subprocess
+
+from .zap import PathIds
+from .zap import Zap
+from scanners import State
+
+CLASSNAME = "ZapLocal"
+
+
+pp = pprint.PrettyPrinter(indent=4)
+
+# Helper: absolute path to this directory (which is not the current directory)
+# Useful for finding files in this directory
+MODULE_DIR = os.path.dirname(__file__)
+
+
+class ZapLocal(Zap):
+    ###############################################################
+    # PRIVATE CONSTANTS                                           #
+    # Accessed by ZapLocalhost only                               #
+    ###############################################################
+
+    ###############################################################
+    # PROTECTED CONSTANTS                                         #
+    # Accessed by parent Zap object                               #
+    ###############################################################
+
+    def __init__(self, config):
+        """Initialize all vars based on the config.
+        The code of the function only deals with the "podman" layer, the "ZAP" layer is handled by super()
+        """
+
+        logging.debug("Initializing podman-based ZAP scanner")
+        super().__init__(config)
+
+        # prepare the host <-> container mapping
+        # Because there's no container layer, there's no need to translate anything
+        temp_dir = self._create_work_dir()
+        policies_dir = f"{os.environ['HOME']}/.ZAP/policies"
+
+        self.path_map.add(PathIds.WORK, temp_dir, temp_dir)
+        self.path_map.add(
+            PathIds.SCRIPTS, f"{MODULE_DIR}/scripts", f"{MODULE_DIR}/scripts"
+        )
+        self.path_map.add(PathIds.POLICIES, policies_dir, policies_dir)
+
+    ###############################################################
+    # PUBLIC METHODS                                              #
+    # Accessed by RapiDAST                                        #
+    # + MUST be implemented                                       #
+    # + SHOUT call super().<method>                               #
+    # + list: setup(), run(), postprocess(), cleanup()            #
+    ###############################################################
+
+    def setup(self, executable=None):
+        """Prepares everything:
+        - the command line to run
+        - environment variables
+        - files & directory
+
+        The code of the function only deals with the "localhost" layer, the "ZAP" layer is handled by super()
+        """
+
+        if self.state != State.UNCONFIGURED:
+            raise RuntimeError(
+                f"Podman setup encounter an unexpected state: {self.state}"
+            )
+
+        super().setup(executable="zap.sh")
+
+        # Since we can't "mount" the policy directory in local mode, and that we can't choose it in ZAP's configuration
+        # We have to copy it to ~/.ZAP/policies/
+        if self.config.get("scanners.zap.activeScan", default=False) is not False:
+            policy = self.config.get(
+                "scanners.zap.activeScan.policy", default="API-scan-minimal"
+            )
+            self._include_file(
+                f"{MODULE_DIR}/policies/{policy}.policy",
+                self.path_map.get(PathIds.POLICIES).container,
+            )
+
+        if self.state != State.ERROR:
+            self.state = State.READY
+
+    def run(self):
+        """If the state is READY, run the final podman run command.
+        There is no need to call super() here.
+        """
+        logging.info("Running up the ZAP scanner on the host")
+        if not self.state == State.READY:
+            raise RuntimeError("[ZAP SCANNER]: ERROR, not ready to run")
+
+        logging.info("Zap: Updating addons")
+        result = subprocess.run(["zap.sh", "-cmd", "-addonupdate"], check=False)
+        if result.returncode != 0:
+            logging.warning(
+                f"The ZAP addon update process did not finish correctly, and exited with code {result.returncode}"
+            )
+
+        # Now the real run
+        logging.info(f"Running ZAP with the following command:\n{self.zap_cli}")
+        result = subprocess.run(self.zap_cli, check=False)
+        logging.debug(
+            f"ZAP returned the following:\n=====\n{pp.pformat(result)}\n====="
+        )
+
+        # Zap's return codes : https://www.zaproxy.org/docs/desktop/addons/automation-framework/
+        if result.returncode in [0, 2]:
+            # 0: ZAP returned correctly. 2: ZAP returned warning
+            logging.info(
+                f"The ZAP process finished with no errors, and exited with code {result.returncode}"
+            )
+            self.state = State.DONE
+        else:
+            # 1: Zap hit an error
+            logging.warning(
+                f"The ZAP process did not finish correctly, and exited with code {result.returncode}"
+            )
+            self.state = State.ERROR
+
+    def postprocess(self):
+        logging.info("Running postprocess for the ZAP Host environment")
+        if not self.state == State.DONE:
+            raise RuntimeError(
+                "No post-processing as ZAP has not successfully run yet."
+            )
+
+        super().postprocess()
+
+        if not self.state == State.ERROR:
+            self.state = State.PROCESSED
+
+    def cleanup(self):
+        logging.info("Running cleanup for the ZAP Host environment")
+
+        if not self.state == State.PROCESSED:
+            raise RuntimeError("No cleanning up as ZAP did not processed results.")
+
+        logging.debug(f"Deleting temp directory {self._host_work_dir()}")
+        shutil.rmtree(self._host_work_dir())
+
+        super().cleanup()
+
+        if not self.state == State.ERROR:
+            self.state = State.CLEANEDUP
+
+    ###############################################################
+    # PROTECTED METHODS                                           #
+    # Accessed by Zap parent only                                 #
+    # + MUST be implemented                                       #
+    ###############################################################
+
+    def _add_env(self, key, value=None):
+        """Environment variable to be added to the container.
+        If value is None, then the value should be taken from the current host
+
+        In "localhost" mode, simply add the environment in the python process
+        It will be copied over to ZAP.
+        If `value` is None, then do nothing, as it means it's already set in
+        python's environment
+        """
+        if value is not None:
+            os.environ[key] = value
+
+    ###############################################################
+    # PRITVATE METHODS                                            #
+    # Accessed by this ZapLocalhost object only                   #
+    ###############################################################

--- a/scanners/zap/zap_podman.py
+++ b/scanners/zap/zap_podman.py
@@ -5,13 +5,13 @@ import shutil
 import string
 import subprocess
 import tarfile
-import tempfile
 from pathlib import PosixPath
 from pathlib import PurePosixPath
 
 import yaml
 
 import configmodel
+from .zap import PathIds
 from .zap import Zap
 from scanners import RapidastScanner
 from scanners import State
@@ -22,17 +22,22 @@ import pprint
 
 pp = pprint.PrettyPrinter(indent=4)
 
+# Helper: absolute path to this directory (which is not the current directory)
+# Useful for finding files in this directory
+MODULE_DIR = os.path.dirname(__file__)
+
 
 class ZapPodman(Zap):
+    ###############################################################
+    # PRIVATE CONSTANTS                                           #
+    # Accessed by ZapPodman only                                  #
+    ###############################################################
     DEFAULT_IMAGE = "docker.io/owasp/zap2docker-stable:latest"
 
-    # path from the container
-    ROOT_CONTAINER_DIR = "/zap"
-    SCRIPTS_CONTAINER_DIR = f"{ROOT_CONTAINER_DIR}/scripts"
-    POLICIES_CONTAINER_DIR = f"/home/zap/.ZAP/policies/"
-    RESULTS_CONTAINER_DIR = f"{ROOT_CONTAINER_DIR}/results"  # R/W & keep
-    SESSION_CONTAINER_DIR = f"{RESULTS_CONTAINER_DIR}/session_data/session"
-    AF_CONTAINER_PATH = f"{RESULTS_CONTAINER_DIR}/af.yaml"
+    ###############################################################
+    # PROTECTED CONSTANTS                                         #
+    # Accessed by parent Zap object                               #
+    ###############################################################
 
     def __init__(self, config):
         """Initialize all vars based on the config.
@@ -51,16 +56,21 @@ class ZapPodman(Zap):
             "".join(random.choices(string.ascii_letters, k=6)),
         )
 
-        # working dir: this will be mounted as the results dir in the container
-        # We store generated data (AF conf & env files) there for safekeep, as part of evidence
-        self.temp_dir = tempfile.mkdtemp(prefix="rapidast_zap_")
-        self.temp_af = f"{self.temp_dir}/af.yaml"
-        logging.debug(f"Temporary directory for ZAP scanner: {self.temp_dir}")
+        # prepare the host <-> container mapping
+        # The default location for WORK can be chosen by parent itself (no overide of self._create_work_dir)
+        self.path_map.add(PathIds.WORK, self._create_work_dir(), "/zap/results")
+        self.path_map.add(PathIds.SCRIPTS, f"{MODULE_DIR}/scripts", "/zap/scripts")
+        self.path_map.add(
+            PathIds.POLICIES, f"{MODULE_DIR}/policies", "/home/zap/.ZAP/policies/"
+        )
 
-        # a "host_path" -> "container_path" dictionary
-        self.volume_map = {}
-
-    # Public methods. each should call super()
+    ###############################################################
+    # PUBLIC METHODS                                              #
+    # Accessed by RapiDAST                                        #
+    # + MUST be implemented                                       #
+    # + SHOUT call super().<method>                               #
+    # + list: setup(), run(), postprocess(), cleanup()            #
+    ###############################################################
 
     def setup(self):
         """Prepares everything:
@@ -81,32 +91,6 @@ class ZapPodman(Zap):
         self._setup_podman_cli()
 
         super().setup(executable="/zap/zap.sh")
-
-        # Save the Automation config, which is prepared by super().setup()
-        self._save_automation_file()
-
-    def _save_automation_file(self):
-        """Save the Automation dictionary as YAML in the container"""
-        self._generate_file(yaml.dump(self.af), ZapPodman.AF_CONTAINER_PATH)
-        logging.info(f"Saved Automation Framework in {ZapPodman.AF_CONTAINER_PATH}")
-
-    def _setup_podman_cli(self):
-        logging.info(
-            f"Preparing a podman container for the zap image, called {self.container_name}"
-        )
-
-        self.podman_opts += ["--name", self.container_name]
-
-        # UID/GID mapping, in case of older podman version
-        self._setup_zap_podman_id_mapping_cli()
-
-        # Volume mappings
-        self._add_volume(self.temp_dir, ZapPodman.RESULTS_CONTAINER_DIR)
-        self._add_volume(self.SCRIPTS_LOCATION_DIR, ZapPodman.SCRIPTS_CONTAINER_DIR)
-        self._add_volume(self.POLICIES_LOCATION_DIR, ZapPodman.POLICIES_CONTAINER_DIR)
-
-        if self.state != State.ERROR:
-            self.state = State.READY
 
     def run(self):
         """If the state is READY, run the final podman run command.
@@ -168,8 +152,8 @@ class ZapPodman(Zap):
         if not self.state == State.PROCESSED:
             raise RuntimeError(f"No cleanning up as ZAP did not processed results.")
 
-        logging.debug(f"Deleting temp directory {self.temp_dir}")
-        shutil.rmtree(self.temp_dir)
+        logging.debug(f"Deleting temp directory {self._host_work_dir()}")
+        shutil.rmtree(self._host_work_dir())
 
         logging.debug(f"Deleting podman container {self.container_name}")
         result = subprocess.run(["podman", "container", "rm", self.container_name])
@@ -182,16 +166,43 @@ class ZapPodman(Zap):
         if not self.state == State.ERROR:
             self.state = State.CLEANEDUP
 
+    ###############################################################
+    # PROTECTED METHODS                                           #
+    # Accessed by Zap parent only                                 #
+    # + MUST be implemented                                       #
+    ###############################################################
+
     def _add_env(self, key, value=None):
         """Environment variable to be added to the container.
         If value is None, then the value should be taken from the current host
         """
-
         if value is None:
             opt = ["--env", key]
         else:
             opt = ["--env", f"{key}={value}"]
         self.podman_opts += opt
+
+    ###############################################################
+    # PRITVATE METHODS                                            #
+    # Accessed by this ZapPodman object only                      #
+    ###############################################################
+
+    def _setup_podman_cli(self):
+        logging.info(
+            f"Preparing a podman container for the zap image, called {self.container_name}"
+        )
+
+        self.podman_opts += ["--name", self.container_name]
+
+        # UID/GID mapping, in case of older podman version
+        self._setup_zap_podman_id_mapping_cli()
+
+        # Volume mappings
+        for mapping in self.path_map.paths.values():
+            self.podman_opts += ["--volume", f"{mapping.host}:{mapping.container}:Z"]
+
+        if self.state != State.ERROR:
+            self.state = State.READY
 
     def _setup_zap_podman_id_mapping_cli(self):
         """Adds a specific user mapping to the Zap podman container.
@@ -253,78 +264,3 @@ class ZapPodman(Zap):
         ]
 
         logging.debug(f"podman enabled UID/GID mapping arguments")
-
-    def _paths_h2c(self, path):
-        """Given a path on the host, find out what will be its path in the container, based on mapping
-        WARNING: no support for subvolumes. we would need to find the "best match"
-        """
-        path = PosixPath(path).resolve()
-        for h, c in self.volume_map.items():
-            # force resolution to make sure we work with absolute paths
-            h = PosixPath(h).resolve()
-
-            # PurePath.is_relative_to() was added in python 3.9, so we have to use `parents` for now
-            if h == path or h in path.parents:
-                # match! replace the host path by the container path
-                path = PurePosixPath(c, path.relative_to(h))
-                return str(path)
-
-        raise RuntimeError(
-            f"_paths_h2c(): unable to find a volume map for path {path}",
-            f"map list: {self.volume_map.keys()}",
-        )
-
-    def _paths_c2h(self, path):
-        """Given a path on the container, find out what will be its path in the host, based on mapping
-        WARNING: no support for subvolumes. we would need to find the "best match"
-        """
-        path = PurePosixPath(path)
-        for h, c in self.volume_map.items():
-            c = PurePosixPath(c)
-
-            # PurePath.is_relative_to() was added in python 3.9 only, so we have to use `parents` for now
-            if c == path or c in path.parents:
-                # match! replace the container path by the host path
-                path = PosixPath(h, path.relative_to(c))
-                return str(path)
-
-        raise RuntimeError(
-            f"_paths_c2h(): unable to find a volume map for path {path}",
-            f"container map list: {self.volume_map.values()}",
-        )
-
-    def _include_file(self, host_path, container_path=None):
-        """Copies the file from host_path on the host to container_path in the container
-        Notes:
-            - MUST be run after the mapping is done
-            - If container_path evaluates to False, default to `RESULTS_CONTAINER_DIR`
-            - If container_path is a directory, copy the file to it without renaming it
-        """
-        if not container_path:
-            container_path = RESULTS_CONTAINER_DIR
-
-        # 1. find the host path to container_path and see if it's an existing directory
-        path_to_dest = self._paths_c2h(container_path)
-        if os.path.isdir(path_to_dest):
-            path_to_dest = os.path.join(path_to_dest, os.path.basename(host_path))
-
-        shutil.copy(host_path, path_to_dest)
-        logging.debug(f"_include_file() created file '{path_to_dest}'")
-
-    def _generate_file(self, data, container_path):
-        """Generates a file (named `container_path` in the container), based on `data`
-        Similar to _include_file, but from a stream instead of a host path
-        Notes:
-            - MUST be run after the mapping is done
-            - container_path MUST be a path
-        """
-        host_path = self._paths_c2h(container_path)
-        with open(host_path, "w") as f:
-            f.write(data)
-        logging.debug(f"_generate_file() created file '{host_path}'")
-
-    def _add_volume(self, host_dir, cont_dir):
-        """Adds a mapping from host_dir to cont_dir"""
-
-        self.volume_map[host_dir] = cont_dir
-        self.podman_opts += ["--volume", f"{host_dir}:{cont_dir}:Z"]

--- a/tests/test_path_translators.py
+++ b/tests/test_path_translators.py
@@ -1,0 +1,16 @@
+from scanners.path_translators import PathMaps
+
+
+def test_path_translation():
+    path_map = PathMaps()
+    path_map.add("id1", "/q/w/e/r/t", "/y/u/i/o/p")
+    path_map.add("id2", "/a/s/d/f/g", "/h/j/k/l")
+    path_map.add("id3", "/z/x/c/v", "/b/n/m")
+
+    assert (
+        path_map.host_2_container("/a/s/d/f/g/subdir/myfile")
+        == "/h/j/k/l/subdir/myfile"
+    )
+    assert (
+        path_map.container_2_host("/b//n/m/subdir/myfile") == "/z/x/c/v/subdir/myfile"
+    )


### PR DESCRIPTION
This PR proposes the following : 

1) having a dedicated layer to handle path translation between the "host" and the "container". 
This, for example, allows the main Zap object to read/write/copy files from the container view and the host view, independently from the type of containment.
As a result: much more code can be store in the zap.py module itself, making writing new container type easier.

2) ZAP local : an object instantiated when "local" type is chosen.
RapiDAST will run `zap.sh` directly on the host itself.
A warning has been added in the README, as this will interfere a little with the host (such as: copying the policy to `~/.ZAP/policies/`)