### PR TITLE
Zap support exclude urls

### DIFF
--- a/config/config-template-long.yaml
+++ b/config/config-template-long.yaml
@@ -102,5 +102,13 @@ scanners:
       # Defaults to True, set False to prevent auto update of ZAP plugins
       updateAddons: True
 
+    urls:
+      # `excludes` takes a list of regexps. A URL matching that regexp will not be used by the scanner
+      # Note: The regular expressions MUST match the whole URL.
+      #       e.g.: 'http://example.com/do-not-descend-here/' will actually descend
+      excludes:
+        - "^https?://example.com/do-not-descend-here/.*$"
+
+
 
 # Other scanners to be defined(TBD)

--- a/scanners/zap/tests/test_setup_podman.py
+++ b/scanners/zap/tests/test_setup_podman.py
@@ -4,6 +4,7 @@ import yaml
 
 import configmodel.converter
 import pytest
+from scanners.zap.zap import find_context
 from scanners.zap.zap_podman import ZapPodman
 
 # from pytest_mock import mocker
@@ -124,6 +125,22 @@ def test_setup_authentication_auth_rtoken_configured(test_config):
     assert test_zap.authenticated == True
     assert "RTOKEN" in test_zap.podman_opts
     assert test_zap.af["jobs"][0]["parameters"]["name"] == "add-bearer-token"
+
+
+## Testing APIs & URLs ##
+
+
+def test_setup_exclude_urls(test_config):
+    test_config.set("general.urls.excludes", ["abc", "def"])
+    test_config.merge(
+        test_config.get("general", default={}), preserve=False, root=f"scanners.zap"
+    )
+
+    test_zap = ZapPodman(config=test_config)
+    test_zap.setup()
+
+    assert "abc" in find_context(test_zap.af)["excludePaths"]
+    assert "def" in find_context(test_zap.af)["excludePaths"]
 
 
 def test_setup_ajax(test_config):

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -187,6 +187,9 @@ class Zap(RapidastScanner):
         try:
             af_context = find_context(self.af)
             af_context["urls"].append(self.config.get("application.url"))
+            af_context["excludePaths"].extend(
+                self.config.get("scanners.zap.urls.excludes", default=[])
+            )
         except KeyError as exc:
             raise RuntimeError(
                 f"Something went wrong with the Zap scanner configuration, while creating the context':\n {str(exc)}"
@@ -267,7 +270,7 @@ class Zap(RapidastScanner):
             },
         }
 
-        # Add to includePath to the context
+        # Add to includePaths to the context
         if self.config.get("scanners.zap.spider.url"):
             new_include_path = self.config.get("scanners.zap.spider.url") + ".*"
             af_context = find_context(self.af)
@@ -296,7 +299,7 @@ class Zap(RapidastScanner):
             },
         }
 
-        # Add to includePath to the context
+        # Add to includePaths to the context
         if self.config.get("scanners.zap.spiderAjax.url"):
             new_include_path = self.config.get("scanners.zap.spiderAjax.url") + ".*"
             af_context = find_context(self.af)


### PR DESCRIPTION
This uses the configuration's "global exclude list".
    
Note/Warning:
- It deletes the list currently configured. By default, this list is not empty, using this option will remove the previously configured list. I am not aware of a method that appends to an existing configuration.
- In non contained mode (flatpak, or direct-host), this affects the user's configuration.