### PR TITLE
fix pylint errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -237,4 +237,7 @@ tags
 # Persistent undo
 [._]*.un~
 
+#pycharm
+.idea/
+
 # End of https://www.toptal.com/developers/gitignore/api/vim,linux,python,macos

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,6 @@ repos:
         args:
           - --max-line-length=120
           - --min-public-methods=0
-          - --good-names=q,f,fp,i,e,af
+          - --good-names=q,f,fp,i,e
           - --disable=E0401,W1201,W1203,W0603,C0114,C0115,C0116,C0411,W0107,W0702,R0801,R1705,R1710
         language_version: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,11 @@ repos:
   # W1203, W1201 - Use %s formatting in logging functions (Read more: https://github.com/PyCQA/pylint/issues/2354)
   # W0603 - Using the global statement
   # C0114,C0115,C0116 - docstring checks. Disabled because of pydocstyle checks
+  # W0107 - unnecessary pass
+  # W0702: No exception type(s) specified (bare-except)
+  # R0801: Similar lines in 2 files. Disabled because it flags any file even those which are unrelated
+  # R1705: Unnecessary "elif" after "return", remove the leading "el" from "elif" (no-else-return)
+  # R1710: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
   - repo: https://github.com/PyCQA/pylint
     rev: v2.13.5
     hooks:
@@ -42,6 +47,6 @@ repos:
         args:
           - --max-line-length=120
           - --min-public-methods=0
-          - --good-names=q,f,fp,i,e
-          - --disable=E0401,W1201,W1203,W0603,C0114,C0115,C0116,C0411
+          - --good-names=q,f,fp,i,e,af
+          - --disable=E0401,W1201,W1203,W0603,C0114,C0115,C0116,C0411,W0107,W0702,R0801,R1705,R1710
         language_version: python3

--- a/scanners/downloaders.py
+++ b/scanners/downloaders.py
@@ -5,14 +5,7 @@ import requests
 import yaml
 
 
-def authenticated_download_with_rtoken(
-    url,
-    dest,
-    rtoken,
-    client_id,
-    auth_url,
-    proxy=None,
-):
+def authenticated_download_with_rtoken(url, dest, auth, proxy=None):
     """Given a URL and Oauth2 authentication parameters, download the URL and store it at `dest`"""
 
     session = requests.Session()
