### PR TITLE
commented activeScan in the simple config to disable by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ This section summarize the basic workflow as follows:
 1. Create a configuration file for testing the application. See the 'configuration' section below for more information.
 2. Optionally, an environment file may be added, e.g., to separate the secrets from the configuration file.
 3. Run RapiDAST and get the results.
+    - First run with passive scanning only which can save your time at the initial scanning  phase. There are various situations that can cause an issue, not only from scanning set up but also from your application or test environment. Active scanning takes a long time in general.
+    - Once passive Scanning has run successfully, run another scan with active scanning enabled in the configuration file.
 
 ## Configuration
 

--- a/config/config-template-long.yaml
+++ b/config/config-template-long.yaml
@@ -72,6 +72,7 @@ general:
     type: "podman"
 
 
+# `scanners' is a section that configures scanning options
 scanners:
   zap:
   # define a scan through the ZAP scanner

--- a/config/config-template.yaml
+++ b/config/config-template.yaml
@@ -17,6 +17,7 @@ application:
 # `general` is a section that will be applied to all scanners.
 general:
 
+  # See the config-template-long.yaml for more authentication options
   authentication:
     type: http_basic
     parameters:
@@ -31,9 +32,10 @@ general:
     #   none: RapiDAST runs each scanner in the same host or container (where RapiDAST itself is running in a container)
     type: "podman"
 
+# `scanners' is a section that configures scanning options
+# See the config-template-long.yaml for more options
 scanners:
   zap:
-  # define a scan through the ZAP scanner
     apiScan:
       apis:
         apiUrl: "<URL to openAPI>"
@@ -43,9 +45,10 @@ scanners:
       # optional list of passive rules to disable
       disabledRules: "2,10015,10027,10096,10024"
 
-    activeScan:
-      # If no policy is chosen, a default ("API-scan-minimal") will be selected
-      # The list of policies can be found in scanners/zap/policies/
-      policy: "API-scan-minimal"
+    # Enable activeScan by uncommenting, once scans with the passiveScan only has run successfully
+    #  # If no policy is chosen, a default ("API-scan-minimal") will be selected
+    #  # The list of policies can be found in scanners/zap/policies/
+    #activeScan:
+    #  policy: "API-scan-minimal"
 
 # Other scanners to be defined(TBD)


### PR DESCRIPTION
This will help a user to make sure all the scanning job/process goes successfully, saving time from running activeScan which takes long time in general.

A user is expected to enable it once they make sure passive scanning has run without an issue.