### PR TITLE
Allows for a scanner to be run multiple times

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,33 @@ To avoid this, RapiDAST proposes 2 ways to provide a value for a given configura
 - Create an entry in the configuration file (this is the usual method)
 - Create an entry in the configuration file pointing to the environment variable that actually contains the data, by appending `_from_var` to the entry name: `general.authentication.parameters.rtoken_from_var=RTOKEN` (in this example, the token value is provided by the `$RTOKEN` environment variable)
 
+#### Running several instance of a scanner
+
+It is possible to run a scanner several times with different configurations. This is done by giving adding a different identifier to each scan, by appending `_<id>` to the scanner name.
+
+For example :
+
+```yaml
+scanners:
+  zap_unauthenticated:
+    apiScan:
+      apis:
+        apiUrl: "https://example.com/api/openapi.json"
+
+  zap_authenticated:
+    authentication:
+      type: "http_basic"
+      parameters:
+        username: "user"
+        password: "mypassw0rd"
+    apiScan:
+      apis:
+        apiUrl: "https://example.com/api/openapi.json"
+```
+
+In the example above, the ZAP scanner will first run without authentication, and then rerun again with a basic HTTP authentication.
+The results will be stored in their respective names (i.e.: `zap_unauthenticated` and `zap_authenticated` in the example above).
+
 ### Defect Dojo integration
 
 #### Preamble: creating Defect Dojo user

--- a/rapidast.py
+++ b/rapidast.py
@@ -76,14 +76,14 @@ def run_scanner(name, config, args, defect_d):
     try:
         class_ = scanners.str_to_scanner(name, typ)
     except ModuleNotFoundError:
-        logging.error(f"Scanner `{name}` of type `{typ}` does not exist")
-        logging.error(f"Ignoring failed Scanner `{name}` of type `{typ}`")
+        logging.error(f"Scanner `{name.split('_')[0]}` of type `{typ}` does not exist")
+        logging.error(f"Ignoring failed Scanner `name.split('_')[0]` of type `{typ}`")
         logging.error(f"Please verify your configuration file: `scanners.{name}`")
         return 1
 
     # Part 1: create a instance based on configuration
     try:
-        scanner = class_(config)
+        scanner = class_(config, name)
     except OSError as excp:
         logging.error(excp)
         logging.error(f"Ignoring failed Scanner `{name}` of type `{typ}`")

--- a/scanners/__init__.py
+++ b/scanners/__init__.py
@@ -17,9 +17,16 @@ class State(Enum):
 
 
 class RapidastScanner:
-    def __init__(self, config):
+    def __init__(self, config, ident):
+        self.ident = ident
         self.config = config
         self.state = State.UNCONFIGURED
+
+    def my_conf(self, path, default=None):
+        """Handy shortcut to get the scanner's configuration.
+        Only for within `scanners.<scanner>`
+        """
+        return self.config.get(f"scanners.{self.ident}.{path}", default)
 
     def __repr__(self):
         return pformat(vars(self), indent=4, width=1)
