### PR TITLE
Containerfile: include Firefox ESR for Ajax spidering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -241,3 +241,6 @@ tags
 .idea/
 
 # End of https://www.toptal.com/developers/gitignore/api/vim,linux,python,macos
+
+# curl creates those lude file
+lude

--- a/containerize/Containerfile
+++ b/containerize/Containerfile
@@ -19,6 +19,13 @@ RUN zap.sh -cmd -silent -addonupdate
 ### Copy them to installation directory
 RUN cp /root/.ZAP/plugin/*.zap /opt/zap/plugin/ || :
 
+# Firefox, for Ajax
+RUN microdnf install -y tar bzip2 gtk3 dbus-glib
+RUN mkdir /opt/firefox
+RUN mkdir -p /tmp/firefox
+RUN curl -sfL  'https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=linux64&lang=en-US' | tar xjvf - -C /tmp/firefox
+RUN mv -T /tmp/firefox/firefox /opt/firefox
+ENV PATH $PATH:/opt/firefox/
 
 ## RapiDAST
 RUN mkdir /opt/rapidast


### PR DESCRIPTION
Includes firefox ESR, to enable Ajax spidering in the RapiDAST image (with firefox-headless as browserid)