### PR TITLE
[ZAP] workaround for OAuth2 download of OpenAPI

### DIFF
--- a/config/config-template-long.yaml
+++ b/config/config-template-long.yaml
@@ -101,6 +101,8 @@ scanners:
       enableUI: False
       # Defaults to True, set False to prevent auto update of ZAP plugins
       updateAddons: True
+      # If set to True and authentication is oauth2_rtoken and api.apiUrl is set, download the API outside of ZAP
+      oauth2OpenapiManualDownload: False
 
     urls:
       # `excludes` takes a list of regexps. A URL matching that regexp will not be used by the scanner

--- a/scanners/downloaders.py
+++ b/scanners/downloaders.py
@@ -1,0 +1,64 @@
+# This is a file with helper functions to download file with authentication.
+import logging
+
+import requests
+import yaml
+
+
+def authenticated_download_with_rtoken(
+    url,
+    dest,
+    rtoken,
+    client_id,
+    auth_url,
+    proxy=None,
+):
+    """Given a URL and Oauth2 authentication parameters, download the URL and store it at `dest`"""
+
+    session = requests.Session()
+
+    # get a token
+    headers = {
+        "Accept": "application/json",
+        "Content-Type": "application/x-www-form-urlencoded",
+    }
+    payload = {
+        "client_id": client_id,
+        "grant_type": "refresh_token",
+        "refresh_token": rtoken,
+    }
+    if proxy:
+        proxy = {
+            "https": f"http://{proxy['proxyHost']}:{proxy['proxyPort']}",
+            "http": f"http://{proxy['proxyHost']}:{proxy['proxyPort']}",
+        }
+
+    resp = session.post(auth_url, data=payload, headers=headers, proxies=proxy)
+
+    if resp.status_code != 200:
+        logging.warning(
+            f"Unable to get a bearer token. Aborting manual download for {url}"
+        )
+        return False
+
+    try:
+        token = yaml.safe_load(resp.text)["access_token"]
+    except Exception as exc:
+        raise RuntimeError(
+            f"Unable to extract access token from OAuth2 authentication:\n {str(exc)}"
+        ) from exc
+    authenticated_headers = {"Authorization": f"Bearer {token}"}
+
+    resp = session.get(url, proxies=proxy, headers=authenticated_headers)
+
+    if resp.status_code >= 400:
+        logging.warning(
+            f"ERROR: download failed with {resp.status_code}. Aborting download for {url}"
+        )
+        return False
+
+    with open(dest, "w") as file:
+        file.write(resp.text)
+
+    logging.debug(f"Successful download of {url} into {dest}")
+    return True

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -11,6 +11,7 @@ import yaml
 
 from scanners import generic_authentication_factory
 from scanners import RapidastScanner
+from scanners.downloaders import authenticated_download_with_rtoken
 
 
 CLASSNAME = "Zap"
@@ -164,7 +165,12 @@ class Zap(RapidastScanner):
         else:
             path_to_dest = self.path_map.container_2_host(dest_in_container)
 
-        shutil.copy(host_path, path_to_dest)
+        try:
+            shutil.copy(host_path, path_to_dest)
+        except shutil.SameFileError:
+            logging.debug(
+                f"_include_file() ignoring '{host_path} → 'container:{path_to_dest}' as they are the same file"
+            )
         logging.debug(f"_include_file() '{host_path} → 'container:{path_to_dest}'")
 
     ###############################################################
@@ -595,6 +601,39 @@ class Zap(RapidastScanner):
         }
         self.af["jobs"].append(script)
         logging.info("ZAP configured with OAuth2 RTOKEN")
+
+        # quickhack: the openapi job currently does not run with user authentication.
+        # This is a problem when openapi requires an authenticated URL.
+        # => manually download the OAS, and change it to apiFile
+        # This can be deleted when https://github.com/zaproxy/zaproxy/issues/7739 is resolved
+        # Note: to avoid a temporary file, we download the file directly in its final destination in work_dir
+        #       This is not a problem: it will simply be ignored by _include_file()
+        oas_url = self.config.get("scanners.zap.apiScan.apis.apiUrl", default=None)
+        if oas_url and self.config.get(
+            "scanners.zap.miscOptions.oauth2OpenapiManualDownload", default=False
+        ):
+            logging.info("ZAP workaround: manually downloading the OpenAPI file")
+            if authenticated_download_with_rtoken(
+                url=oas_url,
+                dest=f"{self._host_work_dir()}/openapi.json",
+                rtoken=os.environ[rtoken],
+                client_id=client_id,
+                auth_url=token_endpoint,
+                proxy=self.config.get("scanners.zap.proxy", default=None),
+            ):
+                logging.info(
+                    "Successful manual download of the OAS: replacing apiUrl by apiFile"
+                )
+                self.config.set(
+                    "scanners.zap.apiScan.apis.apiFile",
+                    f"{self._host_work_dir()}/openapi.json",
+                )
+                self.config.delete("scanners.zap.apiScan.apis.apiUrl")
+            else:
+                logging.warning(
+                    "Failed to manually download the OAS. delegating to ZAP"
+                )
+
         return True
 
     ###############################################################


### PR DESCRIPTION
This is aimed at being temporary only.
If ZAP enables authenticated OpenAPI download, it can be removed. Alternatively, the code could be improved slowly in the future.

-> added a `scanners.zap.miscOptions.oauth2OpenapiManualDownload` config entry. It defaults to `False`
-> if the above is True, *and* authentication is OAuth2 *and* there is a OpenAPI definition downloaded over URL, then the code downloads it, and modifies `apiUrl` to `apiFile`
-> a new `scanners.downloaders.authenticated_download_with_rtoken()` function is provided for this matter.

Note:
Because of the nature of the action, I don't see how to make a pytest for this.