### PR TITLE
Add new log level - verbose

### DIFF
--- a/containerize/Containerfile
+++ b/containerize/Containerfile
@@ -24,6 +24,7 @@ COPY ./exports/ /home/rapidast/exports/
 COPY ./config/ /home/rapidast/config/
 COPY ./configmodel/ /home/rapidast/configmodel/
 COPY ./requirements.txt /home/rapidast/
+COPY ./utils/ /home/rapidast/utils/
 
 RUN chown -R rapidast:rapidast /zap
 RUN chown -R rapidast:rapidast /home/rapidast

--- a/rapidast.py
+++ b/rapidast.py
@@ -12,6 +12,7 @@ from dotenv import load_dotenv
 import configmodel.converter
 import scanners
 from exports.defect_dojo import DefectDojo
+from utils import add_logging_level
 
 pp = pprint.PrettyPrinter(indent=4)
 
@@ -116,7 +117,7 @@ def run():
     parser.add_argument(
         "--log-level",
         dest="loglevel",
-        choices=["debug", "info", "warning", "error", "critical"],
+        choices=["debug", "verbose", "info", "warning", "error", "critical"],
         default="info",
         help="Level of verbosity",
     )
@@ -136,6 +137,7 @@ def run():
 
     args = parser.parse_args()
     args.loglevel = args.loglevel.upper()
+    add_logging_level("VERBOSE", logging.DEBUG + 5)
     logging.basicConfig(format="%(levelname)s:%(message)s", level=args.loglevel)
     logging.debug(
         f"log level set to debug. Config file: '{parser.parse_args().config_file.name}'"

--- a/tests/utils/test_add_logging_level.py
+++ b/tests/utils/test_add_logging_level.py
@@ -1,0 +1,13 @@
+from utils import add_logging_level
+import logging
+import unittest
+
+
+class TestAddLoggingLevel(unittest.TestCase):
+    def test_add_logging_level(self):
+        add_logging_level("VERBOSE", logging.DEBUG + 5)
+        logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.VERBOSE)
+        with self.assertLogs(level='VERBOSE') as cm:
+            logging.verbose("verbose")
+            logging.debug("debug")
+        self.assertEqual(cm.output, ['VERBOSE:root:verbose'])

--- a/tools/updater_config.py
+++ b/tools/updater_config.py
@@ -5,6 +5,7 @@ import logging
 import yaml
 
 import configmodel.converter
+from utils import add_logging_level
 
 
 if __name__ == "__main__":
@@ -15,7 +16,7 @@ In the process any comments will be deleted. Please review any warnings or error
     parser.add_argument(
         "--log-level",
         dest="loglevel",
-        choices=["debug", "info", "warning", "error", "critical"],
+        choices=["debug", "verbose", "info", "warning", "error", "critical"],
         default="info",
         help="Level of verbosity",
     )
@@ -36,6 +37,7 @@ In the process any comments will be deleted. Please review any warnings or error
 
     args = parser.parse_args()
     args.loglevel = args.loglevel.upper()
+    add_logging_level("VERBOSE", logging.DEBUG + 5)
     logging.basicConfig(format="%(levelname)s:%(message)s", level=args.loglevel)
     logging.debug(
         f"log level set to debug. Config file: '{parser.parse_args().config_file.name}'"

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,1 +1,2 @@
+from .add_logging_level import add_logging_level
 from .safe_add import safe_add

--- a/utils/add_logging_level.py
+++ b/utils/add_logging_level.py
@@ -1,0 +1,22 @@
+import logging
+
+
+# Inspired by: https://stackoverflow.com/a/35804945/1691778
+def add_logging_level(level_name, level_num):
+    """
+    Precondition: The log level being added shouldn't already exist in the logging
+    module
+    """
+    method_name = level_name.lower()
+
+    def log_for_level(self, message, *args, **kwargs):
+        if self.isEnabledFor(level_num):
+            self._log(level_num, message, args, **kwargs)
+
+    def log_to_root(message, *args, **kwargs):
+        logging.log(level_num, message, *args, **kwargs)
+
+    logging.addLevelName(level_num, level_name)
+    setattr(logging, level_name, level_num)
+    setattr(logging.getLoggerClass(), method_name, log_for_level)
+    setattr(logging, method_name, log_to_root)


### PR DESCRIPTION
Adds a new log level verbose which is between info and debug. 
Since verbose doesn't exist as a default log level in the logging module, I had to add a new level. I created a util function to add a new level so that I could reuse that code for `rapidast.py` and `tools/updater_config.py`