### PR TITLE
Improved path translation

### DIFF
--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -80,6 +80,30 @@ def authentication_set_http_basic_auth(self):
   """Configure HTTP Basic authentication"""
 ```
 
+### Path helper
+
+Because scanners may need to handle path from the "host" view and the "container" view, and translate from one to another, we have created a `path_translator` module to facilitate this.
+
+In practice, this helps to copy files in and out of the container section, or calculate paths inside the container, indepently from the "container" technology. The scanner first needs to setup the mapping correctly, and the rest of the code can work according to the mapping. The mapping usually corresponds to mountpoints, or important directory where the code will need to store/retrieve data.
+
+Example :
+
+```python
+from scanners.path_translators import PathMaps
+from scanners.path_translators import PathMap
+
+path_map = PathMaps("workdir", "policies", "scripts")
+path_map.workdir = PathMap("/on/host/workdir", "/in/container/workdir")
+
+print(f"workdir in container: {path_map.workdir.container_path}")
+
+myfile = "/in/container/workdir/results/myresults.txt"
+print(f"myfile on host: {path_map.container_2_host(myfile)}")
+```
+
+For `type = None` (the scanner will run on the host), then the map must be the same (e.g.: `PathMap("/path/to/dir", "/path/to/dir")`)
+Important note: there is currently no support for submount : if a mapping is set to `/my/first/mount`, there can not be another map to `/my/first/mount/my/other/mount`
+
 
 ## The configuration model
 

--- a/scanners/__init__.py
+++ b/scanners/__init__.py
@@ -20,8 +20,6 @@ class RapidastScanner:
         self.config = config
         self.state = State.UNCONFIGURED
 
-        self.path_map = PathMaps()
-
     def __repr__(self):
         return pformat(vars(self), indent=4, width=1)
 

--- a/scanners/__init__.py
+++ b/scanners/__init__.py
@@ -3,7 +3,6 @@ from enum import Enum
 from pprint import pformat
 
 import configmodel
-from .path_translators import PathMaps
 
 
 class State(Enum):

--- a/scanners/path_translators.py
+++ b/scanners/path_translators.py
@@ -21,7 +21,11 @@ def dynamic_attributes(cls):
             if key == "_data":
                 self.__dict__[key] = value
             elif key in self._data and self._data[key] is None:
-                self._data[key] = value
+                if not isinstance(value, tuple):
+                    raise ValueError(
+                        f"Setting {self.__class__.__name__}.{key} requires a tuples of 2 paths"
+                    )
+                self._data[key] = PathMap(value[0], value[1])
             else:
                 # Currently: do not allow new entries beyond what was set at creation time
                 raise AttributeError(

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -11,7 +11,6 @@ import yaml
 
 from scanners import generic_authentication_factory
 from scanners import RapidastScanner
-from scanners.path_translators import PathMaps
 
 
 CLASSNAME = "Zap"
@@ -62,7 +61,7 @@ class Zap(RapidastScanner):
         #   - AF file, reports, evidence, etc. are beneath this path
         # + scripts: where scripts are stored
         # + policies: where policies are stored
-        self.path_map = PathMaps("workdir", "policies", "scripts")
+        self.path_map = None  # to be defined by the typed scanner
 
     ###############################################################
     # PUBLIC METHODS                                              #

--- a/scanners/zap/zap_none.py
+++ b/scanners/zap/zap_none.py
@@ -7,7 +7,6 @@ import subprocess
 from .zap import MODULE_DIR
 from .zap import Zap
 from scanners import State
-from scanners.path_translators import PathMap
 
 CLASSNAME = "ZapNone"
 
@@ -44,11 +43,9 @@ class ZapNone(Zap):
         temp_dir = self._create_work_dir()
         policies_dir = f"{os.environ['HOME']}/.ZAP/policies"
 
-        self.path_map.workdir = PathMap(temp_dir, temp_dir)
-        self.path_map.scripts = PathMap(
-            f"{MODULE_DIR}/scripts", f"{MODULE_DIR}/scripts"
-        )
-        self.path_map.policies = PathMap(policies_dir, policies_dir)
+        self.path_map.workdir = (temp_dir, temp_dir)
+        self.path_map.scripts = (f"{MODULE_DIR}/scripts", f"{MODULE_DIR}/scripts")
+        self.path_map.policies = (policies_dir, policies_dir)
 
     ###############################################################
     # PUBLIC METHODS                                              #

--- a/scanners/zap/zap_none.py
+++ b/scanners/zap/zap_none.py
@@ -7,6 +7,7 @@ import subprocess
 from .zap import MODULE_DIR
 from .zap import Zap
 from scanners import State
+from scanners.path_translators import make_mapping_for_scanner
 
 CLASSNAME = "ZapNone"
 
@@ -43,9 +44,12 @@ class ZapNone(Zap):
         temp_dir = self._create_work_dir()
         policies_dir = f"{os.environ['HOME']}/.ZAP/policies"
 
-        self.path_map.workdir = (temp_dir, temp_dir)
-        self.path_map.scripts = (f"{MODULE_DIR}/scripts", f"{MODULE_DIR}/scripts")
-        self.path_map.policies = (policies_dir, policies_dir)
+        self.path_map = make_mapping_for_scanner(
+            "Zap",
+            ("workdir", temp_dir, temp_dir),
+            ("scripts", f"{MODULE_DIR}/scripts", f"{MODULE_DIR}/scripts"),
+            ("policies", policies_dir, policies_dir),
+        )
 
     ###############################################################
     # PUBLIC METHODS                                              #

--- a/scanners/zap/zap_none.py
+++ b/scanners/zap/zap_none.py
@@ -5,9 +5,9 @@ import shutil
 import subprocess
 
 from .zap import MODULE_DIR
-from .zap import PathIds
 from .zap import Zap
 from scanners import State
+from scanners.path_translators import PathMap
 
 CLASSNAME = "ZapNone"
 
@@ -44,11 +44,11 @@ class ZapNone(Zap):
         temp_dir = self._create_work_dir()
         policies_dir = f"{os.environ['HOME']}/.ZAP/policies"
 
-        self.path_map.add(PathIds.WORK, temp_dir, temp_dir)
-        self.path_map.add(
-            PathIds.SCRIPTS, f"{MODULE_DIR}/scripts", f"{MODULE_DIR}/scripts"
+        self.path_map.workdir = PathMap(temp_dir, temp_dir)
+        self.path_map.scripts = PathMap(
+            f"{MODULE_DIR}/scripts", f"{MODULE_DIR}/scripts"
         )
-        self.path_map.add(PathIds.POLICIES, policies_dir, policies_dir)
+        self.path_map.policies = PathMap(policies_dir, policies_dir)
 
     ###############################################################
     # PUBLIC METHODS                                              #
@@ -82,7 +82,7 @@ class ZapNone(Zap):
             )
             self._include_file(
                 host_path=f"{MODULE_DIR}/policies/{policy}.policy",
-                dest_in_container=self.path_map.get(PathIds.POLICIES).container,
+                dest_in_container=self.path_map.policies.container_path,
             )
 
         if self.state != State.ERROR:

--- a/scanners/zap/zap_podman.py
+++ b/scanners/zap/zap_podman.py
@@ -8,7 +8,6 @@ import subprocess
 from .zap import MODULE_DIR
 from .zap import Zap
 from scanners import State
-from scanners.path_translators import PathMap
 
 CLASSNAME = "ZapPodman"
 
@@ -57,11 +56,9 @@ class ZapPodman(Zap):
 
         # prepare the host <-> container mapping
         # The default location for WORK can be chosen by parent itself (no overide of self._create_work_dir)
-        self.path_map.workdir = PathMap(self._create_work_dir(), "/zap/results")
-        self.path_map.scripts = PathMap(f"{MODULE_DIR}/scripts", "/zap/scripts")
-        self.path_map.policies = PathMap(
-            f"{MODULE_DIR}/policies", "/home/zap/.ZAP/policies/"
-        )
+        self.path_map.workdir = (self._create_work_dir(), "/zap/results")
+        self.path_map.scripts = (f"{MODULE_DIR}/scripts", "/zap/scripts")
+        self.path_map.policies = (f"{MODULE_DIR}/policies", "/home/zap/.ZAP/policies/")
 
     ###############################################################
     # PUBLIC METHODS                                              #

--- a/scanners/zap/zap_podman.py
+++ b/scanners/zap/zap_podman.py
@@ -8,6 +8,7 @@ import subprocess
 from .zap import MODULE_DIR
 from .zap import Zap
 from scanners import State
+from scanners.path_translators import make_mapping_for_scanner
 
 CLASSNAME = "ZapPodman"
 
@@ -56,9 +57,12 @@ class ZapPodman(Zap):
 
         # prepare the host <-> container mapping
         # The default location for WORK can be chosen by parent itself (no overide of self._create_work_dir)
-        self.path_map.workdir = (self._create_work_dir(), "/zap/results")
-        self.path_map.scripts = (f"{MODULE_DIR}/scripts", "/zap/scripts")
-        self.path_map.policies = (f"{MODULE_DIR}/policies", "/home/zap/.ZAP/policies/")
+        self.path_map = make_mapping_for_scanner(
+            "Zap",
+            ("workdir", self._create_work_dir(), "/zap/results"),
+            ("scripts", f"{MODULE_DIR}/scripts", "/zap/scripts"),
+            ("policies", f"{MODULE_DIR}/policies", "/home/zap/.ZAP/policies/"),
+        )
 
     ###############################################################
     # PUBLIC METHODS                                              #
@@ -204,7 +208,7 @@ class ZapPodman(Zap):
         self._setup_zap_podman_id_mapping_cli()
 
         # Volume mappings
-        for mapping in self.path_map.list_maps():
+        for mapping in self.path_map:
             self.podman_opts += [
                 "--volume",
                 f"{mapping.host_path}:{mapping.container_path}:Z",

--- a/scanners/zap/zap_podman.py
+++ b/scanners/zap/zap_podman.py
@@ -6,9 +6,9 @@ import string
 import subprocess
 
 from .zap import MODULE_DIR
-from .zap import PathIds
 from .zap import Zap
 from scanners import State
+from scanners.path_translators import PathMap
 
 CLASSNAME = "ZapPodman"
 
@@ -57,10 +57,10 @@ class ZapPodman(Zap):
 
         # prepare the host <-> container mapping
         # The default location for WORK can be chosen by parent itself (no overide of self._create_work_dir)
-        self.path_map.add(PathIds.WORK, self._create_work_dir(), "/zap/results")
-        self.path_map.add(PathIds.SCRIPTS, f"{MODULE_DIR}/scripts", "/zap/scripts")
-        self.path_map.add(
-            PathIds.POLICIES, f"{MODULE_DIR}/policies", "/home/zap/.ZAP/policies/"
+        self.path_map.workdir = PathMap(self._create_work_dir(), "/zap/results")
+        self.path_map.scripts = PathMap(f"{MODULE_DIR}/scripts", "/zap/scripts")
+        self.path_map.policies = PathMap(
+            f"{MODULE_DIR}/policies", "/home/zap/.ZAP/policies/"
         )
 
     ###############################################################
@@ -207,8 +207,11 @@ class ZapPodman(Zap):
         self._setup_zap_podman_id_mapping_cli()
 
         # Volume mappings
-        for mapping in self.path_map.paths.values():
-            self.podman_opts += ["--volume", f"{mapping.host}:{mapping.container}:Z"]
+        for mapping in self.path_map.list_maps():
+            self.podman_opts += [
+                "--volume",
+                f"{mapping.host_path}:{mapping.container_path}:Z",
+            ]
 
     def _setup_zap_podman_id_mapping_cli(self):
         """Adds a specific user mapping to the Zap podman container.

--- a/tests/test_path_translators.py
+++ b/tests/test_path_translators.py
@@ -1,12 +1,11 @@
-from scanners.path_translators import PathMap
-from scanners.path_translators import PathMaps
+from scanners.path_translators import make_mapping_for_scanner
 
 
 def test_path_translation():
-    path_map = PathMaps("id1", "id2", "id3")
-    path_map.id1 = ("/q/w/e/r/t", "/y/u/i/o/p")
-    path_map.id2 = ("/a/s/d/f/g", "/h/j/k/l")
-    path_map.id3 = ("/z/x/c/v", "/b/n/m")
+    id1 = ("id1", "/q/w/e/r/t", "/y/u/i/o/p")
+    id2 = ("id2", "/a/s/d/f/g", "/h/j/k/l")
+    id3 = ("id3", "/z/x/c/v", "/b/n/m")
+    path_map = make_mapping_for_scanner("Test", id1, id2, id3)
 
     assert (
         path_map.host_2_container("/a/s/d/f/g/subdir/myfile")

--- a/tests/test_path_translators.py
+++ b/tests/test_path_translators.py
@@ -4,9 +4,9 @@ from scanners.path_translators import PathMaps
 
 def test_path_translation():
     path_map = PathMaps("id1", "id2", "id3")
-    path_map.id1 = PathMap("/q/w/e/r/t", "/y/u/i/o/p")
-    path_map.id2 = PathMap("/a/s/d/f/g", "/h/j/k/l")
-    path_map.id3 = PathMap("/z/x/c/v", "/b/n/m")
+    path_map.id1 = ("/q/w/e/r/t", "/y/u/i/o/p")
+    path_map.id2 = ("/a/s/d/f/g", "/h/j/k/l")
+    path_map.id3 = ("/z/x/c/v", "/b/n/m")
 
     assert (
         path_map.host_2_container("/a/s/d/f/g/subdir/myfile")

--- a/tests/test_path_translators.py
+++ b/tests/test_path_translators.py
@@ -1,11 +1,12 @@
+from scanners.path_translators import PathMap
 from scanners.path_translators import PathMaps
 
 
 def test_path_translation():
-    path_map = PathMaps()
-    path_map.add("id1", "/q/w/e/r/t", "/y/u/i/o/p")
-    path_map.add("id2", "/a/s/d/f/g", "/h/j/k/l")
-    path_map.add("id3", "/z/x/c/v", "/b/n/m")
+    path_map = PathMaps("id1", "id2", "id3")
+    path_map.id1 = PathMap("/q/w/e/r/t", "/y/u/i/o/p")
+    path_map.id2 = PathMap("/a/s/d/f/g", "/h/j/k/l")
+    path_map.id3 = PathMap("/z/x/c/v", "/b/n/m")
 
     assert (
         path_map.host_2_container("/a/s/d/f/g/subdir/myfile")


### PR DESCRIPTION
Uses a decorator to dynamically generate attributes from a path identifier.
    
For example :
    
```python
    from scanners.path_translators import PathMaps
    from scanners.path_translators import PathMap
    
    path_map = PathMaps("workdir", "policies", "scripts")
    path_map.workdir = PathMap("/on/host/workdir", "/in/container/workdir")
    
    print(f"workdir in container: {path_map.workdir.container_path}")
    
    myfile = "/in/container/workdir/results/myresults.txt"
    print(f"myfile on host: {path_map.container_2_host(myfile)}")
```