### PR TITLE
[ZAP] Added a job for import URLs

### DIFF
--- a/config/config-template-long.yaml
+++ b/config/config-template-long.yaml
@@ -62,7 +62,10 @@ scanners:
       target: "<optional, if different from application.url>"
       apis:
         apiUrl: "<URL to openAPI>"
-        # alternative: apiFile: "<local path to openAPI file>"
+        # alternative to apiURL: apiFile: "<local path to openAPI file>"
+
+    # A list of URLs can also be provided, from a text file (1 URL per line)
+    importUrlsFromFile: "<path to import URL>"
 
     spider:
       maxDuration: 0 # in minutes, default: 0 unlimited

--- a/scanners/zap/tests/test_setup_podman.py
+++ b/scanners/zap/tests/test_setup_podman.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import yaml
 
 import configmodel.converter
@@ -15,6 +17,15 @@ def test_config():
 
 
 ## Testing Authentication methods ##
+
+
+def test_setup_import_urls(test_config):
+    # trick: set this very file as import
+    test_config.set("scanners.zap.importUrlsFromFile", __file__)
+
+    test_zap = ZapPodman(config=test_config)
+    test_zap.setup()
+    assert Path(test_zap._host_work_dir(), "importUrls.txt").is_file()
 
 
 def test_setup_authentication_no_auth_configured(test_config):

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -199,6 +199,7 @@ class Zap(RapidastScanner):
         self._setup_spider()
         self._setup_ajax_spider()
         self._setup_api()
+        self._setup_import_urls()
         self._setup_passive_scan()
         self._setup_active_scan()
         self._setup_passive_wait()
@@ -206,6 +207,21 @@ class Zap(RapidastScanner):
 
         # The AF should now be setup and ready to be written
         self._save_automation_file()
+
+    def _setup_import_urls(self):
+        """If scanners.zap.importUrlsFromFile exists: prepare an import job for URLs
+        scanners.zap.importUrlsFromFile _must_ be an existing file on the host
+        Its content is a text file: a list of GET URLs, each of which will be scanned
+        """
+        job = {"name": "import", "type": "import", "parameters": {"type": "url"}}
+
+        orig = self.config.get("scanners.zap.importUrlsFromFile")
+        if not orig:
+            return
+        dest = f"{self._container_work_dir()}/importUrls.txt"
+        self._include_file(orig, dest)
+        job["parameters"]["fileName"] = dest
+        self.af["jobs"].append(job)
 
     def _setup_api(self):
         """Prepare an openapi job and append it to the job list"""


### PR DESCRIPTION
This maps to the `import` job of type `url`

The path to the file containing URLs is defined by scanners.zap.apiScan.apis.importUrls

The file will be copied as "importUrls.txt" in the container, and an import job will be added to Automation. This file will be included inside the evidences tar file.

Also added a corresponding pytest & template example

It has been tested with VAPI (removing the OAS, and creating a file with a list of GET requests accepted by VAPI)