@@ -23,9 +16,9 @@ def authenticated_download_with_rtoken(
         "Content-Type": "application/x-www-form-urlencoded",
     }
     payload = {
-        "client_id": client_id,
+        "client_id": auth.client_id,
         "grant_type": "refresh_token",
-        "refresh_token": rtoken,
+        "refresh_token": auth.rtoken,
     }
     if proxy:
         proxy = {
@@ -33,7 +26,7 @@ def authenticated_download_with_rtoken(
             "http": f"http://{proxy['proxyHost']}:{proxy['proxyPort']}",
         }
 
-    resp = session.post(auth_url, data=payload, headers=headers, proxies=proxy)
+    resp = session.post(auth.url, data=payload, headers=headers, proxies=proxy)
 
     if resp.status_code != 200:
         logging.warning(
@@ -57,7 +50,7 @@ def authenticated_download_with_rtoken(
         )
         return False
 
-    with open(dest, "w") as file:
+    with open(dest, "w", encoding="utf-8") as file:
         file.write(resp.text)
 
     logging.debug(f"Successful download of {url} into {dest}")

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -46,7 +46,7 @@ class Zap(RapidastScanner):
         # This is used to construct the ZAP Automation config.
         # It will be saved to a file during setup phase
         # and used by the ZAP command during run phase
-        self.af = {}
+        self.automation_config = {}
 
         # When state is READY, this will contain the entire ZAP command that the container layer should run
         self.zap_cli = []
@@ -170,7 +170,7 @@ class Zap(RapidastScanner):
             af_template = f"{MODULE_DIR}/{Zap.AF_TEMPLATE}"
             logging.debug("Load the Automation Framework template")
             with open(af_template, "r", encoding="utf-8") as stream:
-                self.af = yaml.safe_load(stream)
+                self.automation_config = yaml.safe_load(stream)
         except yaml.YAMLError as exc:
             raise RuntimeError(
                 f"Something went wrong while parsing the config '{af_template}':\n {str(exc)}"
@@ -178,7 +178,7 @@ class Zap(RapidastScanner):
 
         # Configure the basic environment target
         try:
-            af_context = find_context(self.af)
+            af_context = find_context(self.automation_config)
             af_context["urls"].append(self.config.get("application.url"))
             af_context["includePaths"].extend(
                 self.config.get("scanners.zap.urls.includes", default=[])
@@ -221,7 +221,7 @@ class Zap(RapidastScanner):
         dest = f"{self._container_work_dir()}/importUrls.txt"
         self._include_file(orig, dest)
         job["parameters"]["fileName"] = dest
-        self.af["jobs"].append(job)
+        self.automation_config["jobs"].append(job)
 
     def _setup_api(self):
         """Prepare an openapi job and append it to the job list"""
@@ -247,7 +247,7 @@ class Zap(RapidastScanner):
         ) or self.config.get("application.url")
         openapi["parameters"]["context"] = Zap.DEFAULT_CONTEXT
 
-        self.af["jobs"].append(openapi)
+        self.automation_config["jobs"].append(openapi)
 
     def _setup_spider(self):
         """Prepare an spider job and append it to the job list"""
@@ -270,10 +270,10 @@ class Zap(RapidastScanner):
         # Add to includePaths to the context
         if self.config.get("scanners.zap.spider.url"):
             new_include_path = self.config.get("scanners.zap.spider.url") + ".*"
-            af_context = find_context(self.af)
+            af_context = find_context(self.automation_config)
             af_context["includePaths"].append(new_include_path)
 
-        self.af["jobs"].append(af_spider)
+        self.automation_config["jobs"].append(af_spider)
 
     def _setup_ajax_spider(self):
         """Prepare an spiderAjax job and append it to the job list"""
@@ -299,10 +299,10 @@ class Zap(RapidastScanner):
         # Add to includePaths to the context
         if self.config.get("scanners.zap.spiderAjax.url"):
             new_include_path = self.config.get("scanners.zap.spiderAjax.url") + ".*"
-            af_context = find_context(self.af)
+            af_context = find_context(self.automation_config)
             af_context["includePaths"].append(new_include_path)
 
-        self.af["jobs"].append(af_spider_ajax)
+        self.automation_config["jobs"].append(af_spider_ajax)
 
     def _setup_graphql(self):
         """Prepare a graphql job and append it to the job list"""
@@ -324,7 +324,7 @@ class Zap(RapidastScanner):
             self._include_file(host_path=host_file, dest_in_container=cont_file)
             af_graphql["parameters"]["schemaFile"] = cont_file
 
-        self.af["jobs"].append(af_graphql)
+        self.automation_config["jobs"].append(af_graphql)
 
     def _setup_passive_scan(self):
         """Adds the passive scan to the job list. Needs to be done prior to Active scan"""
@@ -353,7 +353,7 @@ class Zap(RapidastScanner):
         for rulenum in disabled:
             passive["rules"].append({"id": int(rulenum), "threshold": "off"})
 
-        self.af["jobs"].append(passive)
+        self.automation_config["jobs"].append(passive)
 
     def _setup_passive_wait(self):
         """Adds a wait to the list of jobs, to make sure that the Passive Scan is finished"""
@@ -367,7 +367,7 @@ class Zap(RapidastScanner):
             "name": "passiveScan-wait",
             "parameters": {},
         }
-        self.af["jobs"].append(waitfor)
+        self.automation_config["jobs"].append(waitfor)
 
     def _setup_active_scan(self):
         """Adds the active scan job list."""
@@ -387,7 +387,7 @@ class Zap(RapidastScanner):
             },
         }
 
