### PR TITLE
added overrideConfigs option

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,8 @@ scanners:
             memMaxHeap: "6144m"
 ```
 
++ `scanners.zap.miscOptions.overrideConfigs` allows to run additional '-config' options when the ZAP cli command is run. This can be used to set values for certain parameters such as `{namespace}` in the API path
+
 #### Generic scanner
 
 It is possible to request RapiDAST to run a command in a podman image, using the `generic` plugin.

--- a/config/config-template-zap-long.yaml
+++ b/config/config-template-zap-long.yaml
@@ -129,7 +129,6 @@ scanners:
         executable: "zap.sh"  # for Linux
         #executable: "/Applications/OWASP ZAP.app/Contents/Java/zap.sh"    # for MacOS, when general.container.type is 'none' only
 
-
     report:
       format: ["json"]
       #format: ["json","html","sarif","xml"]  # default: "json" only
@@ -160,6 +159,11 @@ scanners:
       # Maximum heap size of the JVM. Default: ¼ of the RAM. acceptable values: [0-9]+[kKmMgG]?
       # This may be required for large OpenAPI definition
       memMaxHeap: "6144m"
+
+      overrideConfigs:
+        - formhandler.fields.field(0).fieldId=namespace
+        - formhandler.fields.field(0).value=default
+
 
     # (Optional) configure to export scan results to OWASP Defect Dojo.
     # `config.defectDojo` must be configured first.

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -203,6 +203,12 @@ class Zap(RapidastScanner):
             ["-config", f"network.localServers.mainProxy.port={local_port}"]
         )
 
+        override_cfg = self.my_conf("miscOptions.overrideConfigs")
+        if override_cfg:
+            for cfgitem in override_cfg:
+                logging.debug(f"override_cfg is set: {cfgitem}")
+                standard.extend(["-config", cfgitem])
+
         # By default, ZAP allocates ¼ of the available RAM to the Java process.
         # This is not efficient when RapiDAST is executed in a dedicated environment.
         jmem = self.my_conf("miscOptions.memMaxHeap")

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -205,9 +205,12 @@ class Zap(RapidastScanner):
 
         override_cfg = self.my_conf("miscOptions.overrideConfigs")
         if override_cfg:
-            for cfgitem in override_cfg:
-                logging.debug(f"override_cfg is set: {cfgitem}")
-                standard.extend(["-config", cfgitem])
+            if isinstance(override_cfg, list):
+                for cfgitem in override_cfg:
+                    logging.debug(f"override_cfg is set: {cfgitem}")
+                    standard.extend(["-config", cfgitem])
+            else:
+                raise ValueError("miscOptions.overrideConfigs must be a list")
 
         # By default, ZAP allocates ¼ of the available RAM to the Java process.
         # This is not efficient when RapiDAST is executed in a dedicated environment.

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -156,6 +156,17 @@ class Zap(RapidastScanner):
     # May be overloaded by inheriting classes                     #
     ###############################################################
 
+    def _zap_cli_list_to_str_for_sh(self, l_zap_cli):
+        # reserved_chars: space is also included
+        reserved_chars = "\"' (),+$!&?|[]"
+
+        # the escaping logic
+        mapper = ["\\" + ele for ele in reserved_chars]
+        result_mapping = str.maketrans(dict(zip(reserved_chars, mapper)))
+
+        # reforming result
+        return " ".join([sub.translate(result_mapping) for sub in l_zap_cli])
+
     def _setup_zap_cli(self):
         """
         Complete the zap_cli list of ZAP argument.
@@ -172,6 +183,16 @@ class Zap(RapidastScanner):
         if not self.my_conf("miscOptions.enableUI", default=False):
             # Disable UI
             self.zap_cli.append("-cmd")
+
+        override_cfg = self.my_conf("miscOptions.overrideConfigs")
+        if override_cfg:
+            if isinstance(override_cfg, list):
+                for cfgitem in override_cfg:
+                    logging.debug(f"override_cfg is set: {cfgitem}")
+
+                    self.zap_cli.extend(["-config", cfgitem])
+            else:
+                raise ValueError("miscOptions.overrideConfigs must be a list")
 
         # finally: the Automation Framework:
         self.zap_cli.extend(["-autorun", f"{self._container_work_dir()}/af.yaml"])
@@ -202,15 +223,6 @@ class Zap(RapidastScanner):
         standard.extend(
             ["-config", f"network.localServers.mainProxy.port={local_port}"]
         )
-
-        override_cfg = self.my_conf("miscOptions.overrideConfigs")
-        if override_cfg:
-            if isinstance(override_cfg, list):
-                for cfgitem in override_cfg:
-                    logging.debug(f"override_cfg is set: {cfgitem}")
-                    standard.extend(["-config", cfgitem])
-            else:
-                raise ValueError("miscOptions.overrideConfigs must be a list")
 
         # By default, ZAP allocates ¼ of the available RAM to the Java process.
         # This is not efficient when RapiDAST is executed in a dedicated environment.

--- a/scanners/zap/zap_none.py
+++ b/scanners/zap/zap_none.py
@@ -138,7 +138,9 @@ class ZapNone(Zap):
 
         # Now the real run
         logging.info(f"Running ZAP with the following command:\n{self.zap_cli}")
-        result = subprocess.run(self.zap_cli, check=False)
+
+        cli = ["sh", "-c", self._zap_cli_list_to_str_for_sh(self.zap_cli)]
+        result = subprocess.run(cli, check=False)
         logging.debug(
             f"ZAP returned the following:\n=====\n{pp.pformat(result)}\n====="
         )

--- a/scanners/zap/zap_podman.py
+++ b/scanners/zap/zap_podman.py
@@ -103,16 +103,21 @@ class ZapPodman(Zap):
         if self.my_conf("miscOptions.updateAddons", default=True):
             # Update scanner as a first command, then actually run ZAP
             # currently, this is done via a `sh -c` wrapper
-            commands = (
+
+            update_command = (
                 self.my_conf("container.parameters.executable")
                 + " "
                 + " ".join(self._get_standard_options())
-                + " -cmd -addonupdate; "
-                + " ".join(self.zap_cli)
+                + " -cmd -addonupdate"
             )
+
+            commands = (
+                update_command + "; " + self._zap_cli_list_to_str_for_sh(self.zap_cli)
+            )
+
             cli = ["sh", "-c", commands]
         else:
-            cli = self.zap_cli
+            cli = ["sh", "-c", self._zap_cli_list_to_str_for_sh(self.zap_cli)]
 
         cli = self.podman.get_complete_cli(cli)
 

--- a/tests/scanners/zap/test_setup_podman.py
+++ b/tests/scanners/zap/test_setup_podman.py
@@ -309,3 +309,11 @@ def test_override_cfg(test_config):
 
     assert override_cfg1 in test_zap.zap_cli
     assert override_cfg2 in test_zap.zap_cli
+
+
+def test_override_non_list_format(test_config):
+    test_config.set("scanners.zap.miscOptions.overrideConfigs", "non-list-item")
+    test_zap = ZapPodman(config=test_config)
+
+    with pytest.raises(ValueError):
+        test_zap.setup()

--- a/tests/scanners/zap/test_setup_podman.py
+++ b/tests/scanners/zap/test_setup_podman.py
@@ -295,3 +295,17 @@ def test_override_memory_allocation(test_config):
     test_zap = ZapPodman(config=test_config)
     test_zap.setup()
     assert "-Xmx8i" not in test_zap.zap_cli
+
+
+def test_override_cfg(test_config):
+    override_cfg1 = "formhandler.fields.field(0).fieldId=namespace"
+    override_cfg2 = "formhandler.fields.field(0).value=default"
+
+    test_config.set(
+        "scanners.zap.miscOptions.overrideConfigs", [override_cfg1, override_cfg2]
+    )
+    test_zap = ZapPodman(config=test_config)
+    test_zap.setup()
+
+    assert override_cfg1 in test_zap.zap_cli
+    assert override_cfg2 in test_zap.zap_cli

--- a/tests/scanners/zap/test_setup_podman.py
+++ b/tests/scanners/zap/test_setup_podman.py
@@ -307,8 +307,12 @@ def test_override_cfg(test_config):
     test_zap = ZapPodman(config=test_config)
     test_zap.setup()
 
-    assert override_cfg1 in test_zap.zap_cli
-    assert override_cfg2 in test_zap.zap_cli
+    assert f"{override_cfg1}" in test_zap.zap_cli
+    assert f"{override_cfg2}" in test_zap.zap_cli
+
+    assert r"formhandler.fields.field\(0\)" in test_zap._zap_cli_list_to_str_for_sh(
+        test_zap.zap_cli
+    )
 
 
 def test_override_non_list_format(test_config):


### PR DESCRIPTION
`scanners.zap.miscOptions.overrideConfigs` allows to run additional '-config' options when the ZAP cli command is run. This can be used to set values for certain parameters such as `{namespace}` in the API path.