### PR TITLE
[ZAP] Adding support for Header authentication

### DIFF
--- a/config/config-template-long.yaml
+++ b/config/config-template-long.yaml
@@ -38,6 +38,10 @@ general:
       token_endpoint: "<token retrieval URL>"
       rtoken_var_name: "RTOKEN"     # referring to a env defined in general.environ.envFile
     # Other types of authentication:
+    #type: "http_header"
+    #parameters:
+    #  name: "Authorization"
+    #  value: "MySecretHeader"
     #type: "http_basic"
     #parameters:
     #  username: "user"

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -519,6 +519,25 @@ class Zap(RapidastScanner):
         logging.info("ZAP configured with Cookie authentication")
         return False
 
+    @authentication_factory.register("http_header")
+    def authentication_set_http_header_auth(self):
+        """Configure authentication via a header name/value
+        Adds a 'HeaderName: HeaderValue' to every query
+
+        Do this using the ZAP_AUTH_HEADER* environment vars
+
+        Returns False as it does not create a ZAP user
+        """
+        params_path = "scanners.zap.authentication.parameters"
+        header_name = self.config.get(f"{params_path}.name", default="Authorization")
+        header_val = self.config.get(f"{params_path}.value", default="")
+
+        self._add_env("ZAP_AUTH_HEADER", header_name)
+        self._add_env("ZAP_AUTH_HEADER_VALUE", header_val)
+
+        logging.info("ZAP configured with Authentication using HTTP Header")
+        return False
+
     @authentication_factory.register("http_basic")
     def authentication_set_http_basic_auth(self):
         """Configure authentication via HTTP Basic Authentication.

--- a/tests/scanners/zap/test_setup_podman.py
+++ b/tests/scanners/zap/test_setup_podman.py
@@ -53,6 +53,26 @@ def test_setup_authentication_invalid_auth_configured(test_config):
         test_zap.setup()
 
 
+def test_setup_authentication_http_header(test_config):
+    authentication = {
+        "type": "http_header",
+        "parameters": {"name": "myheadername", "value": "myheaderval"},
+    }
+    test_config.set("general.authentication", authentication)
+
+    test_config.merge(
+        test_config.get("general", default={}), preserve=False, root=f"scanners.zap"
+    )
+
+    print(test_config)
+
+    test_zap = ZapPodman(config=test_config)
+    test_zap.setup()
+    assert test_zap.authenticated == False
+    assert "ZAP_AUTH_HEADER_VALUE=myheaderval" in test_zap.podman_opts
+    assert "ZAP_AUTH_HEADER=myheadername" in test_zap.podman_opts
+
+
 def test_setup_authentication_cookie(test_config):
     authentication = {
         "type": "cookie",


### PR DESCRIPTION
authentication type: "http_header"

```
  authentication:
    type: "http_header"
    parameters:
      name: "Authorization"
      value: "my secret header"
```

The default header is `Authorization`

Also added corresponding pytest