### PR TITLE
[rapidast] some error handling

### DIFF
--- a/rapidast.py
+++ b/rapidast.py
@@ -45,6 +45,70 @@ def get_full_result_dir_path(rapidast_config):
     return results_dir_path
 
 
+def run_scanner(name, config, args, defect_d):
+    """given the config `config`, runs scanner `name`.
+    Returns:
+        0 for success
+        1 for failure
+    (in order to count the number of failure)
+    """
+
+    # Merge the "general" configuration into the scanner's config
+    # (but without overwriting anything: scanner's config takes precedence over the general config)
+    logging.debug(f"Merging general config into {name}'s config")
+    config.merge(
+        config.get("general", default={}),
+        preserve=True,
+        root=f"scanners.{name}",
+    )
+
+    typ = config.get(f"scanners.{name}.container.type", default="podman")
+    try:
+        class_ = scanners.str_to_scanner(name, typ)
+    except ModuleNotFoundError:
+        logging.error(f"Scanner `{name}` of type `{typ}` does not exist")
+        logging.error(f"Ignoring failed Scanner `{name}` of type `{typ}`")
+        logging.error(f"Please verify your configuration file: `scanners.{name}`")
+        return 1
+
+    # Part 1: create a instance based on configuration
+    try:
+        scanner = class_(config)
+    except OSError as excp:
+        logging.error(excp)
+        logging.error(f"Ignoring failed Scanner `{name}` of type `{typ}`")
+        return 1
+
+    # Part 2: setup the environment (e.g.: spawn a server)
+    scanner.setup()
+
+    logging.debug(scanner)
+
+    # Part 3: run the actual scan
+    if scanner.state == scanners.State.READY:
+        scanner.run()
+    else:
+        logging.error(f"scanner {name} is not in READY state: it will not be run")
+        return 1
+
+    # Part 4: Post process
+    if scanner.state == scanners.State.DONE:
+        scanner.postprocess()
+    else:
+        logging.error(f"scanner {name} is not in DONE state: no post processing")
+        return 1
+
+    # Part 5: cleanup
+    if not args.no_cleanup:
+        scanner.cleanup()
+
+    # Part 6: export to defect dojo, if the scanner is compatible
+    if defect_d and hasattr(scanner, "data_for_defect_dojo"):
+        defect_d.import_or_reimport_scan(*scanner.data_for_defect_dojo())
+
+    return 0
+
+
 def run():
     parser = argparse.ArgumentParser(
         description="Runs various DAST scanners against a defined target, as configured by a configuration file."
@@ -113,49 +177,7 @@ def run():
     for name in config.get("scanners"):
         logging.info(f"Next scanner: '{name}'")
 
-        # Merge the "general" configuration into the scanner's config
-        # (but without overwriting anything: scanner's config takes precedence over the general config)
-        logging.debug(f"Merging general config into {name}'s config")
-        config.merge(
-            config.get("general", default={}),
-            preserve=True,
-            root=f"scanners.{name}",
-        )
-
-        class_ = scanners.str_to_scanner(
-            name, config.get(f"scanners.{name}.container.type", default="podman")
-        )
-
-        # Part 1: create a instance based on configuration
-        scanner = class_(config)
-
-        # Part 2: setup the environment (e.g.: spawn a server)
-        scanner.setup()
-
-        logging.debug(scanner)
-
-        # Part 3: run the actual scan
-        if scanner.state == scanners.State.READY:
-            scanner.run()
-        else:
-            logging.warning(f"scanner {name} is not in READY state: it will not be run")
-            continue
-
-        # Part 4: Post process
-        if scanner.state == scanners.State.DONE:
-            scanner.postprocess()
-        else:
-            logging.warning(f"scanner {name} is not in DONE state: no post processing")
-            scan_error_count += 1
-            continue
-
-        # Part 5: cleanup
-        if not args.no_cleanup:
-            scanner.cleanup()
-
-        # Part 6: export to defect dojo, if the scanner is compatible
-        if defect_d and hasattr(scanner, "data_for_defect_dojo"):
-            defect_d.import_or_reimport_scan(*scanner.data_for_defect_dojo())
+        scan_error_count += run_scanner(name, config, args, defect_d)
 
     if scan_error_count > 0:
         logging.warning(f"Number of failed scanners: {scan_error_count}")

--- a/scanners/zap/zap_podman.py
+++ b/scanners/zap/zap_podman.py
@@ -35,6 +35,12 @@ class ZapPodman(Zap):
         The code of the function only deals with the "podman" layer, the "ZAP" layer is handled by super()
         """
 
+        # First verify that "podman" exists
+        if not shutil.which("podman"):
+            raise OSError(
+                "Podman is not installed on not in the PATH. It is required to run ZAP in podman"
+            )
+
         logging.debug("Initializing podman-based ZAP scanner")
         super().__init__(config)
 


### PR DESCRIPTION
Catching some errors and prints a better explanation on the console when it happens.

In particular :
- when podman is not in the PATH
- when a scanner is not found, or the type not implemented

Also fixing emerging pylint errors (too many statements and branching in the `run()` function), by creating a new function: `run_scanner()` which runs only 1 scanner. This way, there are 2 smaller functions instead of a giant one.

Maybe we could also implement pytests for this new `run_scanner()`