### PR TITLE
[ZAP] OAuth2: optionally dowload schemas

### DIFF
--- a/config/config-template-generic-scan.yaml
+++ b/config/config-template-generic-scan.yaml
@@ -8,7 +8,7 @@ config:
   # This value tells RapiDAST what schema should be used to read this configuration.
   # Therefore you should only change it if you update the configuration to a newer schema
   # It is intended to keep backward compatibility (newer RapiDAST running an older config)
-  configVersion: 4
+  configVersion: 5
 
 # `application` contains data related to the application, not to the scans.
 application:

--- a/config/config-template-multi-scan.yaml
+++ b/config/config-template-multi-scan.yaml
@@ -10,7 +10,7 @@ config:
   # This value tells RapiDAST what schema should be used to read this configuration.
   # Therefore you should only change it if you update the configuration to a newer schema
   # It is intended to keep backward compatibility (newer RapiDAST running an older config)
-  configVersion: 4
+  configVersion: 5
 
 # `application` contains data related to the application, not to the scans.
 application:

--- a/config/config-template-zap-mac.yaml
+++ b/config/config-template-zap-mac.yaml
@@ -10,7 +10,7 @@ config:
   # This value tells RapiDAST what schema should be used to read this configuration.
   # Therefore you should only change it if you update the configuration to a newer schema
   # It is intended to keep backward compatibility (newer RapiDAST running an older config)
-  configVersion: 4
+  configVersion: 5
 
 # `application` contains data related to the application, not to the scans.
 application:

--- a/config/config-template-zap-simple.yaml
+++ b/config/config-template-zap-simple.yaml
@@ -10,7 +10,7 @@ config:
   # This value tells RapiDAST what schema should be used to read this configuration.
   # Therefore you should only change it if you update the configuration to a newer schema
   # It is intended to keep backward compatibility (newer RapiDAST running an older config)
-  configVersion: 4
+  configVersion: 5
 
 # `application` contains data related to the application, not to the scans.
 application:

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -273,6 +273,9 @@ class Zap(RapidastScanner):
             app_url = self.config.get("application.url")
             if app_url:
                 af_context["urls"].append(app_url)
+            else:
+                logging.error("Configuration: ZAP requires an application.url entry")
+                raise KeyError("Missing `application.url` in configuration")
             af_context["includePaths"].extend(self.my_conf("urls.includes", default=[]))
             af_context["excludePaths"].extend(self.my_conf("urls.excludes", default=[]))
         except KeyError as exc:

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -270,7 +270,9 @@ class Zap(RapidastScanner):
         # Configure the basic environment target
         try:
             af_context = find_context(self.automation_config)
-            af_context["urls"].append(self.config.get("application.url"))
+            app_url = self.config.get("application.url")
+            if app_url:
+                af_context["urls"].append(app_url)
             af_context["includePaths"].extend(self.my_conf("urls.includes", default=[]))
             af_context["excludePaths"].extend(self.my_conf("urls.excludes", default=[]))
         except KeyError as exc:
@@ -278,7 +280,7 @@ class Zap(RapidastScanner):
                 f"Something went wrong with the Zap scanner configuration, while creating the context':\n {str(exc)}"
             ) from exc
 
-        # authentication MUST happen first in case a user is created
+        # authentication MUST happen first in case a user is created, or authenticated manual download is needed
         self.authenticated = self.authentication_factory()
 
         # Create the AF configuration
@@ -680,35 +682,12 @@ class Zap(RapidastScanner):
         self.automation_config["jobs"].append(script)
         logging.info("ZAP configured with OAuth2 RTOKEN")
 
