### PR TITLE
Configurable container type

### DIFF
--- a/config/config-template-long.yaml
+++ b/config/config-template-long.yaml
@@ -86,6 +86,9 @@ scanners:
     container:
       image: "docker.io/owasp/zap2docker-stable:latest"
 
+    # Defaults to False, set True do update ZAP's plugins
+    updateAddons: False
+
     report:
       format: ["json"]
 #      format: ["json","html","sarif"]  # default: "json" only

--- a/config/config-template.yaml
+++ b/config/config-template.yaml
@@ -7,7 +7,7 @@ config:
   # This value tells RapiDAST what schema should be used to read this configuration.
   # Therefore you should only change it if you update the configuration to a newer schema
   # It is intended to keep backward compatibility (newer RapiDAST running an older config)
-  configVersion: "1"
+  configVersion: 2
 
   # Import a particular environment, and inject it for each scanner
   environ:

--- a/config/older-schemas/v1.yaml
+++ b/config/older-schemas/v1.yaml
@@ -7,7 +7,7 @@ config:
   # This value tells RapiDAST what schema should be used to read this configuration.
   # Therefore you should only change it if you update the configuration to a newer schema
   # It is intended to keep backward compatibility (newer RapiDAST running an older config)
-  configVersion: 2
+  configVersion: "1"
 
   # all the results of all scanners will be stored under that location
   base_results_dir: "./results"
@@ -84,9 +84,7 @@ scanners:
       policy:  "API-scan-minimal"
 
     container:
-      parameters:
-        image: "docker.io/owasp/zap2docker-stable:latest" # for type such as podman
-        executable: "zap.sh"
+      image: "docker.io/owasp/zap2docker-stable:latest"
 
     # Defaults to False, set True do update ZAP's plugins
     updateAddons: False

--- a/configmodel/__init__.py
+++ b/configmodel/__init__.py
@@ -31,6 +31,25 @@ class RapidastConfigModel:
         )
         return default
 
