### PR TITLE
[containerfile] chown rapidast home

### DIFF
--- a/containerize/Containerfile
+++ b/containerize/Containerfile
@@ -61,6 +61,7 @@ RUN echo rapidast:rapidast | chpasswd
 # for compability to run with latest Helm chart with RapiDAST v2.2.0 or before
 RUN mkdir /home/rapidast/.ZAP
 RUN ln -sfn  /opt/rapidast/scanners/zap/policies /home/rapidast/.ZAP/policies
+RUN chown -R rapidast:rapidast /home/rapidast
 
 USER rapidast
 WORKDIR /home/rapidast


### PR DESCRIPTION
to prevent the following when running with the rapidast image:

```
The home path is not writable: /home/rapidast/.ZAP/
Found Java version 11.0.20
Available memory: 15979 MB
Using JVM args: -Xmx3994m
The home path is not writable: /home/rapidast/.ZAP/
WARNING:The ZAP process did not finish correctly, and exited with code 1
INFO:Running postprocess for the ZAP Podman environment
Traceback (most recent call last):
  File "/home/cedric/prodsec/rapidast/rapidast/./rapidast.py", line 224, in <module>
    run()
  File "/home/cedric/prodsec/rapidast/rapidast/./rapidast.py", line 209, in run
    ret = run_scanner(name, config, args, defect_d)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/cedric/prodsec/rapidast/rapidast/./rapidast.py", line 106, in run_scanner
    scanner.postprocess()
  File "/home/cedric/prodsec/rapidast/rapidast/scanners/zap/zap_podman.py", line 146, in postprocess
    raise RuntimeError(
RuntimeError: No post-processing as ZAP has not successfully run yet.
```