@@ -29,26 +36,47 @@ class RapidastScanner:
         This directory must be manually deleted by the caller during cleanup.
         Descendent classes *may* overload this directory (e.g.: if they can't map /tmp)
         """
-        temp_dir = tempfile.mkdtemp(
-            prefix=f"rapidast_{self.__class__.__name__}_{name}_"
-        )
+        temp_dir = tempfile.mkdtemp(prefix=f"rapidast_{self.ident}_{name}_")
         logging.debug(f"Temporary directory created in host: {temp_dir}")
         return temp_dir
 
 
-# Given a string representing a scanner, return the corresponding scanner class.
-# For example : str_to_scanner("zap", "podman") will load `scanners/zap/zap_podman.py`
 def str_to_scanner(name, method):
+    """Given a scanner ID (name) and a container method, returns the class to be loaded
+    `name` is in the form "<scanner>[_<id>]", where:
+      - <scanner> is the name of the scanner
+      - <id> is an optional identifier, allowing multiple instances of the same scanner
+        <id> simply needs to be discarded here
+    e.g.:
+    - "zap_unauth", "podman" : returns ZapPodman, loaded from `scanners/zap/zap_podman.py`
+    - "zap", "none" : returns ZapNone loaded from `scanners/zap/zap_none.py`
+    """
+
+    name = name.split("_")[0]
     mod = importlib.import_module(f"scanners.{name}.{name}_{method}")
     class_ = getattr(mod, mod.CLASSNAME)
     return class_
 
 
-# This is a decorator factory for generic authentication.
-# Method:
+###########################################################
+# AUTHENTICATION HELPERS                                  #
+# - authentication factory                                #
+###########################################################
 
 
 def generic_authentication_factory(scanner_name):
+    """Decorator factory for generic authentication.
+    First create the decorator:
+        @generic_authentication_factory("zap")
+        def authentication_factory(self):
+            [ default action. i.e.: probably raise error]
+
+    Then populate it by registering methods:
+        @authentication_factory.register(None)
+        def authentication_set_anonymous(self):
+            [return authentication of type `None`]
+    """
+
     def config_authentication_dispatcher(func):
         """This is intended to be a decorator to register authentication functions
         The function passed during creation will be called in case no suitable functions are found.

--- a/scanners/zap/zap_flatpak.py
+++ b/scanners/zap/zap_flatpak.py
@@ -26,13 +26,13 @@ class ZapFlatpak(Zap):
     # Accessed by parent Zap object                               #
     ###############################################################
 
-    def __init__(self, config):
+    def __init__(self, config, ident="zap"):
         """Initialize all vars based on the config.
         The code of the function only deals with the "no container" layer, the "ZAP" layer is handled by super()
         """
 
         logging.debug("Initializing a local instance of the ZAP scanner")
-        super().__init__(config)
+        super().__init__(config, ident)
 
         # Note: flatpak enforces the executable on its own, so we do not have to fill it up
 
@@ -75,10 +75,8 @@ class ZapFlatpak(Zap):
         super().setup()
 
         # Copy the selected policy to the policies directory
-        if self.config.get("scanners.zap.activeScan", default=False) is not False:
-            policy = self.config.get(
-                "scanners.zap.activeScan.policy", default="API-scan-minimal"
-            )
+        if self.my_conf("activeScan", default=False) is not False:
+            policy = self.my_conf("activeScan.policy", default="API-scan-minimal")
             os.mkdir(self.path_map.policies.host_path)
             self._include_file(
                 host_path=f"{MODULE_DIR}/policies/{policy}.policy",
@@ -96,7 +94,7 @@ class ZapFlatpak(Zap):
         if not self.state == State.READY:
             raise RuntimeError("[ZAP SCANNER]: ERROR, not ready to run")
 
-        if self.config.get("scanners.zap.miscOptions.updateAddons", default=True):
+        if self.my_conf("miscOptions.updateAddons", default=True):
             logging.info("Zap: Updating addons")
             if self._run_in_flatpak(
                 ["-cmd", "-dir", self.zap_home, "-addonupdate"]


### PR DESCRIPTION
With different configuration each times.

With this fix, it is possible to run a scanner several times with different configurations. This is done by giving adding a different identifier to each scan, by appending `_<id>` to the scanner name.

For example :

```yaml
scanners:
  zap_unauthenticated:
    apiScan:
      apis:
        apiUrl: "https://example.com/api/openapi.json"

  zap_authenticated:
    authentication:
      type: "http_basic"
      parameters:
        username: "user"
        password: "mypassw0rd"
    apiScan:
      apis:
        apiUrl: "https://example.com/api/openapi.json"
```

In the example above, the ZAP scanner will first run without authentication, and then rerun again with a basic HTTP authentication.
The results will be stored in their respective names (i.e.: `zap_unauthenticated` and `zap_authenticated` in the example above).

Identifying a scanner is totally optional (i.e: it remains possible to only use `zap` as previously, without identifier, or mixing the 2 : `zap` and `zap_again`).

README as been updated, however, no new testing functions have been created at the moment (but the pytest still runs successfully)