-        self.af["jobs"].append(active)
+        self.automation_config["jobs"].append(active)
 
     def _construct_report_af(self, report_format):
         report_af = {
@@ -426,7 +426,9 @@ class Zap(RapidastScanner):
                 logging.debug(
                     f"report {format_id}, filename: {reports[format_id].name}"
                 )
-                self.af["jobs"].append(self._construct_report_af(reports[format_id]))
+                self.automation_config["jobs"].append(
+                    self._construct_report_af(reports[format_id])
+                )
                 appended += 1
             except KeyError as exc:
                 logging.warning(
@@ -434,7 +436,9 @@ class Zap(RapidastScanner):
                 )
         if not appended:
             logging.warning("Creating a default report as no valid were found")
-            self.af["jobs"].append(self._construct_report_af(reports["json"]))
+            self.automation_config["jobs"].append(
+                self._construct_report_af(reports["json"])
+            )
 
     def _setup_zap_cli(self):
         """prepare the zap command: self.zap_cli
@@ -480,7 +484,7 @@ class Zap(RapidastScanner):
         """Save the Automation dictionary as YAML in the container"""
         af_host_path = self.path_map.workdir.host_path + "/af.yaml"
         with open(af_host_path, "w", encoding="utf-8") as f:
-            f.write(yaml.dump(self.af))
+            f.write(yaml.dump(self.automation_config))
         logging.info(f"Saved Automation Framework in {af_host_path}")
 
     # Building an authentication factory for ZAP
@@ -574,7 +578,7 @@ class Zap(RapidastScanner):
         Returns True as it creates a ZAP user
         """
 
-        context_ = find_context(self.af)
+        context_ = find_context(self.automation_config)
         params_path = "scanners.zap.authentication.parameters"
         client_id = self.config.get(f"{params_path}.client_id", "cloud-services")
         token_endpoint = self.config.get(f"{params_path}.token_endpoint", None)
@@ -602,7 +606,7 @@ class Zap(RapidastScanner):
         context_["users"] = [
             {
                 "name": Zap.USER,
-                "credentials": {"refresh_token": rtoken},
+                "credentials": {"refresh_token": "${RTOKEN}"},
             }
         ]
         # 2- add the name of the variable containing the token
@@ -622,7 +626,7 @@ class Zap(RapidastScanner):
                 "target": "",
             },
         }
-        self.af["jobs"].append(script)
+        self.automation_config["jobs"].append(script)
         logging.info("ZAP configured with OAuth2 RTOKEN")
 
         # quickhack: the openapi job currently does not run with user authentication.
@@ -664,7 +668,7 @@ class Zap(RapidastScanner):
 
 
 # Given an Automation Framework configuration, return its sub-dictionary corresponding to the context we're going to use
-def find_context(af, context=Zap.DEFAULT_CONTEXT):
+def find_context(automation_config, context=Zap.DEFAULT_CONTEXT):
     # quick function that makes sure the context is sane
     def ensure_default(context2):
         # quick function that makes sure an entry is a list (override if necessary)
@@ -678,7 +682,7 @@ def find_context(af, context=Zap.DEFAULT_CONTEXT):
         return context2
 
     try:
-        for context3 in af["env"]["contexts"]:
+        for context3 in automation_config["env"]["contexts"]:
             if context3["name"] == context:
                 return ensure_default(context3)
     except:
@@ -688,9 +692,9 @@ def find_context(af, context=Zap.DEFAULT_CONTEXT):
         "It may be missing from default. An empty context is created",
     )
     # something failed: create an empty one and return it
-    if not af["env"]:
-        af["env"] = {}
-    if not af["env"].get("contexts"):
-        af["env"]["contexts"] = []
-    af["env"]["contexts"].append({"name": context})
-    return ensure_default(af["env"]["contexts"][-1])
+    if not automation_config["env"]:
+        automation_config["env"] = {}
+    if not automation_config["env"].get("contexts"):
+        automation_config["env"]["contexts"] = []
+    automation_config["env"]["contexts"].append({"name": context})
+    return ensure_default(automation_config["env"]["contexts"][-1])

--- a/scanners/zap/zap_podman.py
+++ b/scanners/zap/zap_podman.py
@@ -9,6 +9,7 @@ from .zap import MODULE_DIR
 from .zap import Zap
 from scanners import State
 from scanners.path_translators import make_mapping_for_scanner
+from utils import safe_add
 
 CLASSNAME = "ZapPodman"
 
@@ -50,10 +51,9 @@ class ZapPodman(Zap):
         self.podman_opts = []
 
         # Container name in the form 'rapidast_zap_<app-shortName>_<random-chars>
-        self.container_name = "rapidast_zap_{}_{}".format(
-            self.config.get("application.shortName"),
-            "".join(random.choices(string.ascii_letters, k=6)),
-        )
+        application_shortname = self.config.get("application.shortName")
+        random_chars = "".join(random.choices(string.ascii_letters, k=6))
+        self.container_name = f"rapidast_zap_{application_shortname}_{random_chars}"
 
         # prepare the host <-> container mapping
         # The default location for WORK can be chosen by parent itself (no overide of self._create_work_dir)
