### PR TITLE
[ZAP] choose an uncommon port for proxy, but let user override if needed

### DIFF
--- a/config/config-template-long.yaml
+++ b/config/config-template-long.yaml
@@ -150,6 +150,9 @@ scanners:
       # If set to True and authentication is oauth2_rtoken and api.apiUrl is set, download the API outside of ZAP
       oauth2OpenapiManualDownload: False
 
+      # overwrite the default port in case it is required. The default port was selected to avoid any collision with other services
+      zapPort: 8080
+
     # (Optional) configure to export scan results to OWASP Defect Dojo.
     # `config.defectDojo` must be configured first.
     defectDojoExport:

--- a/scanners/zap/zap_none.py
+++ b/scanners/zap/zap_none.py
@@ -115,13 +115,13 @@ class ZapNone(Zap):
 
         if self.my_conf("miscOptions.updateAddons", default=True):
             logging.info("Zap: Updating addons")
-            command = [
-                self.my_conf("container.parameters.executable"),
-                "-dir",
-                self.zap_home,
-                "-cmd",
-                "-addonupdate",
-            ]
+
+            command = [self.my_conf("container.parameters.executable")]
+            command.extend(self._get_standard_options())
+            command.extend(["-dir", self.zap_home])
+            command.append("-cmd")
+            command.append("-addonupdate")
+
             logging.debug(f"update command: {command}")
             result = subprocess.run(command, check=False)
             if result.returncode != 0:
@@ -227,12 +227,12 @@ class ZapNone(Zap):
         See https://github.com/zaproxy/zaproxy/issues/7703
         """
         logging.info("Zap: verifying the viability of ZAP")
-        command = [
-            self.my_conf("container.parameters.executable"),
-            "-dir",
-            self.zap_home,
-            "-cmd",
-        ]
+
+        command = [self.my_conf("container.parameters.executable")]
+        command.extend(self._get_standard_options())
+        command.extend(["-dir", self.zap_home])
+        command.append("-cmd")
+
         logging.debug(f"ZAP create home command: {command}")
         result = subprocess.run(command, check=False, capture_output=True)
         if result.returncode == 0:
@@ -254,13 +254,13 @@ class ZapNone(Zap):
                 proxy=self.my_conf("proxy", default=None),
             )
             logging.info("Workaround: installing all addons")
-            command = [
-                self.my_conf("container.parameters.executable"),
-                "-dir",
-                self.zap_home,
-                "-cmd",
-                "-addoninstallall",
-            ]
+
+            command = [self.my_conf("container.parameters.executable")]
+            command.extend(self._get_standard_options())
+            command.extend(["-dir", self.zap_home])
+            command.append("-cmd")
+            command.append("-addoninstallall")
+
             logging.debug(f"ZAP: installing all addons: {command}")
             result = subprocess.run(command, check=False)
 

--- a/scanners/zap/zap_podman.py
+++ b/scanners/zap/zap_podman.py
@@ -122,6 +122,8 @@ class ZapPodman(Zap):
             # currently, this is done via a `sh -c` wrapper
             commands = (
                 self.my_conf("container.parameters.executable")
+                + " "
+                + " ".join(self._get_standard_options())
                 + " -cmd -addonupdate; "
                 + " ".join(self.zap_cli)
             )


### PR DESCRIPTION
Prevent by default ZAP to bind to port 8080.

Since we should not have to use this port (we're not using ZAP as a proxy, except in spider mode, but this is automated) a random port was selected (47691).
However, in the miscOptions, the user can override it if needed.

Note: I have not written any pytest at the moment, because the pytest code needs to be adapted to the "generic plugin" change, which hasn't been merged yet.

Side note: I also tried to prevent ZAP to bind its proxy port entirely using the following configuration, but this did not work, so I simply changed the port:
```
<mainProxy><enabled>false</enabled><proxy>false</proxy>
```