### PR TITLE
[ZAP] add experimental support for podman on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,39 @@ Taking advantage of [OWASP ZAP](https://www.zaproxy.org/) and additional scanner
 
 Linux and MacOS are supported.
 
+#### Note regarding MacOS and ZAP
+
+RapiDAST supports executing ZAP on the host directly, or, experimentally, in podman. See [Choosing the execution environment](#choosing-the-execution-environment) for further information on configuring execution environments.
+
+* When using ZAP directly on the host (`general.container.type: "none"` or `scanners.zap.container.type: "none" in the configuration): you will need to configure `scanners.zap.container.parameters.executable` to the installation path of the `zap.sh` command, because it is not available in the PATH. Usually, its path is `/Applications/OWASP ZAP.app/Contents/Java/zap.sh`
+
+Example:
+
+```yaml
+scanners:
+  zap:
+    container:
+      type: none
+      parameters:
+        executable: "/Applications/OWASP ZAP.app/Contents/Java/zap.sh"
+```
+
+* When using "podman" as execution environemtn (`general.container.type: "podman"` or `scanners.zap.container.type: "podman" in the configuration): This mode is currently experimental. You will need to start the podman virtual machine sharing both the `rapidast` directory as well as the current temporary directory.
+
+Example:
+
+```sh
+podman machine init -v "$PWD:$PWD" -v "$TMPDIR:$TMPDIR" rapidast
+podman machine start rapidast
+./rapidast --config ./config/<config-file>
+
+ # after successful run, when the VM is no longer needed:
+podman machine stop rapidast
+podman machine rm rapidast
+```
+
+
+
 ## Installation
 
 It is recommended to create a virtual environment.

--- a/scanners/zap/zap_podman.py
+++ b/scanners/zap/zap_podman.py
@@ -1,4 +1,5 @@
 import logging
+import platform
 import pprint
 import random
 import shutil
@@ -208,10 +209,15 @@ class ZapPodman(Zap):
 
         # Volume mappings
         for mapping in self.path_map:
-            self.podman_opts += [
-                "--volume",
-                f"{mapping.host_path}:{mapping.container_path}:Z",
-            ]
+            vol_map = f"{mapping.host_path}:{mapping.container_path}"
+            if platform.system() == "Darwin":
+                logging.debug(
+                    "Darwin(MacOS) is detected. Disabling Podman SELinux eXtented attributes for volume mapping"
+                )
+            else:
+                vol_map += ":Z"
+
+            self.podman_opts += ["--volume", vol_map]
 
     def _setup_zap_podman_id_mapping_cli(self):
         """Adds a specific user mapping to the Zap podman container.


### PR DESCRIPTION
Adds documentation for running podman type on MacOS

Also prevent SELinux on volume mapping on MacOS specifically, to prevent the following error:

```
lsetxattr <work dir>: operation not supported
```