@@ -237,7 +237,7 @@ class ZapPodman(Zap):
             .strip("\n")
         )
         logging.debug(f"UIDmapping sizes: {sizes}")
-        subuid_size = eval(f"{sizes} - 1")
+        subuid_size = safe_add(f"{sizes} - 1")
         sizes = (
             subprocess.run(
                 [
@@ -253,7 +253,7 @@ class ZapPodman(Zap):
             .strip("\n")
         )
         logging.debug(f"UIDmapping sizes: {sizes}")
-        subgid_size = eval(f"{sizes} - 1")
+        subgid_size = safe_add(f"{sizes} - 1")
 
         runas_uid = 1000
         runas_gid = 1000

--- a/tests/configmodel/test_configmodel.py
+++ b/tests/configmodel/test_configmodel.py
@@ -1,8 +1,8 @@
 import os
 
+import pytest
 import yaml
 
-import pytest
 from configmodel import RapidastConfigModel
 
 

--- a/tests/configmodel/test_convert.py
+++ b/tests/configmodel/test_convert.py
@@ -1,7 +1,7 @@
+import pytest
 import yaml
 
 import configmodel.converter
-import pytest
 
 
 @pytest.fixture(name="config_v0")

--- a/tests/scanners/zap/test_setup_podman.py
+++ b/tests/scanners/zap/test_setup_podman.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 
-import configmodel.converter
 import pytest
+
+import configmodel.converter
 from scanners.zap.zap import find_context
 from scanners.zap.zap_podman import ZapPodman
 

--- a/tests/utils/test_safe_add.py
+++ b/tests/utils/test_safe_add.py
@@ -1,0 +1,34 @@
+import pytest
+
+from utils import safe_add
+
+
+def test_no_operator():
+    assert safe_add("1") == 1
+
+
+def test_value_error():
+    with pytest.raises(TypeError):
+        safe_add("abc")
+
+
+def test_addition():
+    assert safe_add("2 + 3") == 5
+
+
+def test_subtraction():
+    assert safe_add("2 - 3") == -1
+
+
+def test_negative():
+    assert safe_add("-3") == -3
+
+
+def test_positive():
+    assert safe_add("+3") == 3
+
+
+def test_mix():
+    assert safe_add("+3+2-1") == 4
+    assert safe_add("-3-2") == -5
+    assert safe_add("3 + 2   - 1 - 4") == 0

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+from .safe_add import safe_add

--- a/utils/safe_add.py
+++ b/utils/safe_add.py
@@ -1,0 +1,23 @@
+import ast
+import operator as op
+
+
+def safe_add(expr):
+    return _eval(ast.parse(expr, mode="eval").body)
+
+
+def _eval(node):
+    if isinstance(node, ast.Num):  # <number>
+        return node.n
+    elif isinstance(node, ast.BinOp):  # <left> +/- <right>
+        if isinstance(node.op, ast.Add):
+            return op.add(_eval(node.left), _eval(node.right))
+        elif isinstance(node.op, ast.Sub):
+            return op.sub(_eval(node.left), _eval(node.right))
+    elif isinstance(node, ast.UnaryOp):  # <operator> <operand> e.g., -/+ 1
+        if isinstance(node.op, ast.UAdd):
+            return op.pos(_eval(node.operand))
+        elif isinstance(node.op, ast.USub):
+            return op.neg(_eval(node.operand))
+    else:
+        raise TypeError(node)


### PR DESCRIPTION
This PR aims to resolve all the pylint errors.

I choose to disable the following rules:
- W0107 - unnecessary pass
We might need this for parent classes which haven't implemented the method but also dont want to throw an error

- W0702: No exception type(s) specified (bare-except)
Useful when we need to catch all the exceptions

- R0801: Similar lines in 2 files. 
Disabled because it flags any file even those which are unrelated such as rapidast.py and updater_config.py

- R1705: Unnecessary "elif" after "return", remove the leading "el" from "elif" (no-else-return):
I think this is a personal style preference. I personally like the `elif` as it makes it immediately clear to me (without reading the `if` block code) that we will only take this branch if the `if` block fails

- R1710: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
Disabled because this is not feasible when creating recursive functions or even functions which might possibly return None

To fix the `eval` error, I implemented a `safe_add` function which safely evaluates all strings that are a simple addition or subtraction expression. I could have added another package such as [simpleeval](https://github.com/danthedeckie/simpleeval) but since our use case was very basic it didn't make sense to add another dependency