### PR TITLE
[ZAP] Allow user to override default Java max heap

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,8 @@ Example: `podman pod create --userns=keep-id:uid=1000,gid=1000 myApp_Pod`
 
 + Disable add-on updates: `scanners.zap.miscOptions.updateAddons: False` (default: True): Prior to running, ZAP will update its addons unless this value is `False`
 
++ Force maximum heap size for the JVM: `scanners.zap.miscOptions.memMaxHeap` (default: ¼ of the RAM): Java's `-Xmx` option
+
 Example:
 
 ```yaml
@@ -278,6 +280,7 @@ scanners:
         miscOptions:
             enableUI: True
             updateAddons: False
+            memMaxHeap: "6144m"
 ```
 
 #### Generic scanner
@@ -390,6 +393,33 @@ RapiDAST works around this bug, but with little inconvenients (slower because it
 e.g., in a MacOS installation, `/Applications/OWASP ZAP.app/Contents/Java/plugin/` will be mostly empty. In particular, no `callhome*.zap` and `network*.zap` file are present.
 - Reinstall ZAP, but __DO NOT RUN IT__, as it would delete the plugins. Verify that the directory contains many plugins.
 - `chown` the installation files to root, so that when running ZAP, the application running as the user does not have sufficient permission to delete its own plugins
+
+### ZAP crashing with `java.lang.OutOfMemoryError: Java heap space`
+
+ZAP allows the JVM heap to grow up to a quarter of the RAM. The value can be increased using the `scanners.zap.miscOptions.memMaxHeap` configuration entry
+
+```
+2023-09-04 08:44:37,782 [main ] INFO  CommandLine - Job openapi started
+2023-09-04 08:44:46,985 [main ] INFO  CommandLineBootstrap - OWASP ZAP 2.13.0 terminated.
+2023-09-04 08:44:46,985 [main ] ERROR UncaughtExceptionLogger - Exception in thread "main"
+java.lang.OutOfMemoryError: Java heap space
+        at java.lang.AbstractStringBuilder.<init>(AbstractStringBuilder.java:86) ~[?:?]
+        at java.lang.StringBuilder.<init>(StringBuilder.java:116) ~[?:?]
+        at com.fasterxml.jackson.core.util.TextBuffer.contentsAsString(TextBuffer.java:487) ~[?:?]
+        at com.fasterxml.jackson.core.io.SegmentedStringWriter.getAndClear(SegmentedStringWriter.java:99) ~[?:?]
+        at com.fasterxml.jackson.databind.ObjectWriter.writeValueAsString(ObjectWriter.java:1141) ~[?:?]
+        at io.swagger.v3.core.util.Json.pretty(Json.java:24) ~[?:?]
+        at org.zaproxy.zap.extension.openapi.ExtensionOpenApi.importOpenApiDefinitionV2(ExtensionOpenApi.java:371) ~[?:?]
+        at org.zaproxy.zap.extension.openapi.automation.OpenApiJob.runJob(OpenApiJob.java:123) ~[?:?]
+        at org.zaproxy.addon.automation.ExtensionAutomation.runPlan(ExtensionAutomation.java:366) ~[?:?]
+        at org.zaproxy.addon.automation.ExtensionAutomation.runAutomationFile(ExtensionAutomation.java:507) ~[?:?]
+        at org.zaproxy.addon.automation.ExtensionAutomation.execute(ExtensionAutomation.java:621) ~[?:?]
+        at org.parosproxy.paros.extension.ExtensionLoader.runCommandLine(ExtensionLoader.java:553) ~[zap-2.13.0.jar:2.13.0]
+        at org.parosproxy.paros.control.Control.runCommandLine(Control.java:426) ~[zap-2.13.0.jar:2.13.0]
+        at org.zaproxy.zap.CommandLineBootstrap.start(CommandLineBootstrap.java:91) ~[zap-2.13.0.jar:2.13.0]
+        at org.zaproxy.zap.ZAP.main(ZAP.java:94) ~[zap-2.13.0.jar:2.13.0]
+```
+
 
 ## Caveats
 

--- a/config/config-template-zap-long.yaml
+++ b/config/config-template-zap-long.yaml
@@ -156,6 +156,10 @@ scanners:
       # overwrite the default port in case it is required. The default port was selected to avoid any collision with other services
       zapPort: 8080
 
+      # Maximum heap size of the JVM. Default: ¼ of the RAM. acceptable values: [0-9]+[kKmMgG]?
+      # This may be required for large OpenAPI definition
+      memMaxHeap: "6144m"
+
     # (Optional) configure to export scan results to OWASP Defect Dojo.
     # `config.defectDojo` must be configured first.
     defectDojoExport:

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -2,6 +2,7 @@ import glob
 import logging
 import os
 import pprint
+import re
 import shutil
 import tarfile
 from base64 import urlsafe_b64encode
@@ -201,6 +202,16 @@ class Zap(RapidastScanner):
         standard.extend(
             ["-config", f"network.localServers.mainProxy.port={local_port}"]
         )
+
+        # By default, ZAP allocates ¼ of the available RAM to the Java process.
+        # This is not efficient when RapiDAST is executed in a dedicated environment.
+        jmem = self.my_conf("miscOptions.memMaxHeap")
+        if jmem:
+            logging.debug(f"Memory allocation override: {jmem}")
+            if not re.search("^[0-9]+[kmg]?$", jmem, flags=re.IGNORECASE):
+                logging.warning(f"Invalid value miscOptions.memMaxHeap: {jmem}")
+            else:
+                standard.append(f"-Xmx{jmem}")
 
         return standard
 

--- a/tests/scanners/zap/test_setup_podman.py
+++ b/tests/scanners/zap/test_setup_podman.py
@@ -19,15 +19,6 @@ def test_config():
 ## Testing Authentication methods ##
 
 
-def test_setup_import_urls(test_config):
-    # trick: set this very file as import
-    test_config.set("scanners.zap.importUrlsFromFile", __file__)
-
-    test_zap = ZapPodman(config=test_config)
-    test_zap.setup()
-    assert Path(test_zap._host_work_dir(), "importUrls.txt").is_file()
-
-
 def test_setup_authentication_no_auth_configured(test_config):
     print(test_config.get("general"))
 
@@ -155,6 +146,15 @@ def test_setup_authentication_auth_rtoken_configured(test_config):
 ## Testing APIs & URLs ##
 
 
+def test_setup_import_urls(test_config):
+    # trick: set this very file as import
+    test_config.set("scanners.zap.importUrlsFromFile", __file__)
+
+    test_zap = ZapPodman(config=test_config)
+    test_zap.setup()
+    assert Path(test_zap._host_work_dir(), "importUrls.txt").is_file()
+
+
 def test_setup_exclude_urls(test_config):
     test_config.set("scanners.zap.urls.excludes", ["abc", "def"])
     test_config.merge(
@@ -262,3 +262,20 @@ def test_setup_report_format(test_config, result_format, expected_template):
             break
     else:
         assert False
+
+
+# Misc tests
+
+
+def test_override_memory_allocation(test_config):
+    # "regular" test
+    test_config.set("scanners.zap.miscOptions.memMaxHeap", "8G")
+    test_zap = ZapPodman(config=test_config)
+    test_zap.setup()
+    assert "-Xmx8G" in test_zap.zap_cli
+
+    # Fail match
+    test_config.set("scanners.zap.miscOptions.memMaxHeap", "8i")
+    test_zap = ZapPodman(config=test_config)
+    test_zap.setup()
+    assert "-Xmx8i" not in test_zap.zap_cli


### PR DESCRIPTION
zap.sh calculates the total RAM, divides by 4 and use that for the `-Xmx` java option.  
Issue: When RapiDAST runs on a dedicated environment (e.g.: pod, VM, etc.), most of the ¾ RAM remaining is wasted.
This commits allows to override the value, which is necessary for parsing large OpenAPI files (several MBs)

pytest added
