### PR TITLE
[IMG] adding a dast group to multiuser image

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ $ podman build . -f containerize/Containerfile -t <image-tag>
 
 Disclaimer: This tool is not intended to be run as a long-running service. Instead, it is designed to be run for a short period of time while a scan is being invoked and executed in a separate test environment. If this tool is used solely for the scanning purposes, vulnerabilities that may be indicated to exist in the image will not have a chance to be exploited. The user assumes all risks and liability associated with its use.
 
+The `Containerfile.multiuser` image can be used with additional freedom, such as creating additional users. Members of the `dast` group will also have the ability to modify rapidast (such as: adding new policies and writing results in the default location)
+
 ### Running on Kubernetes or OpenShift
 
 Helm chart is provided to help with running RapiDAST on Kubernetes or OpenShift.

--- a/containerize/Containerfile.multiuser
+++ b/containerize/Containerfile.multiuser
@@ -32,15 +32,20 @@ COPY ./utils/ /opt/rapidast/utils/
 COPY ./config/ /opt/rapidast/config/
 COPY ./requirements.txt /opt/rapidast/
 
-### Add /opt/zap to the PATH (for any user and future user)
+### Add /opt/{zap,rapidast}/ to the PATH (for any user and future user)
 COPY ./containerize/path_rapidast.sh /etc/profile.d/rapidast.sh
 
 ### Install RapiDAST requirements, globally, so that it's available to any user
 RUN python3 -m ensurepip --upgrade
 RUN pip3 install -r /opt/rapidast/requirements.txt
 
+### Allow the `dast` usergroup to make modifications to rapidast
+RUN groupadd dast
+RUN chown -R :dast /opt/rapidast
+RUN chmod -R g+w /opt/rapidast
 
-RUN useradd -u 1000 -d /home/rapidast -m -s /bin/bash rapidast
-RUN echo rapidast:rapidast | chpasswd 
+
+RUN useradd -u 1000 -d /home/rapidast -m -s /bin/bash -G dast rapidast
+RUN echo rapidast:rapidast | chpasswd
 USER rapidast
 WORKDIR /home/rapidast


### PR DESCRIPTION
Make RapiDAST useable to all members of rapidast group, allowing to :
- create policies
- store results in the default location (/opt/rapidast/results/)
- optionally patch rapidast on the fly