### PR TITLE
Container multiusers

### DIFF
--- a/containerize/Containerfile.multiuser
+++ b/containerize/Containerfile.multiuser
@@ -5,10 +5,7 @@
 # build and install scanners in advance (more scanners will be added)
 FROM registry.access.redhat.com/ubi9-minimal
 
-RUN microdnf install -y procps tar gzip shadow-utils java-11-openjdk
-
-# TMP!!!
-RUN microdnf install -y nano
+RUN microdnf install -y procps tar gzip shadow-utils java-11-openjdk nano
 
 ## ZAP
 RUN mkdir /opt/zap
@@ -16,6 +13,12 @@ RUN mkdir -p /tmp/zap
 RUN curl -sfL https://github.com/zaproxy/zaproxy/releases/download/v2.12.0/ZAP_2.12.0_Linux.tar.gz | tar zxvf - -C /tmp/zap
 RUN mv -T /tmp/zap/ZAP_2.12.0 /opt/zap
 ENV PATH $PATH:/opt/zap/
+
+### Update add-ons
+RUN zap.sh -cmd -silent -addonupdate
+### Copy them to installation directory
+RUN cp /root/.ZAP/plugin/*.zap /opt/zap/plugin/ || :
+
 
 ## RapiDAST
 RUN mkdir /opt/rapidast

--- a/containerize/Containerfile.multiuser
+++ b/containerize/Containerfile.multiuser
@@ -31,9 +31,8 @@ COPY ./requirements.txt /opt/rapidast/
 COPY ./containerize/run_rapidast.sh /usr/bin/
 
 ### Add /opt/zap to the PATH (for any user and future user)
-COPY ./containerize/path_zap.sh /usr/profile.d/zap.sh
+COPY ./containerize/path_zap.sh /etc/profile.d/zap.sh
 
 ### Install RapiDAST requirements, globally, so that it's available to any user
 RUN python3 -m ensurepip --upgrade
 RUN pip3 install -r /opt/rapidast/requirements.txt
-

--- a/containerize/Containerfile.multiuser
+++ b/containerize/Containerfile.multiuser
@@ -1,0 +1,39 @@
+#####
+# Build RapiDAST image
+#####
+
+# build and install scanners in advance (more scanners will be added)
+FROM registry.access.redhat.com/ubi9-minimal
+
+RUN microdnf install -y procps tar gzip shadow-utils java-11-openjdk
+
+# TMP!!!
+RUN microdnf install -y nano
+
+## ZAP
+RUN mkdir /opt/zap
+RUN mkdir -p /tmp/zap
+RUN curl -sfL https://github.com/zaproxy/zaproxy/releases/download/v2.12.0/ZAP_2.12.0_Linux.tar.gz | tar zxvf - -C /tmp/zap
+RUN mv -T /tmp/zap/ZAP_2.12.0 /opt/zap
+ENV PATH $PATH:/opt/zap/
+
+## RapiDAST
+RUN mkdir /opt/rapidast
+
+COPY ./rapidast.py /opt/rapidast/
+COPY ./scanners/ /opt/rapidast/scanners/
+COPY ./tools/ /opt/rapidast/tools/
+COPY ./exports/ /opt/rapidast/exports/
+COPY ./configmodel/ /opt/rapidast/configmodel/
+COPY ./utils/ /opt/rapidast/utils/
+COPY ./config/ /opt/rapidast/config/
+COPY ./requirements.txt /opt/rapidast/
+COPY ./containerize/run_rapidast.sh /usr/bin/
+
+### Add /opt/zap to the PATH (for any user and future user)
+COPY ./containerize/path_zap.sh /usr/profile.d/zap.sh
+
+### Install RapiDAST requirements, globally, so that it's available to any user
+RUN python3 -m ensurepip --upgrade
+RUN pip3 install -r /opt/rapidast/requirements.txt
+

--- a/containerize/path_zap.sh
+++ b/containerize/path_zap.sh
@@ -1,0 +1,1 @@
+pathmunge /opt/zap

--- a/containerize/run_rapidast.sh
+++ b/containerize/run_rapidast.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/bash
+
+CONF=$(realpath $1)
+
+pushd /opt/rapidast/
+./rapidast.py --log-level debug --config "${CONF}"

--- a/scanners/__init__.py
+++ b/scanners/__init__.py
@@ -1,4 +1,6 @@
 import importlib
+import logging
+import tempfile
 from enum import Enum
 from pprint import pformat
 
@@ -21,6 +23,15 @@ class RapidastScanner:
 
     def __repr__(self):
         return pformat(vars(self), indent=4, width=1)
+
+    def _create_temp_dir(self, name="X"):
+        """This function simply creates a temporary directory aiming at storing data in transit.
+        This directory must be manually deleted by the caller during cleanup.
+        Descendent classes *may* overload this directory (e.g.: if they can't map /tmp)
+        """
+        temp_dir = tempfile.mkdtemp(prefix=f"rapidast_{self.__class__.__name__}_{name}_")
+        logging.debug(f"Temporary directory created in host: {temp_dir}")
+        return temp_dir
 
 
 # Given a string representing a scanner, return the corresponding scanner class.

--- a/scanners/__init__.py
+++ b/scanners/__init__.py
@@ -29,7 +29,9 @@ class RapidastScanner:
         This directory must be manually deleted by the caller during cleanup.
         Descendent classes *may* overload this directory (e.g.: if they can't map /tmp)
         """
-        temp_dir = tempfile.mkdtemp(prefix=f"rapidast_{self.__class__.__name__}_{name}_")
+        temp_dir = tempfile.mkdtemp(
+            prefix=f"rapidast_{self.__class__.__name__}_{name}_"
+        )
         logging.debug(f"Temporary directory created in host: {temp_dir}")
         return temp_dir
 

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -3,7 +3,6 @@ import os
 import pprint
 import shutil
 import tarfile
-import tempfile
 from base64 import urlsafe_b64encode
 from collections import namedtuple
 
@@ -195,16 +194,6 @@ class Zap(RapidastScanner):
         logging.warning(
             "_add_env() was called on the parent ZAP class. This is likely a bug. No operation done"
         )
-
-    def _create_work_dir(self):
-        """This function simply creates a temporary directory aiming at storing data in transit.
-        Data such as: the AF configuration, evidence, reports, etc.
-        This directory will be deleted during cleanup.
-        Descendent classes *may* overload this directory (e.g.: if they can't map /tmp)
-        """
-        temp_dir = tempfile.mkdtemp(prefix=f"rapidast_{self.__class__.__name__}_")
-        logging.debug(f"Temporary work directory for ZAP scanner in host: {temp_dir}")
-        return temp_dir
 
     def _host_work_dir(self):
         """Shortcut to the host path of the work directory"""

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -149,6 +149,38 @@ class Zap(RapidastScanner):
     # May be overloaded by inheriting classes                     #
     ###############################################################
 
+    def _setup_zap_cli(self):
+        """
+        Complete the zap_cli list of ZAP argument.
+        This is must be overloaded by descendant, which optionally call this one
+        If called, the descendant must fill at least the executable
+        """
+
+        # Proxy workaround (because it currently can't be configured from Automation Framework)
+        proxy = self.config.get("scanners.zap.proxy")
+        if proxy:
+            self.zap_cli += [
+                "-config",
+                f"network.connection.httpProxy.host={proxy.get('proxyHost')}",
+                "-config",
+                f"network.connection.httpProxy.port={proxy.get('proxyPort')}",
+                "-config",
+                "network.connection.httpProxy.enabled=true",
+            ]
+        else:
+            self.zap_cli += ["-config", "network.connection.httpProxy.enabled=false"]
+
+        # Create a session, to store them as evidence
+        self.zap_cli.append("-newsession")
+        self.zap_cli.append(f"{self._container_work_dir()}/session_data/session")
+
+        if not self.config.get("scanners.zap.miscOptions.enableUI", default=False):
+            # Disable UI
+            self.zap_cli.append("-cmd")
+
+        # finally: the Automation Framework:
+        self.zap_cli.extend(["-autorun", f"{self._container_work_dir()}/af.yaml"])
+
     def get_type(self):
         """Return container type, based on configuration.
         This is only a helper to shorten long lines
@@ -492,46 +524,6 @@ class Zap(RapidastScanner):
             self.automation_config["jobs"].append(
                 self._construct_report_af(reports["json"])
             )
-
-    def _setup_zap_cli(self):
-        """prepare the zap command: self.zap_cli
-        This is a list of strings, representing the entire ZAP command to match the desired run
-        """
-
-        self.zap_cli = [self.config.get("scanners.zap.container.parameters.executable")]
-
-        # Proxy workaround (because it currently can't be configured from Automation Framework)
-        proxy = self.config.get("scanners.zap.proxy")
-        if proxy:
-            self.zap_cli += [
-                "-config",
-                f"network.connection.httpProxy.host={proxy.get('proxyHost')}",
-                "-config",
-                f"network.connection.httpProxy.port={proxy.get('proxyPort')}",
-                "-config",
-                "network.connection.httpProxy.enabled=true",
-            ]
-        else:
-            self.zap_cli += ["-config", "network.connection.httpProxy.enabled=false"]
-
-        # Create a session, to store them as evidence
-        self.zap_cli.extend(
-            [
-                "-newsession",
-                f"{self.path_map.workdir.container_path}/session_data/session",
-            ]
-        )
-
-        if not self.config.get("scanners.zap.miscOptions.enableUI", default=False):
-            # Disable UI
-            self.zap_cli.append("-cmd")
-
-        # finally: the Automation Framework:
-        self.zap_cli.extend(
-            ["-autorun", self.path_map.workdir.container_path + "/af.yaml"]
-        )
-
-        logging.debug(f"ZAP will run with: {self.zap_cli}")
 
     def _save_automation_file(self):
         """Save the Automation dictionary as YAML in the container"""

--- a/scanners/zap/zap_flatpak.py
+++ b/scanners/zap/zap_flatpak.py
@@ -36,15 +36,19 @@ class ZapFlatpak(Zap):
 
         # Note: flatpak enforces the executable on its own, so we do not have to fill it up
 
+        # Generate on the fly a ZAP home dir, which will be filled up with default data.
+        # The policies will be copied inside it.
+        # Benefits: don't fiddle with user's ZAP environment, have a predictable base config
+        self.zap_home = self._create_temp_dir("home")
+
         # prepare the host <-> container mapping: flatpak container shares most directory with host
-        work_dir = self._create_temp_dir("workdir")
-        policies_dir = f"{os.environ['HOME']}/.ZAP/policies/"
-        scripts_dir = f"{MODULE_DIR}/scripts"
+        temp_dir = self._create_temp_dir("workdir")
+        policies_dir = f"{self.zap_home}/policies/"
 
         self.path_map = make_mapping_for_scanner(
             "Zap",
-            ("workdir", work_dir, work_dir),
-            ("scripts", scripts_dir, scripts_dir),
+            ("workdir", temp_dir, temp_dir),
+            ("scripts", f"{MODULE_DIR}/scripts", f"{MODULE_DIR}/scripts"),
             ("policies", policies_dir, policies_dir),
         )
 
@@ -75,6 +79,7 @@ class ZapFlatpak(Zap):
             policy = self.config.get(
                 "scanners.zap.activeScan.policy", default="API-scan-minimal"
             )
+            os.mkdir(self.path_map.policies.host_path)
             self._include_file(
                 host_path=f"{MODULE_DIR}/policies/{policy}.policy",
                 dest_in_container=f"{self.path_map.policies.container_path}/{policy}.policy",
@@ -93,8 +98,18 @@ class ZapFlatpak(Zap):
 
         if self.config.get("scanners.zap.miscOptions.updateAddons", default=True):
             logging.info("Zap: Updating addons")
-            if self._run_in_flatpak(["-cmd", "-addonupdate"]).returncode:
+            if self._run_in_flatpak(
+                ["-cmd", "-dir", self.zap_home, "-addonupdate"]
+            ).returncode:
                 logging.warning("ZAP addon update failed")
+
+            # temporary workaround: cleanup addon state
+            # see https://github.com/zaproxy/zaproxy/issues/7590#issuecomment-1308909500
+            statefile = f"{self.zap_home}/add-ons-state.xml"
+            try:
+                os.remove(statefile)
+            except FileNotFoundError:
+                logging.info(f"The addon state file {statefile} was not created")
 
         # Now the real run
         logging.info(f"Running ZAP with the following options:\n{self.zap_cli}")
@@ -136,8 +151,11 @@ class ZapFlatpak(Zap):
         if not self.state == State.PROCESSED:
             raise RuntimeError("No cleanning up as ZAP did not processed results.")
 
-        logging.debug(f"Deleting temp directories {self._host_work_dir()}")
+        logging.debug(
+            f"Deleting temp directories {self._host_work_dir()} and {self.zap_home}"
+        )
         shutil.rmtree(self._host_work_dir())
+        shutil.rmtree(self.zap_home)
 
         super().cleanup()
 
@@ -155,6 +173,11 @@ class ZapFlatpak(Zap):
         Generate the main ZAP command line (not the container command).
         Uses super() to generate the generic part of the command
         """
+
+        # Note: flatpak automatically adds the executable for us,
+        # so we only add the command options
+
+        self.zap_cli = ["-dir", self.zap_home]
 
         super()._setup_zap_cli()
 
@@ -184,6 +207,7 @@ class ZapFlatpak(Zap):
         flat = ["flatpak", "run"]
         # Share the `workdir` with flatpak
         flat.append(f"--filesystem={self.path_map.workdir.host_path}")
+        flat.append(f"--filesystem={self.zap_home}")
         flat.append("org.zaproxy.ZAP")
 
         flat.extend(command)

--- a/scanners/zap/zap_flatpak.py
+++ b/scanners/zap/zap_flatpak.py
@@ -154,6 +154,18 @@ class ZapFlatpak(Zap):
     # + MUST be implemented                                       #
     ###############################################################
 
+    def _setup_zap_cli(self):
+        """
+        Generate the main ZAP command line (not the container command).
+        Uses super() to generate the generic part of the command
+        """
+
+        self.zap_cli = [self.config.get("scanners.zap.container.parameters.executable")]
+
+        super()._setup_zap_cli()
+
+        logging.debug(f"ZAP will run with: {self.zap_cli}")
+
     def _add_env(self, key, value=None):
         """Environment variable to be added to the container.
         If value is None, then the value should be taken from the current host

--- a/scanners/zap/zap_flatpak.py
+++ b/scanners/zap/zap_flatpak.py
@@ -34,16 +34,16 @@ class ZapFlatpak(Zap):
         logging.debug("Initializing a local instance of the ZAP scanner")
         super().__init__(config)
 
-        # Setup defaults specific to "no container" mode
-        self.config.set(
-            "scanners.zap.container.parameters.executable", "zap", overwrite=False
-        )
+        # Note: flatpak enforces the executable on its own, so we do not have to fill it up
+
+        # Generate on the fly a ZAP home dir, which will be filled up with default data.
+        # The policies will be copied inside it.
+        # Benefits: don't fiddle with user's ZAP environment, have a predictable base config
+        self.zap_home = self._create_temp_dir("home")
 
         # prepare the host <-> container mapping: flatpak container shares most directory with host
-        temp_dir = self._create_work_dir()
-        policies_dir = (
-            f"{os.environ['HOME']}/.ZAP/policies"  # Flatpak is supposed only on Linux
-        )
+        temp_dir = self._create_temp_dir("workdir")
+        policies_dir = (f"{self.zap_home}/policies/")
 
         self.path_map = make_mapping_for_scanner(
             "Zap",
@@ -97,13 +97,13 @@ class ZapFlatpak(Zap):
 
         if self.config.get("scanners.zap.miscOptions.updateAddons", default=True):
             logging.info("Zap: Updating addons")
-            if self._run_in_flatpak(["-cmd", "-addonupdate"]).returncode:
+            if self._run_in_flatpak(["-cmd", "-dir", self.zap_home, "-addonupdate"]).returncode:
                 logging.warning("ZAP addon update failed")
 
         # Now the real run
-        logging.info(f"Running ZAP with the following command:\n{self.zap_cli}")
+        logging.info(f"Running ZAP with the following options:\n{self.zap_cli}")
         # note: we need to pop out the first element (`zap`) as it is implicitly called by flatpak
-        result = self._run_in_flatpak(self.zap_cli[1:])
+        result = self._run_in_flatpak(self.zap_cli)
         logging.debug(
             f"ZAP returned the following:\n=====\n{pp.pformat(result)}\n====="
         )
@@ -140,8 +140,9 @@ class ZapFlatpak(Zap):
         if not self.state == State.PROCESSED:
             raise RuntimeError("No cleanning up as ZAP did not processed results.")
 
-        logging.debug(f"Deleting temp directory {self._host_work_dir()}")
+        logging.debug(f"Deleting temp directories {self._host_work_dir()} and {self.zap_home}")
         shutil.rmtree(self._host_work_dir())
+        shutil.rmtree(self.zap_home)
 
         super().cleanup()
 
@@ -160,11 +161,14 @@ class ZapFlatpak(Zap):
         Uses super() to generate the generic part of the command
         """
 
-        self.zap_cli = [self.config.get("scanners.zap.container.parameters.executable")]
+        # Note: flatpak automatically adds the executable for us, 
+        # so we only add the command options
+
+        self.zap_cli = ["-dir", self.zap_home]
 
         super()._setup_zap_cli()
 
-        logging.debug(f"ZAP will run with: {self.zap_cli}")
+        logging.debug(f"ZAP will run with these options: {self.zap_cli}")
 
     def _add_env(self, key, value=None):
         """Environment variable to be added to the container.
@@ -190,6 +194,7 @@ class ZapFlatpak(Zap):
         flat = ["flatpak", "run"]
         # Share the `workdir` with flatpak
         flat.append(f"--filesystem={self.path_map.workdir.host_path}")
+        flat.append(f"--filesystem={self.zap_home}")
         flat.append("org.zaproxy.ZAP")
 
         flat.extend(command)

--- a/scanners/zap/zap_none.py
+++ b/scanners/zap/zap_none.py
@@ -173,6 +173,18 @@ class ZapNone(Zap):
     # + MUST be implemented                                       #
     ###############################################################
 
+    def _setup_zap_cli(self):
+        """
+        Generate the main ZAP command line (not the container command).
+        Uses super() to generate the generic part of the command
+        """
+
+        self.zap_cli = [self.config.get("scanners.zap.container.parameters.executable")]
+
+        super()._setup_zap_cli()
+
+        logging.debug(f"ZAP will run with: {self.zap_cli}")
+
     def _add_env(self, key, value=None):
         """Environment variable to be added to the container.
         If value is None, then the value should be taken from the current host

--- a/scanners/zap/zap_none.py
+++ b/scanners/zap/zap_none.py
@@ -117,6 +117,13 @@ class ZapNone(Zap):
                 logging.warning(
                     f"The ZAP addon update process did not finish correctly, and exited with code {result.returncode}"
                 )
+            # temporary workaround: cleanup addon state
+            # see https://github.com/zaproxy/zaproxy/issues/7590#issuecomment-1308909500
+            statefile = f"{self.zap_home}/add-ons-state.xml"
+            try:
+                os.remove(statefile)
+            except FileNotFoundError:
+                logging.info(f"The addon state file {statefile} was not created")
 
         # Now the real run
         logging.info(f"Running ZAP with the following command:\n{self.zap_cli}")

--- a/scanners/zap/zap_none.py
+++ b/scanners/zap/zap_none.py
@@ -42,7 +42,7 @@ class ZapNone(Zap):
 
         # prepare the host <-> container mapping
         # Because there's no container layer, there's no need to translate anything
-        temp_dir = self._create_work_dir()
+        temp_dir = self._create_temp_dir("workdir")
 
         if platform.system() == "Darwin":
             logging.debug(

--- a/scanners/zap/zap_none.py
+++ b/scanners/zap/zap_none.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import platform
 import pprint
 import shutil
 import subprocess
@@ -44,15 +43,12 @@ class ZapNone(Zap):
         # Because there's no container layer, there's no need to translate anything
         temp_dir = self._create_temp_dir("workdir")
 
-        if platform.system() == "Darwin":
-            logging.debug(
-                "Darwin(MacOS) is detected. Setting the policies_dir accordingly"
-            )
-            policies_dir = (
-                f"{os.environ['HOME']}/Library/Application Support/ZAP/policies"
-            )
-        else:
-            policies_dir = f"{os.environ['HOME']}/.ZAP/policies"
+        # Generate on the fly a ZAP home dir, which will be filled up with default data.
+        # The policies will be copied inside it.
+        # Benefits: don't fiddle with user's ZAP environment, have a predictable base config
+        self.zap_home = self._create_temp_dir("home")
+
+        policies_dir = f"{self.zap_home}/policies"
 
         self.path_map = make_mapping_for_scanner(
             "Zap",
@@ -84,14 +80,15 @@ class ZapNone(Zap):
         super().setup()
 
         # Without a container layer, can't "mount" the policy directory, and ZAP does not allow changing it
-        # We have to copy it to ~/.ZAP/policies/
+        # We have to copy it to ZAP's policies directory
         if self.config.get("scanners.zap.activeScan", default=False) is not False:
             policy = self.config.get(
                 "scanners.zap.activeScan.policy", default="API-scan-minimal"
             )
+            os.mkdir(self.path_map.policies.host_path)
             self._include_file(
                 host_path=f"{MODULE_DIR}/policies/{policy}.policy",
-                dest_in_container=self.path_map.policies.container_path,
+                dest_in_container=f"{self.path_map.policies.container_path}/{policy}.policy",
             )
 
         if self.state != State.ERROR:
@@ -107,14 +104,15 @@ class ZapNone(Zap):
 
         if self.config.get("scanners.zap.miscOptions.updateAddons", default=True):
             logging.info("Zap: Updating addons")
-            result = subprocess.run(
-                [
-                    self.config.get("scanners.zap.container.parameters.executable"),
-                    "-cmd",
-                    "-addonupdate",
-                ],
-                check=False,
-            )
+            command = [
+                self.config.get("scanners.zap.container.parameters.executable"),
+                "-dir",
+                self.zap_home,
+                "-cmd",
+                "-addonupdate",
+            ]
+            logging.debug(f"update command: {command}")
+            result = subprocess.run(command, check=False)
             if result.returncode != 0:
                 logging.warning(
                     f"The ZAP addon update process did not finish correctly, and exited with code {result.returncode}"
@@ -159,8 +157,11 @@ class ZapNone(Zap):
         if not self.state == State.PROCESSED:
             raise RuntimeError("No cleanning up as ZAP did not processed results.")
 
-        logging.debug(f"Deleting temp directory {self._host_work_dir()}")
+        logging.debug(
+            f"Deleting temp directories {self._host_work_dir()} and {self.zap_home}"
+        )
         shutil.rmtree(self._host_work_dir())
+        shutil.rmtree(self.zap_home)
 
         super().cleanup()
 
@@ -179,7 +180,11 @@ class ZapNone(Zap):
         Uses super() to generate the generic part of the command
         """
 
-        self.zap_cli = [self.config.get("scanners.zap.container.parameters.executable")]
+        self.zap_cli = [
+            self.config.get("scanners.zap.container.parameters.executable"),
+            "-dir",
+            self.zap_home,
+        ]
 
         super()._setup_zap_cli()
 

--- a/scanners/zap/zap_podman.py
+++ b/scanners/zap/zap_podman.py
@@ -63,10 +63,10 @@ class ZapPodman(Zap):
         self.container_name = f"rapidast_zap_{application_shortname}_{random_chars}"
 
         # prepare the host <-> container mapping
-        # The default location for WORK can be chosen by parent itself (no overide of self._create_work_dir)
+        # The default location for WORK can be chosen by parent itself (no overide of self._create_temp_dir)
         self.path_map = make_mapping_for_scanner(
             "Zap",
-            ("workdir", self._create_work_dir(), "/zap/results"),
+            ("workdir", self._create_temp_dir("workdir"), "/zap/results"),
             ("scripts", f"{MODULE_DIR}/scripts", "/zap/scripts"),
             ("policies", f"{MODULE_DIR}/policies", "/home/zap/.ZAP/policies/"),
         )

--- a/scanners/zap/zap_podman.py
+++ b/scanners/zap/zap_podman.py
@@ -188,6 +188,18 @@ class ZapPodman(Zap):
     # + MUST be implemented                                       #
     ###############################################################
 
+    def _setup_zap_cli(self):
+        """
+        Generate the main ZAP command line (not the container command).
+        Uses super() to generate the generic part of the command
+        """
+
+        self.zap_cli = [self.config.get("scanners.zap.container.parameters.executable")]
+
+        super()._setup_zap_cli()
+
+        logging.debug(f"ZAP will run with: {self.zap_cli}")
+
     def _add_env(self, key, value=None):
         """Environment variable to be added to the container.
         If value is None, then the value should be taken from the current host


### PR DESCRIPTION
Several changes have been made in order to make the RapiDAST image more multi-user friendly (such that it does not require to use the "zap" user inside the image).

This includes :
- In `none` mode, the ZAP scanner will create a fresh directory inside /tmp to host ZAP data (scripts, plugin, etc.) 
- the new containerfile `Containerfile.multiuser` does not create any user, adds `zap.sh` to PATH by default, and a `run_rapidast.sh <config>` wrapper.

The aim is to make the rapidast image more Jenkins friendly

There is one caveat:
Using the multiuser image, because users will not have write access to rapidast's directory, the config file needs to have `config.base_results_dir` set to a writable location (and should be an absolute path), such as `/tmp/rapidast_results/` for example. (reason: it defaults to rapidast's `./results` which the user may not have write permissions into)