### PR TITLE
[ZAP] enforce a '/' at the end of the target URL

### DIFF
--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -271,7 +271,10 @@ class Zap(RapidastScanner):
         try:
             af_context = find_context(self.automation_config)
             app_url = self.config.get("application.url")
-            if app_url:
+            if app_url and isinstance(app_url, str):
+                if not app_url.endswith("/"):
+                    # For some unknonw reason, ZAP appears to behave weirdly if the URL is just the hostname without '/'
+                    app_url = app_url + "/"
                 af_context["urls"].append(app_url)
             else:
                 logging.error("Configuration: ZAP requires an application.url entry")

--- a/tests/scanners/zap/test_setup_podman.py
+++ b/tests/scanners/zap/test_setup_podman.py
@@ -18,6 +18,20 @@ def test_config():
     )
 
 
+## Basic test
+
+
+def test_setup_basic(test_config):
+    test_zap = ZapPodman(config=test_config)
+    test_zap.setup()
+
+    # a '/' should have been appended
+    assert (
+        test_zap.automation_config["env"]["contexts"][0]["urls"][0]
+        == "http://example.com/"
+    )
+
+
 ## Testing Authentication methods ##
 
 


### PR DESCRIPTION
For some unknonw reason, ZAP appears to behave weirdly if the URL is just the hostname without '/'