### PR TITLE
Add ability to read config file from remote URL 

### DIFF
--- a/tests/scanners/zap/test_setup_podman.py
+++ b/tests/scanners/zap/test_setup_podman.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 
-import configmodel.converter
 import pytest
+
+import configmodel.converter
 from scanners.zap.zap import find_context
 from scanners.zap.zap_podman import ZapPodman
 

--- a/tests/test_load_config_file.py
+++ b/tests/test_load_config_file.py
@@ -1,0 +1,22 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import rapidast
+import urllib  # pylint: disable=unused-import
+
+
+class TestLoadConfigFile(unittest.TestCase):
+    @patch('urllib.request.urlopen')
+    def test_load_config_file_from_url(self, mock_urlopen):
+        response = MagicMock()
+        response.getcode.return_value = 200
+        response.read.return_value = "config: 3"
+        mock_urlopen.return_value = response
+        result = rapidast.load_config_file("https://location/config.yaml")
+        assert result is response
+
+    @patch('builtins.open')
+    def test_load_config_file_from_local_file(self, mock_open):
+        response = MagicMock()
+        mock_open.return_value = response
+        result = rapidast.load_config_file("./config/config.yaml")
+        assert result is response

--- a/tests/test_result_dirname.py
+++ b/tests/test_result_dirname.py
@@ -1,7 +1,8 @@
 import re
 
-import configmodel
 import pytest  # pylint: disable=unused-import
+
+import configmodel
 import rapidast
 
 # from pytest_mock import mocker

--- a/tests/utils/test_add_logging_level.py
+++ b/tests/utils/test_add_logging_level.py
@@ -1,13 +1,14 @@
-from utils import add_logging_level
 import logging
 import unittest
+
+from utils import add_logging_level
 
 
 class TestAddLoggingLevel(unittest.TestCase):
     def test_add_logging_level(self):
         add_logging_level("VERBOSE", logging.DEBUG + 5)
         logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.VERBOSE)
-        with self.assertLogs(level='VERBOSE') as cm:
+        with self.assertLogs(level="VERBOSE") as cm:
             logging.verbose("verbose")
             logging.debug("debug")
-        self.assertEqual(cm.output, ['VERBOSE:root:verbose'])
+        self.assertEqual(cm.output, ["VERBOSE:root:verbose"])

--- a/utils/add_logging_level.py
+++ b/utils/add_logging_level.py
@@ -11,6 +11,7 @@ def add_logging_level(level_name, level_num):
 
     def log_for_level(self, message, *args, **kwargs):
         if self.isEnabledFor(level_num):
+            # pylint: disable=protected-access
             self._log(level_num, message, args, **kwargs)
 
     def log_to_root(message, *args, **kwargs):


### PR DESCRIPTION
You can now pass a URL to the `--config` option. For example:
```
rapidast.py --config https://location/config.yaml
```