-        # quickhack: the openapi job currently does not run with user authentication.
-        # This is a problem when openapi requires an authenticated URL.
-        # => manually download the OAS, and change it to apiFile
-        # This can be deleted when https://github.com/zaproxy/zaproxy/issues/7739 is resolved
-        # Note: to avoid a temporary file, we download the file directly in its final destination in work_dir
-        #       This is not a problem: it will simply be ignored by _include_file()
-        oas_url = self.my_conf("apiScan.apis.apiUrl", default=None)
-        if oas_url and self.my_conf(
-            "miscOptions.oauth2OpenapiManualDownload", default=False
-        ):
-            logging.info("ZAP workaround: manually downloading the OpenAPI file")
-            if authenticated_download_with_rtoken(
-                url=oas_url,
-                dest=f"{self._host_work_dir()}/openapi.json",
+        if self.my_conf("miscOptions.oauth2ManualDownload"):
+            # See if manual authenticated downloads are required
+            self._manual_oauth2_download(
                 auth={"rtoken": rtoken, "client_id": client_id, "url": token_endpoint},
                 proxy=self.my_conf("proxy", default=None),
-            ):
-                logging.info(
-                    "Successful manual download of the OAS: replacing apiUrl by apiFile"
-                )
-                self.config.set(
-                    f"scanners.{self.ident}.apiScan.apis.apiFile",
-                    f"{self._host_work_dir()}/openapi.json",
-                )
-                self.config.delete(f"scanners.{self.ident}.apiScan.apis.apiUrl")
-            else:
-                logging.warning(
-                    "Failed to manually download the OAS. delegating to ZAP"
-                )
+            )
 
         return True
 
@@ -716,6 +695,54 @@ class Zap(RapidastScanner):
     # MAGIC METHODS                                               #
     # Special functions (other than __init__())                   #
     ###############################################################
+
+    def _manual_oauth2_download(self, auth, proxy):
+        """QUICKHACK: some ZAP requests can't be authenticated.
+        This is an issue for schema downloads behind a login (e.g.: openapi, graphQL)
+
+        IF a manual download is requested:
+        1) identify those URLs in the config
+        2) For each ones:
+          a) Download the said schema
+          b) Modify the config to use a file path instead of the URL
+
+        Example of issues: https://github.com/zaproxy/zaproxy/issues/7739 is resolved
+        Note: to avoid a temporary file, we download the files directly in its final destination in work_dir
+              This is not a problem: it will simply be ignored by _include_file()
+        """
+        logging.info("Looking for URLs to downloads manually")
+
+        # Preparation: list of all locations in the RapiDAST configuration that might need replacement
+        #  - config_url: URL's placement in the rapidast configuration, under the scanner
+        #  - path: destination for the download
+        #  - config_path: the RapiDAST config entry that will replace `config_url`
+        Change = namedtuple("Change", ["config_url", "path", "config_path"])
+        changes = [
+            Change(
+                "apiScan.apis.apiUrl",
+                f"{self._host_work_dir()}/openapi.json",
+                "apiScan.apis.apiFile",
+            ),
+            Change(
+                "graphql.schemaUrl",
+                f"{self._host_work_dir()}/schema.graphql",
+                "graphql.schemaFile",
+            ),
+        ]
+
+        for change in changes:
+            url = self.my_conf(change.config_url)
+            if url:
+                if authenticated_download_with_rtoken(url, change.path, auth, proxy):
+                    logging.info(
+                        f"Successful download of scanner's {change.config_url}"
+                    )
+                    self.config.set(
+                        f"scanners.{self.ident}.{change.config_path}", change.path
+                    )
+                    self.config.delete(f"scanners.{self.ident}.{change.config_url}")
+                else:
+                    logging.warning("Failed to download scanner's {change.config_url}")
 
 
 # Given an Automation Framework configuration, return its sub-dictionary corresponding to the context we're going to use

--- a/tests/configmodel/older-schemas/v4.yaml
+++ b/tests/configmodel/older-schemas/v4.yaml
@@ -1,7 +1,4 @@
 # This is a verbose configuration template. A lot of value do not need to be present, for most configuration.
-#
-# Author: Red Hat Product Security
-#
 # See "config-template.yaml" for a simpler configuration file.
 # All the values are optional (except `config.configVersion`): if a key is missing, it will mean either "disabled" or a sensible default will be selected
 
@@ -10,7 +7,7 @@ config:
   # This value tells RapiDAST what schema should be used to read this configuration.
   # Therefore you should only change it if you update the configuration to a newer schema
   # It is intended to keep backward compatibility (newer RapiDAST running an older config)
