### PR TITLE
Adds Jenkins Job workflow example to run rapidast.

### DIFF
--- a/workflow_examples/jenkins/rapidastjob.groovy
+++ b/workflow_examples/jenkins/rapidastjob.groovy
@@ -1,0 +1,32 @@
+// This is an example implemtation of how we could rapidast in jenkins
+// This job doesn't expose all the rapidast options but gives us an idea on how it could be used in jenkins pipeline job
+
+pipelineJob('rapidast-scan-job') {
+    displayName('Rapidast Scanner Job')
+    description('Job will help scan services for Vulnerabilities with rapidast')
+        properties {
+        disableConcurrentBuilds()
+    }
+    parameters {
+        stringParam('SERVICENAME','','Required. Service Name that is scanned (No spaces/special char allowed)')
+        stringParam('API_SCANNER','OpenApiScan','Required. Currently only OpenApi Spec)')
+        nonStoredPasswordParam('RTOKEN','Required. Request token to access the service API. ')
+        stringParam('TARGET_URL', '', 'Starting point of URL Ex. http://localhost:9000/api/ ')
+        stringParam('SSO_ENDPOINT','','Required. Endpoint of the Authentication with Oauth')
+        stringParam('CLIENT_ID', '', 'Client_id required for jwt auth')
+        stringParam('PROXY', '', 'Optional, Ex. localhost:9090')
+        stringParam('API_SPEC_URL', '', 'Url where the openapi is present. Ex. http://localhost:9001/openapi.yaml')
+    }
+    logRotator {
+        numToKeep(50)
+    }
+    definition {
+        cps {
+            script(readFileFromWorkspace('workflow_examples/jenkins/rapidastscan.groovy'))
+            sandbox()
+        }
+    }
+}
+
+
+

--- a/workflow_examples/jenkins/rapidastscan.groovy
+++ b/workflow_examples/jenkins/rapidastscan.groovy
@@ -1,0 +1,97 @@
+#!/usr/bin/env groovy
+
+
+podTemplate(
+        containers: [
+            containerTemplate(
+                name: 'rapidast',
+                image: "quay.io/repository/redhatproductsecurity/rapidast:2.2.1",
+                resourceRequestCpu: '2',
+                resourceLimitCpu: '3',
+                resourceRequestMemory: '1Gi',
+                resourceLimitMemory: '3Gi',
+                ttyEnabled: true,
+                command: 'cat',
+                alwaysPullImage: true,
+                ),
+            ],
+        showRawYaml: true,
+        serviceAccount: "jenkins",
+        cloud: defaults.cloud
+    ) {
+
+        node(POD_LABEL) {
+            container("rapidast") {
+                stage("Install Rapidast for ${SERVICENAME}") {
+                     currentBuild.displayName = "#"+ env.BUILD_NUMBER + " " + "${SERVICENAME}"
+                }
+
+                stage("Inject configs for  Service") {
+                    parse_rapidast_options("${SERVICENAME}", "${API_SCANNER}", "${TARGET_URL}", "${API_SPEC_URL}", "${CLIENT_ID}", "${SSO_ENDPOINT}", $"{PROXY}")
+                }
+
+                stage("Run Rapidast for service") {
+                    dir('rapidast') {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            writeFile file: '.env', text: "RTOKEN="${RTOKEN}"
+                            sh "./rapidast.py --log-level debug --config config/config.yaml"
+                        }
+                    }
+                }
+
+                stage("Collect artifacts") {
+                    dir('rapidast') {
+                        archiveArtifacts allowEmptyArchive: true, artifacts: "results/${SERVICENAME}/**/zap/*.*, , results.html"
+
+                    }
+                }
+            }
+        }
+    }
+
+
+def parse_rapidast_options(String ServiceName, String ApiScanner, String TargetUrl, String ApISpecUrl, String CLIENT_ID, String SSO_ENDPOINT, String Proxy) {
+    // Parse the options for rapidast and add it to the config file. Always pull the latest config file
+
+    git url: 'https://github.com/RedHatProductSecurity/rapidast.git', branch: 'development'
+    def filename = 'config/config-template-long.yaml'
+    // Comment the fields not required.
+    sh "sed -i 's/importUrlsFromFile:/# importUrlsFromFile:/' ${filename}"
+    sh "sed -i 's/defectDojoExport:/# defectDojoExport:/' ${filename}"
+    sh "sed -i 's/# format:/format:/' ${filename}"
+    if ("${ApiScanner}" == "OpenApiScan") {
+        // Comment the fields not required.
+        echo "OpenAPI Spec Compliant API Scan selected"
+        sh "sed -i 's/graphql:/# graphql:/' ${filename}"
+        sh "sed -i 's/spiderAjax:/# spiderAjax:/' ${filename}"
+        sh "sed -i 's/spider:/# spider:/' ${filename}"
+    }
+    else {
+        echo "Scanner not supported."
+        currentBuild.result = 'FAILURE'
+        sh "exit 1"
+    }
+    // Read the YAML and them populate the fields
+    def data = readYaml file: filename
+
+    data.config.environ = ".env"
+    data.application.shortName = "${ServiceName}"
+    data.application.url = "${TargetUrl}"
+    data.general.authentication.parameters.client_id = "${CLIENT_ID}"
+    data.general.authentication.parameters.token_endpoint = "${SSO_ENDPOINT}"
+    data.general.container.type = "none"
+    data.scanners.zap.apiScan.target = "${TargetUrl}"
+    data.scanners.zap.apiScan.apis.apiUrl = "${ApISpecUrl}"
+    data.scanners.zap.miscOptions.oauth2OpenapiManualDownload = "True"
+
+    def Proxy = "${Proxy}"
+    if (Proxy) {
+        String[] proxyarr;
+        proxyarr = Proxy.split(':');
+        data.general.proxy.proxyHost = proxyarr[0]
+        data.general.proxy.proxyPort = proxyarr[1]
+    }
+    //create new with updated YAML config
+    writeYaml file: 'config/config.yaml', data: data
+    echo "Configuration Value: " + data
+}


### PR DESCRIPTION
The is an workflow with specific options from rapidast and doesn't exposes all of rapidast capabilities as of today. This can be extended to incorporates the requirements as needed. 
For Example: The current Job only uses Oauth authentication for rapidast, but can be easily extended to support other auth types supported by rapidast. 