+    def delete(self, path):
+        """Delete path"""
+        path = path_to_list(path)
+        walk = self.conf
+        try:
+            for e in path[:-1]:
+                walk = walk[e]
+            del walk[path[-1]]
+            return True
+        except KeyError:
+            pass
+        except AttributeError:
+            pass
+        # Failed to iterate until the end: the path does not exist
+        logging.warning(
+            f"RapidastConfigModel.delete(): Config path {path} was not found. No deletion"
+        )
+        return False
+
     def exists(self, path):
         """Returns true if `path` exists in configuration
         Even if the value is None

--- a/configmodel/tests/test_configmodel.py
+++ b/configmodel/tests/test_configmodel.py
@@ -1,0 +1,45 @@
+import yaml
+
+import pytest
+from configmodel import RapidastConfigModel
+
+
+@pytest.fixture(name="config_template")
+def generate_config_template():
+    model = "config/config-template-long.yaml"
+    try:
+        with open(model) as file:
+            config = RapidastConfigModel(yaml.safe_load(file))
+    except yaml.YAMLError as exc:
+        raise RuntimeError("Unable to load TEST file {model}") from exc
+
+    return config
+
+
+@pytest.fixture(name="some_nested_config")
+def generate_some_nested_config():
+    return {
+        "key1": "value1",
+        "key2": {"key21": "value21"},
+        "nested": {"morenested": {"key3": "nestedvalue"}},
+    }
+
+
+def test_configmodel_set(some_nested_config):
+    myconf = RapidastConfigModel(some_nested_config)
+
+    # Simple set *but* no overwrite (no change)
+    myconf.set("key2.key21", "mynewval", overwrite=False)
+    assert myconf.get("key2.key21") == "value21"
+
+    # Simple set with overwrite (successful overwrite)
+    myconf.set("key2.key21", "mynewval", overwrite=True)
+    assert myconf.get("key2.key21") == "mynewval"
+
+    # incompatible set, no overwrite
+    myconf.set("nested.morenested", "mynewval", overwrite=False)
+    assert myconf.get("nested.morenested.key3") == "nestedvalue"
+
+    # incompatible set, with overwrite
+    myconf.set("nested.morenested", "mynewval", overwrite=True)
+    assert myconf.get("nested.morenested") == "mynewval"

--- a/configmodel/tests/test_configmodel.py
+++ b/configmodel/tests/test_configmodel.py
@@ -25,6 +25,18 @@ def generate_some_nested_config():
     }
 
 
+def test_configmodel_get(some_nested_config):
+    myconf = RapidastConfigModel(some_nested_config)
+
+    # existing get
+    assert myconf.get("key1", "x") == "value1"
+    assert myconf.get("nested.morenested", "x") == {"key3": "nestedvalue"}
+
+    # unexisting values
+    assert myconf.get("nothing", "x") == "x"
+    assert myconf.get("nested.nothing", "x") == "x"
+
+
 def test_configmodel_set(some_nested_config):
     myconf = RapidastConfigModel(some_nested_config)
 
@@ -43,3 +55,20 @@ def test_configmodel_set(some_nested_config):
     # incompatible set, with overwrite
     myconf.set("nested.morenested", "mynewval", overwrite=True)
     assert myconf.get("nested.morenested") == "mynewval"
+
+
+def test_configmodel_delete(some_nested_config):
+    myconf = RapidastConfigModel(some_nested_config)
+
+    # Simple delete
+    myconf.delete("key1")
+    assert not myconf.exists("key1")
+    # Simple nested delete
+    myconf.delete("key2.key21")
+    assert myconf.exists("key2")
+    assert not myconf.exists("key2.key21")
+    # branch delete
+    myconf.delete("nested")
+    assert not myconf.exists("nested.morenested.key3")
+    assert not myconf.exists("nested.morenested")
+    assert not myconf.exists("nested")

--- a/configmodel/tests/test_convert.py
+++ b/configmodel/tests/test_convert.py
@@ -1,18 +1,37 @@
-import pytest
 import yaml
 
 import configmodel.converter
+import pytest
 
 
 @pytest.fixture(name="config_v0")
 def generate_config_v0():
     try:
         with open("config/older-schemas/v0.yaml") as file:
-            config = configmodel.RapidastConfigModel(yaml.safe_load(file))
+            return configmodel.RapidastConfigModel(yaml.safe_load(file))
     except yaml.YAMLError as exc:
         raise RuntimeError("Unable to load TEST file v0.yaml") from exc
 
     return config
+
+
+@pytest.fixture(name="config_v1")
+def generate_config_v1():
+    path = "config/older-schemas/v1.yaml"
+    try:
+        with open(path) as file:
+            return configmodel.RapidastConfigModel(yaml.safe_load(file))
+    except yaml.YAMLError as exc:
+        raise RuntimeError(f"Unable to load TEST file {path}") from exc
+
+
+def test_v1_to_v2(config_v1):
+    oldconf = config_v1
+    newconf = configmodel.converter.convert_from_version_1_to_2(oldconf)
+
+    assert newconf.get("scanners.zap.container.parameters.image", "x") == oldconf.get(
+        "scanners.zap.container.image", "y"
+    )
 
 
 def test_v0_to_v1(config_v0):

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -73,18 +73,17 @@ class Zap(RapidastScanner):
     # Called via inheritence only                                 #
     ###############################################################
 
-    def setup(self, executable="zap.sh"):
+    def setup(self):
         """Prepares everything:
         - the command line to run
         - environment variables
         - files & directory
 
-        `exec` contains the ZAP executable name, which may vary depending on container
         This code handles only the "ZAP" layer, independently of the container used.
         This method should not be called directly, but only via super() from a child's setup()
         """
         logging.info("Preparing ZAP configuration")
-        self._setup_zap_cli(executable)
+        self._setup_zap_cli()
         self._setup_zap_automation()
 
     def run(self):
@@ -413,10 +412,12 @@ class Zap(RapidastScanner):
                 self._construct_report_af(zap_template, report_filename)
             )
 
-    def _setup_zap_cli(self, executable):
-        """prepare the zap command"""
+    def _setup_zap_cli(self):
+        """prepare the zap command: self.zap_cli
+        This is a list of strings, representing the entire ZAP command to match the desired run
+        """
 
-        self.zap_cli = [executable]
+        self.zap_cli = [self.config.get("scanners.zap.container.parameters.executable")]
 
         # Proxy workaround (because it currently can't be configured from Automation Framework)
         proxy = self.config.get("scanners.zap.proxy")

--- a/scanners/zap/zap_none.py
+++ b/scanners/zap/zap_none.py
@@ -91,12 +91,13 @@ class ZapNone(Zap):
         if not self.state == State.READY:
             raise RuntimeError("[ZAP SCANNER]: ERROR, not ready to run")
 
-        logging.info("Zap: Updating addons")
-        result = subprocess.run(["zap.sh", "-cmd", "-addonupdate"], check=False)
-        if result.returncode != 0:
-            logging.warning(
-                f"The ZAP addon update process did not finish correctly, and exited with code {result.returncode}"
-            )
+        if self.config.get("scanners.zap.updateAddons", default=False):
+            logging.info("Zap: Updating addons")
+            result = subprocess.run(["zap.sh", "-cmd", "-addonupdate"], check=False)
+            if result.returncode != 0:
+                logging.warning(
+                    f"The ZAP addon update process did not finish correctly, and exited with code {result.returncode}"
+                )
 
         # Now the real run
         logging.info(f"Running ZAP with the following command:\n{self.zap_cli}")

--- a/scanners/zap/zap_none.py
+++ b/scanners/zap/zap_none.py
@@ -34,6 +34,11 @@ class ZapNone(Zap):
         logging.debug("Initializing a local instance of the ZAP scanner")
         super().__init__(config)
 
+        # Setup defaults specific to "no container" mode
+        self.config.set(
+            "scanners.zap.container.parameters.executable", "zap.sh", overwrite=False
+        )
+
         # prepare the host <-> container mapping
         # Because there's no container layer, there's no need to translate anything
         temp_dir = self._create_work_dir()
@@ -53,7 +58,7 @@ class ZapNone(Zap):
     # + list: setup(), run(), postprocess(), cleanup()            #
     ###############################################################
 
-    def setup(self, executable=None):
+    def setup(self):
         """Prepares everything:
         - the command line to run
         - environment variables
