### PR TITLE
Zap podman in pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,20 +197,6 @@ It is also possible to set the container type for each scanner differently by se
 
 ### Additional options
 
-In `scanners.zap.miscOptions`, additional options can be provided :
-
-+ enableUI (default: False): Runs ZAP with the UI (useful for debugging). The runtime type must support it (only `none` and `flatpak`)
-+ updateAddons (default: True): Prior to running, ZAP will update its addons
-
-Example:
-
-```
-scanners:
-    zap:
-        miscOptions:
-            enableUI: True
-            updateAddons: False
-```
 
 ### Build a RapiDAST image
 
@@ -235,6 +221,33 @@ See [helm/README.md](./helm/README.md)
 OWASP® ZAP (Zed Attack Proxy) is an open-source DAST tool. It can be used for scanning web applications and API.
 
 See https://www.zaproxy.org/ for more information.
+
+##### ZAP scanner specific options
+
+Below are some configuration tips related to the ZAP scanner.
+
+* Podman only: inject the ZAP container in an existing Pod.
+It is possible to gather both RapiDAST and the tested application into the same podman Pod. This might help CI/CD automation & clean-up.
+In order to do that, the user must create the Pod prior to running RapiDAST, and indicate its name in the RapiDAST configuration: `scanners.zap.container.parameters.podName`.
+However, it is currently necessary to map the host user to UID 1000 / GID 1000 manually during the creation of the Pod using the `--userns=keep-id:uid=1000,gid=1000` option
+Example: `podman pod create --userns=keep-id:uid=1000,gid=1000 myApp_Pod`
+
++ Enable ZAP's Graphical UI (useful for debugging): set `scanners.zap.miscOptions.enableUI: True` (default: False). The runtime type must support it (only `none` and `flatpak`)
+
++ Disable add-on updates: `scanners.zap.miscOptions.updateAddons: False` (default: True): Prior to running, ZAP will update its addons unless this value is `False`
+
+Example:
+
+```yaml
+scanners:
+    zap:
+        container:
+            parameters:
+                podName: "myApp_Pod"
+        miscOptions:
+            enableUI: True
+            updateAddons: False
+```
 
 #### More scanners
 

--- a/config/config-template-long.yaml
+++ b/config/config-template-long.yaml
@@ -119,8 +119,11 @@ scanners:
     container:
       parameters:
         image: "docker.io/owasp/zap2docker-stable:latest" # for type such as podman
+        #podName: "mypod"  # optional: inject ZAP in an existing Pod
+
         executable: "zap.sh"  # for Linux
         # executable: "/Applications/OWASP ZAP.app/Contents/Java/zap.sh"    # for MacOS, when general.container.type is 'none' only
+
 
     report:
       format: ["json"]

--- a/scanners/zap/zap_podman.py
+++ b/scanners/zap/zap_podman.py
@@ -204,14 +204,23 @@ class ZapPodman(Zap):
     ###############################################################
 
     def _setup_podman_cli(self):
+        """Prepare the podman command.
+        The function does not return anything, but adds options to self.podman_opts
+        """
         logging.info(
             f"Preparing a podman container for the zap image, called {self.container_name}"
         )
 
         self.podman_opts += ["--name", self.container_name]
 
-        # UID/GID mapping, in case of older podman version
-        self._setup_zap_podman_id_mapping_cli()
+        pod_name = self.config.get("scanners.zap.container.parameters.podName")
+        if pod_name:
+            # injecting the container in an existing pod
+            self.podman_opts += ["--pod", pod_name]
+        else:
+            # UID/GID mapping, in case of older podman version
+            # note: incompatible with pod injection
+            self._setup_zap_podman_id_mapping_cli()
 
         # Volume mappings
         for mapping in self.path_map:

--- a/tests/scanners/zap/test_setup_podman.py
+++ b/tests/scanners/zap/test_setup_podman.py
@@ -219,6 +219,19 @@ def test_setup_graphql(test_config):
         assert False, "graphql job not found"
 
 
+def test_setup_pod_injection(test_config):
+    test_config.set("scanners.zap.container.parameters.podName", "podABC")
+
+    test_zap = ZapPodman(config=test_config)
+    test_zap.setup()
+
+    assert "--pod" in test_zap.podman_opts
+    assert "podABC" in test_zap.podman_opts
+
+    # Also assert that there is no uid mapping
+    assert not "--uidmap" in test_zap.podman_opts
+
+
 ## Testing report format ##
 
 


### PR DESCRIPTION
In "podman" mode, adds the ability to inject the ZAP container in an existing pod.
This was originally written to facilitate e2e testings, but can be beneficial in general.

The idea is : the user creates a pod, and launch both the application and the ZAP scanner. As a benefit, both application share the same `localhost`, and thus can facilitate the configuration of the test.

Minor caveat: the upstream ZAP image requires a specific UID/GID mapping. This can not be handled automatically when injecting it in an existing Pod (in this case, the mapping needs to be done during the creation of the Pod, before RapiDAST runs). This is explained in the README.

Additional changes: 
- In the README, the ZAP specific configuration options were moved to the `ZAP` chapter, instead of the generic configuration chapter.
- pytest have been added for Pod injection.