### PR TITLE
Pylint fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,5 +48,5 @@ repos:
           - --max-line-length=120
           - --min-public-methods=0
           - --good-names=q,f,fp,i,e
-          - --disable=E0401,W1201,W1203,W0603,C0114,C0115,C0116,C0411,W0107,W0702,R0801,R1705,R1710
+          - --disable=E0401,W1201,W1203,C0114,C0115,C0116,C0411,W0107,W0702,R0801,R1705,R1710
         language_version: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
   # R1705: Unnecessary "elif" after "return", remove the leading "el" from "elif" (no-else-return)
   # R1710: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
   - repo: https://github.com/PyCQA/pylint
-    rev: v2.13.5
+    rev: v2.17.4
     hooks:
       - id: pylint
         exclude: ^tests/

--- a/exports/defect_dojo.py
+++ b/exports/defect_dojo.py
@@ -94,7 +94,7 @@ class DefectDojo:
             endpoint,
             headers=self.headers,
             data=data,
-            files={"file": open(filename, "rb")},
+            files={"file": open(filename, "rb")},  # pylint: disable=consider-using-with
         )
         if resp.status_code >= 400:
             print(vars(resp))

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -9,7 +9,6 @@ from collections import namedtuple
 
 import yaml
 
-from configmodel import RapidastConfigModel
 from scanners import generic_authentication_factory
 from scanners import RapidastScanner
 from scanners.downloaders import authenticated_download_with_rtoken
@@ -159,7 +158,7 @@ class Zap(RapidastScanner):
         )
 
     # disabling these 2 rules only here since they might actually be useful else where
-    # pylint: disable=unused-argument,no-self-use
+    # pylint: disable=unused-argument
     def _add_env(self, key, value=None):
         logging.warning(
             "_add_env() was called on the parent ZAP class. This is likely a bug. No operation done"


### PR DESCRIPTION
3 pylint related commits :
1) [pre-commit] enabling errors for global statements
resolves https://issues.redhat.com/browse/PSSECDEV-924

pylint W0603 (global statement) is no longer required for some time now. Let's enable it in pylint.

2) updating pylint version from 2.13 to the current latest, in pre-commit
This prevents me from seeing buggy `E1101: Module 'os' has no 'path' member (no-member)` ... it seems to be a bug from older pylint version. Updating pylint in the pre-commit resolves this

3) fixing new pylint errors caused by the update above
Updating pylint to latest created new pylint issues. This is a fix for these errors