### PR TITLE
[bug][configmodel] crash when an entry is None

### DIFF
--- a/configmodel/__init__.py
+++ b/configmodel/__init__.py
@@ -60,6 +60,8 @@ class RapidastConfigModel:
             for key in path:
                 tmp = tmp[key]
             return True
+        except TypeError:
+            return False
         except KeyError:
             return False
 

--- a/configmodel/tests/test_configmodel.py
+++ b/configmodel/tests/test_configmodel.py
@@ -22,7 +22,29 @@ def generate_some_nested_config():
         "key1": "value1",
         "key2": {"key21": "value21"},
         "nested": {"morenested": {"key3": "nestedvalue"}},
+        "nothing": None,
     }
+
+
+def test_configmodel_exists(some_nested_config):
+    myconf = RapidastConfigModel(some_nested_config)
+
+    # verify that some values exist
+    assert myconf.exists("key1")
+    assert myconf.exists("nested.morenested.key3")
+    assert myconf.exists("nothing")
+
+    # verify that some values do not exist
+    assert not myconf.exists("thisdoesntexists")
+    assert not myconf.exists("key1.thisdoesntexists")
+    assert not myconf.exists("key1.value1.thisdoesntexists")
+    assert not myconf.exists("key1.value2.thisdoesntexists")
+    assert not myconf.exists("nested.value2.thisdoesntexists")
+    assert not myconf.exists("nothing.thisdoesntexists")
+
+    # exists looks for keys, not values, so these should return False also
+    assert not myconf.exists("key1.value1")
+    assert not myconf.exists("nested.morenested.key3.nestedvalue")
 
 
 def test_configmodel_get(some_nested_config):
@@ -33,8 +55,8 @@ def test_configmodel_get(some_nested_config):
     assert myconf.get("nested.morenested", "x") == {"key3": "nestedvalue"}
 
     # unexisting values
-    assert myconf.get("nothing", "x") == "x"
-    assert myconf.get("nested.nothing", "x") == "x"
+    assert myconf.get("thisdoesnotexists", "x") == "x"
+    assert myconf.get("nested.thisdoesnotexists", "x") == "x"
 
 
 def test_configmodel_set(some_nested_config):


### PR DESCRIPTION
`config.exists()` did not work correctly when an entry was set to None. This is because getting `None["x"]` returns a `TypeError` instead of the usual `KeyError`, and thus the exception was not caught, crashing RapiDAST.

This fixes the issue by catching this particular exception.

The issue was made visible when converting from older schema when `general` existed but was empty.

eg.:

```yaml
config:
        configVersion: 1
general:
```

Also added a test dedicated to the `config.exists()` function.