### PR TITLE
[WIP] store zap.log in the result dir for better troubleshooting

### DIFF
--- a/containerize/Containerfile
+++ b/containerize/Containerfile
@@ -48,7 +48,7 @@ RUN cp -r $HOME/scanners/zap/policies/*.policy $HOME/.ZAP/policies/
 ## for compatiblity, in case /home/zap/.ZAP/policies is referred
 USER root
 RUN mkdir -p /home/zap/.ZAP
-RUN ln -s $HOME/.ZAP/policies/ /home/zap/.ZAP/policies
+RUN ln -sfn $HOME/.ZAP /home/zap/.ZAP
 USER rapidast
 
 ## ZAP addon update

--- a/rapidast.py
+++ b/rapidast.py
@@ -102,13 +102,16 @@ def run_scanner(name, config, args, defect_d):
         return 1
 
     # Part 4: Post process
-    if scanner.state == scanners.State.DONE:
-        scanner.postprocess()
-    else:
-        logging.error(f"scanner {name} is not in DONE state: no post processing")
-        return 1
+    # Even in case of error, some information will be stored in the result directory for troubleshooting
+    scanner.postprocess()
 
     # Part 5: cleanup
+    if not scanner.state == scanners.State.PROCESSED:
+        logging.error(
+            f"Something is wrong. Scanner {name} is not in PROCESSED state: the workdir won't be cleaned up"
+        )
+        return 1
+
     if not args.no_cleanup:
         scanner.cleanup()
 

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -89,6 +89,7 @@ class Zap(RapidastScanner):
     def postprocess(self):
         logging.info(f"Extracting report, storing in {self.results_dir}")
         reports_dir = os.path.join(self.path_map.workdir.host_path, Zap.REPORTS_SUBDIR)
+        logging.debug(f"Extracting report from {reports_dir}")
         shutil.copytree(reports_dir, self.results_dir)
 
         logging.info("Saving the session as evidence")

--- a/scanners/zap/zap_none.py
+++ b/scanners/zap/zap_none.py
@@ -159,10 +159,11 @@ class ZapNone(Zap):
 
     def postprocess(self):
         logging.info("Running postprocess for the ZAP Host environment")
-        if not self.state == State.DONE:
-            raise RuntimeError(
-                "No post-processing as ZAP has not successfully run yet."
-            )
+
+        logging.debug(f"zap_home: {self.zap_home}")
+        shutil.copy(
+            f"{self.zap_home}/zap.log", f"{self._host_work_dir()}/{self.REPORTS_SUBDIR}"
+        )
 
         super().postprocess()
 

--- a/scanners/zap/zap_none.py
+++ b/scanners/zap/zap_none.py
@@ -160,11 +160,6 @@ class ZapNone(Zap):
     def postprocess(self):
         logging.info("Running postprocess for the ZAP Host environment")
 
-        logging.debug(f"zap_home: {self.zap_home}")
-        shutil.copy(
-            f"{self.zap_home}/zap.log", f"{self._host_work_dir()}/{self.REPORTS_SUBDIR}"
-        )
-
         super().postprocess()
 
         if not self.state == State.ERROR:

--- a/scanners/zap/zap_podman.py
+++ b/scanners/zap/zap_podman.py
@@ -69,7 +69,10 @@ class ZapPodman(Zap):
             ("workdir", self._create_temp_dir("workdir"), "/zap/results"),
             ("scripts", f"{MODULE_DIR}/scripts", "/zap/scripts"),
             ("policies", f"{MODULE_DIR}/policies", "/home/zap/.ZAP/policies/"),
+            ("zaphomedir", self._create_temp_dir("zaphomedir"), "/home/zap/.ZAP"),
         )
+        self.zap_home = self.path_map.zaphomedir.host_path
+        logging.debug(f"zap_home is set: {self.zap_home}")
 
     ###############################################################
     # PUBLIC METHODS                                              #


### PR DESCRIPTION
store zap.log in the result dir (both in case of success and error).

It's applied to the container 'none' mode. 

WIP: it will be applied to the other modes.
