### PR TITLE
Configmodel: get from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ The configuration file is presented as YAML, and contains several main entries:
 
 See `config/config-template.yaml`(a simple version) and `config/config-template-long.yaml`(an exhaustive version) for examples. Each can be used.
 
+### Advanced configuration
+
+You may not want to directly have configuration values inside the configuration. Typically: either the entry is a secret (such as a password), but the configuration needs to be public, or the entry needs to be dynamically generated (e.g.: a cookie, a uniquely generated URL, etc.) at the time of running RapiDAST, and it's an inconvenient to always having to modify the configuration file for each run.
+
+To avoid this, RapiDAST proposes 2 ways to provide a value for a given configuration entry. For example, to provide a value for the entry `general.authentication.parameters.rtoken`, you can either (in order of priority):
+
+- Create an entry in the configuration file (this is the usual method)
+- Create an entry in the configuration file pointing to the environment variable that actually contains the data, by appending `_from_var` to the entry name: `general.authentication.parameters.rtoken_from_var=RTOKEN` (in this example, the token value is provided by the `$RTOKEN` environment variable)
+
 ## Execution
 
 Once you have created a configuration file, you can run a scan with it.

--- a/configmodel/__init__.py
+++ b/configmodel/__init__.py
@@ -196,15 +196,6 @@ def path_to_list(path):
     return list(path)
 
 
-def path_to_env(path):
-    """Path is a list of values (as returned by `path_to_list()`)
-    Returns the equivalent environment variable
-    e.g.: ["a", "b"] returns the string "RAPIDAST_A_B"
-    """
-    separator = "_"
-    return "RAPIDAST" + separator + separator.join(path).upper()
-
-
 def deep_dict_merge(dest, merge, preserve=False):
     """Modifies and returns the 'dest' dict, after merging 'merge' into it
 

--- a/configmodel/__init__.py
+++ b/configmodel/__init__.py
@@ -70,7 +70,7 @@ class RapidastConfigModel:
         - Create the path if necessary
         - To prevent modification of existing value: overwrite=False
         - Discard previous value
-        - Override (with a warning) path if necessary (if something in the path was not a dict)
+        - Overwrite (with a warning) path if necessary (if something in the path was not a dict)
         - Returns True if a modifcation was made
         """
         path = path_to_list(path)
@@ -98,6 +98,24 @@ class RapidastConfigModel:
             walk[path[-1]] = value
             return True
         return False
+
+    def move(self, orig, dest):
+        """Move a subtree to another location. Nothing happens if the origin does not exist
+        Both `orig` and `dest` are paths (list or dot-separated string) within the configuration
+        """
+
+        orig = path_to_list(orig)
+        dest = path_to_list(dest)
+
+        if dest[0 : len(orig)] == orig:
+            raise ValueError("Moving config entry to a subentry is not supported")
+
+        if self.exists(orig):
+            self.set(dest, self.get(orig))
+            self.delete(orig)
+            logging.debug(f"Moved '{orig}' to '{dest}'")
+        else:
+            logging.debug(f"NOT moving '{orig}' as it did not exist")
 
     def merge(self, merge, preserve=False, root=None):
         """Recursively merge `merge` into the configuration.

--- a/configmodel/converter.py
+++ b/configmodel/converter.py
@@ -5,7 +5,7 @@ import configmodel
 
 # WARNING: this needs to be incremented everytime a non-compatible change is made in the configuration.
 # A corresponding function also needs to be written
-CURR_CONFIG_VERSION = 3
+CURR_CONFIG_VERSION = 4
 
 
 def config_converter_dispatcher(func):
@@ -50,9 +50,31 @@ def convert_configmodel(conf):
     )
 
 
+@convert_configmodel.register(3)
+def convert_from_version_3_to_4(old):
+    """Returns a *copy* of the original rapidast config file, but updated to v4
+    Changes: Now any entry can be optionally appended with `_from_var`.
+    `oauth2_rtoken` authentication can now piggy back on this feature, so the original entry is removed
+    """
+    new = copy.deepcopy(old)
+    new.move(
+        "scanners.zap.authentication.parameters.rtoken_var_name",
+        "scanners.zap.authentication.parameters.rtoken_from_var",
+    )
+    new.move(
+        "general.authentication.parameters.rtoken_var_name",
+        "general.authentication.parameters.rtoken_from_var",
+    )
+
+    # Finally, set the correct version number
+    new.set("config.configVersion", 4)
+
+    return new
+
+
 @convert_configmodel.register(2)
 def convert_from_version_2_to_3(old):
-    """Returns a *copy* of the original rapidast config file, but updated to v2
+    """Returns a *copy* of the original rapidast config file, but updated to v3
     Change: `scanners.zap.updateAddons` moved to `scanners.zap.miscOptions.updateAddons`
     """
     new = copy.deepcopy(old)

