### PR TITLE
[experimental] support Defect Dojo

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ In order to do that:
 * create a user without any global role
 * add that user as a "writer" for the product(s) it is supposed to scan
 
-Then the product, as well as an engagement for that product, must be created on RapiDAST. It would not be advised to give the RapiDAST user an "admin" role and simply set `auto_create_context` to True, as it would be both insecure and accident prone (a typo in the product name would let RapiDAST create a new product)
+Then the product, as well as an engagement for that product, must be created in Defect Dojo. It would not be advised to give the RapiDAST user an "admin" role and simply set `auto_create_context` to True, as it would be both insecure and accident prone (a typo in the product name would let RapiDAST create a new product)
 
 #### Defect Dojo configuration in RapiDAST
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,58 @@ To avoid this, RapiDAST proposes 2 ways to provide a value for a given configura
 - Create an entry in the configuration file (this is the usual method)
 - Create an entry in the configuration file pointing to the environment variable that actually contains the data, by appending `_from_var` to the entry name: `general.authentication.parameters.rtoken_from_var=RTOKEN` (in this example, the token value is provided by the `$RTOKEN` environment variable)
 
+### Defect Dojo integration
+
+#### Preamble: creating Defect Dojo user
+
+RapiDAST needs to be able to authenticate to Defect Dojo. However, ideally, it should have the minimum set of permissions, such that it will not be allow to modify products other than the one(s) it is supposed to.
+In order to do that:
+* create a user without any global role
+* add that user as a "writer" for the product(s) it is supposed to scan
+
+Then the product, as well as an engagement for that product, must be created on RapiDAST. It would not be advised to give the RapiDAST user an "admin" role and simply set `auto_create_context` to True, as it would be both insecure and accident prone (a typo in the product name would let RapiDAST create a new product)
+
+#### Defect Dojo configuration in RapiDAST
+
+First, RapiDAST needs to be able to authenticate itself to a Defect Dojo service. This is a typical configuration:
+
+```yaml
+config:
+  # Defect dojo configuration
+  defectDojo:
+    url: "https://mydefectdojo.example.com/"
+    authorization:
+      username: "rapidast_productname"
+      password: "password"
+      # alternatively, a `token` entry can be set in place of username/password
+```
+
+You can either authenticate using a username/password combination, or a token (make sure it is not expired). In either case, you can use the `_from_var` method described in previous chapter to avoid hardcoding the value in the configuration.
+
+Then, RapiDAST needs to know, for each scanner, sufficient information such that it can identify which product/engagement/test to match.
+This is configured in the `zap.scanner.defectDojoExport.parameters` entry. See the `import-scan` or  `reimport-scan` parameters at https://demo.defectdojo.org/api/v2/doc/ for a list of accepted entries.
+Notes:
+    * `engagement` and `test` refer to identifiers, and should be integers (as opposed to `engagement_name` and `test_title`
+    * If a `test` identifier is provided, RapiDAST will reimport the result to that test. The existing test must be compatible (same file schema, such as ZAP Scan, for example)
+    * If the `product_name` does not exist, the scanner should default to `application.productName`, or `application.shortName`
+    * Tip: the entries common to all scanners can be added to `general.defectDojoExport.parameters`, while the scanner-dependant entries (e.g.: test identifier) can be set in the scanner's configuration (e.g.: `scanners.zap.defectDojoExport.parameters`)
+
+```yaml
+general:
+  defectDojoExport:
+    parameters:
+      productName: "My product"
+      tags: ["RapiDAST"]
+
+scanners:
+  zap:
+    defectDojoExport:
+      parameters:
+        test: 34
+        endpoint_to_add: "https://qa.myapp.local/"
+```
+
+
 ## Execution
 
 Once you have created a configuration file, you can run a scan with it.

--- a/config/config-template-long.yaml
+++ b/config/config-template-long.yaml
@@ -144,7 +144,7 @@ scanners:
       oauth2OpenapiManualDownload: False
 
     defectDojoExport:
-      type: "reimport" # choose betwee: import, reimport, False (disable export). Default (or other content): re-import if test is set
+      type: "reimport" # choose between: import, reimport, False (disable export). Default (or other content): re-import if test is set
       # Parameters contain data that will directly be sent as parameters to DefectDojo's import/reimport endpoints.
       # For example: commit tag, version, push_to_jira, etc.
       # See https://demo.defectdojo.org/api/v2/doc/ for a list of possibilities
@@ -155,13 +155,13 @@ scanners:
       parameters:
         product_name: "My Product"
         engagement_name: "RapiDAST"
-          # - or -
-        engagement: 3   # engagement ID
-          # - or -
-        test_title: "ZAP"
-          # - or -
-        test: 5       # test ID, that will force "reimport" mode
-          # additional options, see https://demo.defectdojo.org/api/v2/doc/ for list
+        # - or -
+        #engagement: 3   # engagement ID
+        # - or -
+        #test_title: "ZAP"
+        # - or -
+        #test: 5       # test ID, that will force "reimport" mode
+        # additional options, see https://demo.defectdojo.org/api/v2/doc/ for list
         auto_create_context: False  # Optional. set to True to auto-create engagement (requires product_name and engagement_name)
 
 

--- a/config/config-template-long.yaml
+++ b/config/config-template-long.yaml
@@ -16,6 +16,15 @@ config:
   environ:
     envFile: "path/to/env/file"
 
+  # Defect Dojo configuration
+  defectDojo:
+    url: "https://mydefectdojo.example.com/"
+    authorization:
+      username: "rapidast"
+      password: "password"
+        # or
+      token: "abc"
+
 # `application` contains data related to the application, not to the scans.
 application:
   shortName: "MyApp-1.0"
@@ -24,6 +33,7 @@ application:
 # `general` is a section that will be applied to all scanners.
 # Any scanner can override a value by creating an entry of the same name in their own configuration
 general:
+
 
   # remove `proxy` entirely for direct connection
   proxy:
@@ -132,6 +142,27 @@ scanners:
       updateAddons: True
       # If set to True and authentication is oauth2_rtoken and api.apiUrl is set, download the API outside of ZAP
       oauth2OpenapiManualDownload: False
+
+    defectDojoExport:
+      type: "reimport" # choose betwee: import, reimport, False (disable export). Default (or other content): re-import if test is set
+      # Parameters contain data that will directly be sent as parameters to DefectDojo's import/reimport endpoints.
+      # For example: commit tag, version, push_to_jira, etc.
+      # See https://demo.defectdojo.org/api/v2/doc/ for a list of possibilities
+      # The minimum set of data is whatever is needed to identify which engagement/test needs to be chosen.
+      # If neither a test ID (`test` parameter), nor product_name and engagement_name were provided, sane default will be attempted:
+      #   - product_name chosen from either application.productName or application.shortName
+      #   - engagement_name:  "RapiDAST" [this way the same engagement will always be chosen, regardless of the scanner]
+      parameters:
+        product_name: "My Product"
+        engagement_name: "RapiDAST"
+          # - or -
+        engagement: 3   # engagement ID
+          # - or -
+        test_title: "ZAP"
+          # - or -
+        test: 5       # test ID, that will force "reimport" mode
+          # additional options, see https://demo.defectdojo.org/api/v2/doc/ for list
+        auto_create_context: False  # Optional. set to True to auto-create engagement (requires product_name and engagement_name)
 
 
 # Other scanners to be defined(TBD)

--- a/config/config-template.yaml
+++ b/config/config-template.yaml
@@ -7,7 +7,15 @@ config:
   # This value tells RapiDAST what schema should be used to read this configuration.
   # Therefore you should only change it if you update the configuration to a newer schema
   # It is intended to keep backward compatibility (newer RapiDAST running an older config)
-  configVersion: 3
+  configVersion: 4
+
+  # Defect Dojo configuration
+  defectDojo:
+    url: "https://mydefectdojo.example.com/"
+    authorization:
+      username: "rapidast"
+      password: "password"
+
 
 # `application` contains data related to the application, not to the scans.
 application:

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -108,7 +108,7 @@ __NOTES__
 
 ### Integrating the scanner to Defect Dojo
 
-The scanner can optionally be integrated to Defect Dojo. All it needs to do is to create an optional `data_for_defect_dojo()` method (no parameters).
+If a scanner is supported by Defect Dojo, the scanner can be configured to export its scan results to Defect Dojo automatically. All it needs to do is to create an optional `data_for_defect_dojo()` method (no parameters).
 This can be useful when the scanner exports a file that can be imported into a Defect Dojo test.
 This method must return a tuple of 2 values:
 * A dictionary containing a subset of values accepted by Defect Dojo's `import-scan` or `reimport-scan` endpoints (see https://demo.defectdojo.org/api/v2/doc/)

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -106,6 +106,22 @@ __NOTES__
 + The path are immutable: they must be chosen during creation (in the `__init__()` function), and must not be modified afterwards. The parent scanner (e.g.: `Zap`) should define the mount points, and each runtime (e.g.: `ZapPodman`) should fill each map *once*
 + For `type = None` (the scanner will run on the host), then the map must be the same (e.g.: `PathMap("/path/to/dir", "/path/to/dir")`)
 
+### Integrating the scanner to Defect Dojo
+
+The scanner can optionally be integrated to Defect Dojo. All it needs to do is to create an optional `data_for_defect_dojo()` method (no parameters).
+This can be useful when the scanner exports a file that can be imported into a Defect Dojo test.
+This method must return a tuple of 2 values:
+* A dictionary containing a subset of values accepted by Defect Dojo's `import-scan` or `reimport-scan` endpoints (see https://demo.defectdojo.org/api/v2/doc/)
+* A string corresponding to path of the file containing the scan result, in a format parsable by Defect Dojo.
+
+The dictionary must not:
+* contain the `file` entry, as it is done via the tuple's 2nd value
+
+The dictionary must:
+* Contain enough information to let Defect Dojo import the file (e.g.: provide a test identifier for re-import, or at least a `product_name` + `engagement_name` so that Defect Dojo can create a test on its own)
+* Provide the scan `scan_type` corresponding to the result file (e.g.: `ZAP Scan` for ZAP), as well as all other mandatory field (`verified` and `active`)
+
+Note: simply return the `(None, None)` tuple to abort the operation.
 
 ## The configuration model
 

--- a/exports/defect_dojo.py
+++ b/exports/defect_dojo.py
@@ -1,0 +1,138 @@
+import json
+import logging
+from urllib import parse
+from urllib import request
+
+import requests
+
+
+class DefectDojo:
+    """This class instanciates a connection to DefectDojo, and pushes reports"""
+
+    def __init__(self, base_url, username=None, password=None, token=None):
+        if not base_url:
+            raise ValueError(
+                "Defect Dojo invalid configuration: URL is a mandatory value"
+            )
+        parsed = parse.urlparse(base_url)  # expects to raise exception on invalid URL
+        if parsed.scheme not in ["http", "https"]:
+            raise ValueError("Defect Dojo invalid configuration: URL is not correct")
+
+        self.base_url = base_url
+        self.username = username
+        self.password = password
+        self.token = token
+        self.headers = {}
+        if token:
+            self.headers["Authorization"] = f"Token {token}"
+
+    def get_token(self):
+        """Force a refresh of the token using the username/password"""
+        logging.debug("Defect Dojo: refreshing token")
+        if not self.username or not self.password:
+            raise ValueError(
+                "Defect Dojo invalid configuration: A username and a password are required to get a token"
+            )
+        url = self.base_url + "/api/v2/api-token-auth/"
+        data = {"username": self.username, "password": self.password}
+        data = parse.urlencode(data).encode("ascii")
+
+        with request.urlopen(url, data=data) as resp:
+            if resp.getcode() >= 400:
+                logging.warning(
+                    f"Defect Dojo did not answer as expected during login (status: {resp.getcode()})"
+                )
+
+            self.token = json.load(resp)["token"]
+
+        self.headers["Authorization"] = f"Token {self.token}"
+        logging.debug("Defect Dojo: successfully refreshed token")
+
+    def engagement_exists(self, engagement_id=None, name=None):
+        """Return True if an engagement exists, False otherwise
+        Engagement is identified either by its name or its ID (positive integer)"""
+        if not self.token:
+            self.get_token()
+        if engagement_id:
+            resp = requests.get(
+                f"{self.base_url}/api/v2/engagements/?engagment={engagement_id}",
+                headers=self.headers,
+            )
+        elif name:
+            resp = requests.get(
+                f"{self.base_url}/api/v2/engagements/?name={parse.quote_plus(name)}",
+                headers=self.headers,
+            )
+        else:
+            raise ValueError("Either an engagement name or ID must be provided")
+
+        if resp.status_code >= 400:
+            logging.warning(
+                f"Error while looking for engagement ({resp.status_code}, {resp.get('message')})"
+            )
+        counts = resp.json()["counts"]
+        if counts > 1:
+            logging.warning("Error while looking for engagement: too many hits")
+        return counts >= 1
+
+    def _private_import(self, endpoint, data, filename):
+        """Send a POST request to endpoint [typically import or reimport], with data and filname"""
+        if not self.token:
+            self.get_token()
+
+        resp = requests.post(
+            endpoint,
+            headers=self.headers,
+            data=data,
+            files={"file": open(filename, "rb")},
+        )
+        if resp.status_code >= 400:
+            print(vars(resp))
+            err = resp.json()
+            logging.warning(f"Error while exporting ({resp.status_code}, {err})")
+
+    def reimport_scan(self, data, filename):
+        """Reimport to an existing engagement with an existing compatible scan."""
+
+        mandatory = {
+            "product_name",
+            "engagement_name",
+            "scan_type",
+            "active",
+            "verified",
+        }
+        missing = mandatory - set(data.keys())
+        if missing:
+            raise ValueError(f"Missing required entries for reimport: {missing}")
+
+        self._private_import(f"{self.base_url}/api/v2/reimport-scan/", data, filename)
+
+    def import_scan(self, data, filename):
+        """Import to an existing engagement."""
+
+        mandatory = {
+            "product_name",
+            "engagement_name",
+            "scan_type",
+            "active",
+            "verified",
+        }
+        missing = mandatory - set(data.keys())
+        if missing:
+            raise ValueError(f"Missing required entries for reimport: {missing}")
+        self._private_import(f"{self.base_url}/api/v2/import-scan/", data, filename)
+
+    def import_or_reimport_scan(self, data, filename):
+        """Decide wether to import or reimport. Based on:
+        - If the data contains a test ID ("test"): it's a reimport
+        - Otherwise import
+        """
+        if not data or not filename:
+            # missing data means nothing to do
+            logging.debug("Insufficient data for Defect Dojo")
+            return
+
+        if data.get("test"):
+            self.reimport_scan(data, filename)
+        else:
+            self.import_scan(data, filename)

--- a/rapidast.py
+++ b/rapidast.py
@@ -10,6 +10,7 @@ from dotenv import load_dotenv
 
 import configmodel.converter
 import scanners
+from exports.defect_dojo import DefectDojo
 
 pp = pprint.PrettyPrinter(indent=4)
 
@@ -96,6 +97,15 @@ if __name__ == "__main__":
     # Do early: load the environment file if one is there
     load_environment()
 
+    # Prepare Defect Dojo if configured
+    if config.get("config.defectDojo.url"):
+        defect_d = DefectDojo(
+            config.get("config.defectDojo.url"),
+            config.get("config.defectDojo.authorization.username"),
+            config.get("config.defectDojo.authorization.password"),
+            config.get("config.defectDojo.authorization.token"),
+        )
+
     # Run all scanners
     for name in config.get("scanners"):
         logging.info(f"Next scanner: '{name}'")
@@ -138,3 +148,7 @@ if __name__ == "__main__":
         # Part 5: cleanup
         if not args.no_cleanup:
             scanner.cleanup()
+
+        # Part 6: export to defect dojo, if the scanner is compatible
+        if defect_d and hasattr(scanner, "data_for_defect_dojo"):
+            defect_d.import_or_reimport_scan(*scanner.data_for_defect_dojo())

--- a/tests/test_result_dirname.py
+++ b/tests/test_result_dirname.py
@@ -1,8 +1,7 @@
 import re
 
-import pytest  # pylint: disable=unused-import
-
 import configmodel
+import pytest  # pylint: disable=unused-import
 import rapidast
 
 # from pytest_mock import mocker


### PR DESCRIPTION
This is a first commit that shows a Proof of Concept for Defect Dojo integration.

The idea is that RapiDAST adds an optional 6th step for each scanner.

This 6th step is, if the scanner has the capability, to provide the scan information for Defect Dojo.
Rapidast, then push this to Defect Dojo using URL & authentication provided via the configuration file.

Additional notes:
* In ZAP, when DD is enabled, we enforce the XML report (in addition to whichever report(s) may have been set). In the code, the report list was changed to a set, so that we do not have to bother about duplicate reports

* templates & READMEs have been updated with docs for both user and devs

* currently, there is a lack of test functions. That will arrive in the next iteration.

Path forward and improvement:
Ideally, the parent `RapidastScanner` should be able to make more heavy lifting, so that the scanners themselves don't need to duplicate too much code.
In other word: `data_for_defect_dojo()` should move to parent, and the scanner themselves should be able to only provide a filename and default values.
That can be worked out when we are okay with the process.