### PR TITLE
[ZAP]regression workaround for MacOS missing addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,19 @@ org.zaproxy.zap.extension.openapi.converter.swagger.SwaggerException: Failed to 
 2023-02-17 22:43:01,073 [main ] INFO  CommandLineBootstrap - OWASP ZAP 2.12.0 terminated.
 ```
 
+### ZAP's plugins are missing from the host installation
+
+Only when using the host's ZAP (`type: none`)
+
+If you see a message such as `Missing mandatory plugins. Fixing`, or ZAP fails with an error containing the string `The mandatory add-on was not found:`, this is because ZAP deleted the application's plugin.
+See https://github.com/zaproxy/zaproxy/issues/7703 for additional information.
+RapiDAST works around this bug, but with little inconvenients (slower because it has to fix itself and download all the plugins)
+
+- Verify that the host installation directory is missing its plugins.
+e.g., in a MacOS installation, `/Applications/OWASP ZAP.app/Contents/Java/plugin/` will be mostly empty. In particular, no `callhome*.zap` and `network*.zap` file are present.
+- Reinstall ZAP, but __DO NOT RUN IT__, as it would delete the plugins. Verify that the directory contains many plugins.
+- `chown` the installation files to root, so that when running ZAP, the application running as the user does not have sufficient permission to delete its own plugins
+
 ## Caveats
 
 * Currently, RapiDAST does not clean up the temporary data when there is an error. The data may include:

--- a/scanners/downloaders.py
+++ b/scanners/downloaders.py
@@ -5,6 +5,30 @@ import requests
 import yaml
 
 
+def anonymous_download(url, dest=None, proxy=None):
+    """Given a URL, load it using a GET request to dest"""
+
+    logging.verbose(f"Downloading {url}")
+    if proxy:
+        proxy = {
+            "https": f"http://{proxy['proxyHost']}:{proxy['proxyPort']}",
+            "http": f"http://{proxy['proxyHost']}:{proxy['proxyPort']}",
+        }
+    resp = requests.get(url, allow_redirects=True, proxies=proxy)
+    if resp.status_code >= 400:
+        logging.warning(f"Download {url} failed with {resp.status_code}.")
+        return False
+
+    if dest:
+        with open(dest, "wb") as file:
+            file.write(resp.content)
+        logging.verbose(f"Download saved in {dest}")
+        return True
+    else:
+        logging.verbose("Returning content")
+        return resp.content
+
+
 def authenticated_download_with_rtoken(url, dest, auth, proxy=None):
     """Given a URL and Oauth2 authentication parameters, download the URL and store it at `dest`"""
 


### PR DESCRIPTION
This is a workaround for upstream ZAP issue 7703
https://github.com/zaproxy/zaproxy/issues/7703

Waiting for the upstream fix to be pulled in a stable release.

Issue description:
ZAP attempts to delete outdated plugins. The problem is that, in MacOS, the installation is done as the user, and thus the user has permission to delete the installation's plugins, and most of the plugins are deleted.
The updated version of those plugins are stored in the user's home ZAP directory, but RapiDAST no longer use this directory.

The result is: ZAP refuses to start because 2 mandatory plugins are missing.

The workaround:
When the mandatory plugins are found to be missing, this happens:

1) the plugins are manually downloaded, straight from upstream. This is sufficient to run ZAP, but not sufficient to run RapiDAST, because other plugins are still missing (e.g.: automation plugin)

2) RapiDAST then installs *all* plugins.

The downside of this is a longer runtime, because not only RapiDAST must be run 1 more time, it also has to download all plugins. The other downside is size: the plugin are roughly ½GB in size. This will be deleted after the RapiDAST run (in case of success).

To avoid the downside, in MacOS, you can do the following: 
1- Reinstall ZAP, but DO NOT RUN IT! (or it will delete the installation plugins)
2- change the ownership of the ZAP application to `root`, so that when run as a regular user, the deletion of the plugins will fail. 
3- then you can run ZAP and RapiDAST normally

The README was updated to contain the above information, in the "troubleshooting" chapter.