--- a/configmodel/converter.py
+++ b/configmodel/converter.py
@@ -56,13 +56,7 @@ def convert_from_version_2_to_3(old):
     Change: `scanners.zap.updateAddons` moved to `scanners.zap.miscOptions.updateAddons`
     """
     new = copy.deepcopy(old)
-
-    if old.exists("scanners.zap.updateAddons"):
-        new.set(
-            "scanners.zap.miscOptions.updateAddons",
-            old.get("scanners.zap.updateAddons"),
-        )
-        new.delete("scanners.zap.updateAddons")
+    new.move("scanners.zap.updateAddons", "scanners.zap.miscOptions.updateAddons")
 
     # Finally, set the correct version number
     new.set("config.configVersion", 3)
@@ -80,19 +74,13 @@ def convert_from_version_1_to_2(old):
     # We need to move all scanners.*.container.image
     # In practice, currently, there's only `zap` to worry about
     for key in old.conf["scanners"]:
-        if old.exists(f"scanners.{key}.container.image"):
-            new.set(
-                f"scanners.{key}.container.parameters.image",
-                old.get(f"scanners.{key}.container.image"),
-            )
-            new.delete(f"scanners.{key}.container.image")
+        new.move(
+            f"scanners.{key}.container.image",
+            f"scanners.{key}.container.parameters.image",
+        )
 
     # This should not happen: image is not meant to be stored there, but just to be clean
-    if old.exists("general.container.image"):
-        new.set(
-            "general.container.parameters.image", old.get("general.container.image")
-        )
-        new.delete("general.container.image")
+    new.move("general.container.image", "general.container.parameters.image")
 
     # Finally, set the correct version number
     new.set("config.configVersion", 2)

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -576,7 +576,7 @@ class Zap(RapidastScanner):
         params_path = "scanners.zap.authentication.parameters"
         client_id = self.config.get(f"{params_path}.client_id", "cloud-services")
         token_endpoint = self.config.get(f"{params_path}.token_endpoint", None)
-        rtoken = self.config.get(f"{params_path}.rtoken_var_name", "RTOKEN")
+        rtoken = self.config.get(f"{params_path}.rtoken", None)
         scripts_dir = self.path_map.scripts.container_path
 
         # 1- complete the context: script, verification and user
@@ -600,12 +600,12 @@ class Zap(RapidastScanner):
         context_["users"] = [
             {
                 "name": Zap.USER,
-                "credentials": {"refresh_token": f"${{{rtoken}}}"},
+                "credentials": {"refresh_token": f"${{RTOKEN}}"},
             }
         ]
         # 2- add the name of the variable containing the token
         # The value will be taken from the environment at the time of starting
-        self._add_env(rtoken)
+        self._add_env("RTOKEN", rtoken)
 
         # 2- complete the HTTPSender script job
         script = {
@@ -637,7 +637,7 @@ class Zap(RapidastScanner):
             if authenticated_download_with_rtoken(
                 url=oas_url,
                 dest=f"{self._host_work_dir()}/openapi.json",
-                rtoken=os.environ[rtoken],
+                rtoken=rtoken,
                 client_id=client_id,
                 auth_url=token_endpoint,
                 proxy=self.config.get("scanners.zap.proxy", default=None),

--- a/tests/configmodel/older-schemas/v3.yaml
+++ b/tests/configmodel/older-schemas/v3.yaml
@@ -7,7 +7,7 @@ config:
   # This value tells RapiDAST what schema should be used to read this configuration.
   # Therefore you should only change it if you update the configuration to a newer schema
   # It is intended to keep backward compatibility (newer RapiDAST running an older config)
-  configVersion: 4
+  configVersion: 3
 
   # all the results of all scanners will be stored under that location
   base_results_dir: "./results"
@@ -36,7 +36,7 @@ general:
     parameters:
       client_id: "cloud-services"
       token_endpoint: "<token retrieval URL>"
-      rtoken_from_var: "RTOKEN"     # referring to a env defined in general.environ.envFile
+      rtoken_var_name: "RTOKEN"     # referring to a env defined in general.environ.envFile
     # Other types of authentication:
     #type: "http_header"
     #parameters:

--- a/tests/configmodel/test_configmodel.py
+++ b/tests/configmodel/test_configmodel.py
@@ -1,3 +1,5 @@
+import os
+
 import yaml
 
 import pytest
@@ -59,6 +61,11 @@ def test_configmodel_get(some_nested_config):
     # unexisting values
     assert myconf.get("thisdoesnotexists", "x") == "x"
     assert myconf.get("nested.thisdoesnotexists", "x") == "x"
+
+    # Value from config "_from_var"
+    os.environ["MY_SECRET"] = "myEnvVal"
+    myconf.set("nested.keyenv.def_from_var", "MY_SECRET")
+    assert myconf.get("nested.keyenv.def", "x") == os.environ["MY_SECRET"]
 
 
 def test_configmodel_set(some_nested_config):


### PR DESCRIPTION
    Transparently get config values from environment:
    
    1) if config entry `path` entry exists, return its value
    2) if config entry f"{path}_from_var" exist,
       AND that the value corresponds to an existing environment variable
       THEN return the value of that environment variable
    3) return default
    
    Useful for:
    - not putting secrets inside the configuration
    - allow to dynamically modify values without having to change the
      configuration
      - useful for dynamic values (e.g.: cookie)
      - useful for testing without modifying the config

Example : `general.authentication.parameters.rtoken_from_var=RTOKEN` ⇒ RapiDAST will use the value of `$RTOKEN` environment variable. 

Also added pytests and README information.

Quick note: 
* the `..._from_var` suffix is not following the standard CamelCase of the configuration. That is on purpose, just so that it stands out and looks different from the "regular" configuration entries.
* The original entry to retrieve the rtoken was `general.authentication.parameters.rtoken_var_name`, but the `_var_name` looked a little weird, so I renamed it. The downside is that I had to increase the config schema number (and added a conversion, so it should be transparent).

Let me know if that's good and if we can use it, or if we need to rename the `_from_var` into another suffix, etc.

I originally wanted to add the ability to create variable named as `RAPIDAST_PATH_TO_ENTRY`, but it does not work properly with merging configs as currently written.

The only caveat is when we look into the configuration manually (such as https://github.com/RedHatProductSecurity/rapidast/blob/development/scanners/zap/zap.py#L228): in those cases, the `_var_name` will not automatically be looked for. We will have rewrite those to make sure to always use `self.config.get()` instead of getting the sub-dictionary shortcut.