@@ -67,7 +72,7 @@ class ZapNone(Zap):
                 f"Podman setup encounter an unexpected state: {self.state}"
             )
 
-        super().setup(executable="zap.sh")
+        super().setup()
 
         # Without a container layer, can't "mount" the policy directory, and ZAP does not allow changing it
         # We have to copy it to ~/.ZAP/policies/
@@ -93,7 +98,14 @@ class ZapNone(Zap):
 
         if self.config.get("scanners.zap.updateAddons", default=False):
             logging.info("Zap: Updating addons")
-            result = subprocess.run(["zap.sh", "-cmd", "-addonupdate"], check=False)
+            result = subprocess.run(
+                [
+                    self.config.get("scanners.zap.container.parameters.executable"),
+                    "-cmd",
+                    "-addonupdate",
+                ],
+                check=False,
+            )
             if result.returncode != 0:
                 logging.warning(
                     f"The ZAP addon update process did not finish correctly, and exited with code {result.returncode}"

--- a/scanners/zap/zap_podman.py
+++ b/scanners/zap/zap_podman.py
@@ -99,10 +99,13 @@ class ZapPodman(Zap):
             )
         )
 
-        # Update scanner as a first command, then actually run ZAP
-        # currently, this is done via a `sh -c` wrapper
-        commands = "zap.sh -cmd -addonupdate; " + " ".join(self.zap_cli)
-        cli += ["sh", "-c", commands]
+        if self.config.get("scanners.zap.updateAddons", default=False):
+            # Update scanner as a first command, then actually run ZAP
+            # currently, this is done via a `sh -c` wrapper
+            commands = "zap.sh -cmd -addonupdate; " + " ".join(self.zap_cli)
+            cli += ["sh", "-c", commands]
+        else:
+            cli += self.zap_cli
 
         # DO STUFF
         logging.info(f"Running ZAP with the following command:\n{cli}")

--- a/scanners/zap/zap_podman.py
+++ b/scanners/zap/zap_podman.py
@@ -75,7 +75,6 @@ class ZapPodman(Zap):
                 f"Podman setup encounter an unexpected state: {self.state}"
             )
 
-        # MUST be done _before_ super().setup, because we need to prepare volume mapping
         self._setup_podman_cli()
 
         super().setup(executable="/zap/zap.sh")


### PR DESCRIPTION
Added the ability to choose which executable each scanner will run.
Each type provides a sensible default (zap.sh), which can be overwritten by the user using `scanners.*.container.parameters.executable`

As a result, `scanners.*.container.image` was moved to `scanners.*.container.parameters.image`

In order to achieve that cleanly: also added a "overwrite=True" parameters to RapidastConfigModel.set() to allow each scanners to set a parameter *if* it wasn't previously set (similar to `merge()` but for only 1 value)

* Since this is an incompatible change, configModel is increased and converter function written
* pytests have been added for new functions as well as some previously untested functions.

Final Note: I am realizing just now that it might be better if we rename `overwrite` to `preserve` so that the parameter naming is consistent between `RapidastConfigModel.set()` and  `RapidastConfigModel.merge()` . 
Let me know if I should make the change now or separately