### PR TITLE
added urls.includes for extra scope of scanning

### DIFF
--- a/config/config-template-long.yaml
+++ b/config/config-template-long.yaml
@@ -104,7 +104,7 @@ scanners:
       #       e.g.: 'http://example.com/do-not-descend-here/' will actually descend
 
       #includes:
-      #  - "^https?://example.com:3000/do-not-descend-here/.*$"
+      #  - "^https?://example.com:3000/.*$"
       #excludes:
       #  - "^https?://example.com:3000/do-not-descend-here/.*$"
 

--- a/config/config-template-long.yaml
+++ b/config/config-template-long.yaml
@@ -96,19 +96,23 @@ scanners:
       format: ["json"]
       # format: ["json","html","sarif"]  # default: "json" only
 
+    urls:
+      # Optional, `includes` and `excludes` take a list of regexps.
+      # includes: A URL matching that regexp will be in the scope of scanning, in addition to application.url which is already in scope
+      # excludes: A URL matching that regexp will NOT be in the scope of scanning
+      # Note: The regular expressions MUST match the whole URL.
+      #       e.g.: 'http://example.com/do-not-descend-here/' will actually descend
+
+      #includes:
+      #  - "^https?://example.com:3000/do-not-descend-here/.*$"
+      #excludes:
+      #  - "^https?://example.com:3000/do-not-descend-here/.*$"
+
     miscOptions:
       # enableUI (default: false), requires a compatible runtime (e.g.: flatpak or no containment)
       enableUI: False
       # Defaults to True, set False to prevent auto update of ZAP plugins
       updateAddons: True
-
-    urls:
-      # `excludes` takes a list of regexps. A URL matching that regexp will not be used by the scanner
-      # Note: The regular expressions MUST match the whole URL.
-      #       e.g.: 'http://example.com/do-not-descend-here/' will actually descend
-      excludes:
-        - "^https?://example.com/do-not-descend-here/.*$"
-
 
 
 # Other scanners to be defined(TBD)

--- a/scanners/zap/tests/test_setup_podman.py
+++ b/scanners/zap/tests/test_setup_podman.py
@@ -1,9 +1,8 @@
 from pathlib import Path
 
-import yaml
+import pytest
 
 import configmodel.converter
-import pytest
 from scanners.zap.zap import find_context
 from scanners.zap.zap_podman import ZapPodman
 
@@ -131,7 +130,7 @@ def test_setup_authentication_auth_rtoken_configured(test_config):
 
 
 def test_setup_exclude_urls(test_config):
-    test_config.set("general.urls.excludes", ["abc", "def"])
+    test_config.set("scanners.zap.urls.excludes", ["abc", "def"])
     test_config.merge(
         test_config.get("general", default={}), preserve=False, root=f"scanners.zap"
     )
@@ -141,6 +140,19 @@ def test_setup_exclude_urls(test_config):
 
     assert "abc" in find_context(test_zap.af)["excludePaths"]
     assert "def" in find_context(test_zap.af)["excludePaths"]
+
+
+def test_setup_include_urls(test_config):
+    test_config.set("scanners.zap.urls.includes", ["abc", "def"])
+    test_config.merge(
+        test_config.get("general", default={}), preserve=False, root=f"scanners.zap"
+    )
+
+    test_zap = ZapPodman(config=test_config)
+    test_zap.setup()
+
+    assert "abc" in find_context(test_zap.af)["includePaths"]
+    assert "def" in find_context(test_zap.af)["includePaths"]
 
 
 def test_setup_ajax(test_config):

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -187,6 +187,9 @@ class Zap(RapidastScanner):
         try:
             af_context = find_context(self.af)
             af_context["urls"].append(self.config.get("application.url"))
+            af_context["includePaths"].extend(
+                self.config.get("scanners.zap.urls.includes", default=[])
+            )
             af_context["excludePaths"].extend(
                 self.config.get("scanners.zap.urls.excludes", default=[])
             )


### PR DESCRIPTION
Simlarly to the format for `urls.excludes` in config, `urls.includes` gets a list of regex, and enables users to add extra urls to the scope of scanning.

Moved the order of `urls` and `miscOptions`