-  configVersion: 5
+  configVersion: 4
 
   # all the results of all scanners will be stored under that location
   base_results_dir: "./results"
@@ -150,15 +147,11 @@ scanners:
       enableUI: False
       # Defaults to True, set False to prevent auto update of ZAP plugins
       updateAddons: True
-      # If set to True and authentication is oauth2_rtoken: manually download schemas (e.g.: openAPI, GraphQL)
-      oauth2ManualDownload: False
+      # If set to True and authentication is oauth2_rtoken and api.apiUrl is set, download the API outside of ZAP
+      oauth2OpenapiManualDownload: False
 
       # overwrite the default port in case it is required. The default port was selected to avoid any collision with other services
       zapPort: 8080
-
-      # Maximum heap size of the JVM. Default: ¼ of the RAM. acceptable values: [0-9]+[kKmMgG]?
-      # This may be required for large OpenAPI definition
-      memMaxHeap: "6144m"
 
     # (Optional) configure to export scan results to OWASP Defect Dojo.
     # `config.defectDojo` must be configured first.
@@ -182,3 +175,6 @@ scanners:
         #test: 5       # test ID, that will force "reimport" mode
         # additional options, see https://demo.defectdojo.org/api/v2/doc/ for list
         auto_create_context: False  # Optional. set to True to auto-create engagement (requires product_name and engagement_name)
+
+
+# Other scanners to be defined(TBD)

--- a/tests/configmodel/test_convert.py
+++ b/tests/configmodel/test_convert.py
@@ -45,6 +45,28 @@ def test_v2_to_v3(config_v2):
     assert not newconf.exists("scanners.zap.updateAddons")
 
 
+@pytest.fixture(name="config_v4")
+def generate_config_v4():
+    path = "tests/configmodel/older-schemas/v4.yaml"
+    try:
+        with open(path) as file:
+            return configmodel.RapidastConfigModel(yaml.safe_load(file))
+    except yaml.YAMLError as exc:
+        raise RuntimeError(f"Unable to load TEST file {path}") from exc
+
+
+def test_v4_to_v5(config_v4):
+    oldconf = config_v4
+    newconf = configmodel.converter.convert_from_version_4_to_5(oldconf)
+
+    # Check that new path was created
+    assert newconf.get(
+        "scanners.zap.miscOptions.oauth2ManualDownload", "x"
+    ) == oldconf.get("scanners.zap.miscOptions.oauth2OpenapiManualDownload", "y")
+    # Check that old path was deleted
+    assert not newconf.exists("scanners.zap.miscOptions.oauth2OpenapiManualDownload")
+
+
 def test_v1_to_v2(config_v1):
     oldconf = config_v1
     newconf = configmodel.converter.convert_from_version_1_to_2(oldconf)

--- a/tests/scanners/zap/test_setup_podman.py
+++ b/tests/scanners/zap/test_setup_podman.py
@@ -13,7 +13,9 @@ CONFIG_TEMPLATE_LONG = "config/config-template-long.yaml"
 
 @pytest.fixture(scope="function")
 def test_config():
-    return configmodel.RapidastConfigModel()
+    return configmodel.RapidastConfigModel(
+        {"application": {"url": "http://example.com"}}
+    )
 
 
 ## Testing Authentication methods ##


### PR DESCRIPTION
ZAP can't use authenticated user when downloading schemas, such as OpenAPI and GraphQL.

This workaround looks for places with URLs, downloads them and changes the config to point at the file instead.

I tried to make it future proof, in case there are other URLs which we might need to download in the future.

WARNING: I have renamed `oauth2OpenapiManualDownload` into `oauth2ManualDownload`, which is better fitting since it's now used to download GraphQL as well, not just OpenAPI.

This means I updated the config schema from v4 to v5. There is a conversion function from config schema v4 to v5 (i.e.: someone using a config with oauth2OpenapiManualDownload will not see any difference)

Note: I tested with openAPI that it still works, but I dont have the infrastructure for GraphQL.