### PR TITLE
[ZAP] Adds ability to install addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,8 @@ Example: `podman pod create --userns=keep-id:uid=1000,gid=1000 myApp_Pod`
 
 + Disable add-on updates: `scanners.zap.miscOptions.updateAddons: False` (default: True): Prior to running, ZAP will update its addons unless this value is `False`
 
++ Install additional addons: `scanners.zap.miscOptions.additionalAddons: "comma,separated,list,of,addons"` (default: []): Prior to running, ZAP will install a given list of addons. The list can be provided either as a YAML list, or a string of the addons, separated by a comma
+
 + Force maximum heap size for the JVM: `scanners.zap.miscOptions.memMaxHeap` (default: ¼ of the RAM): Java's `-Xmx` option
 
 Example:

--- a/config/config-template-zap-long.yaml
+++ b/config/config-template-zap-long.yaml
@@ -146,10 +146,15 @@ scanners:
       #  - "^https?://example.com:3000/do-not-descend-here/.*$"
 
     miscOptions:
-      # EnableUI (default: false), requires a compatible runtime (e.g.: flatpak or no containment)
+      # EnableUI (default: false), requires a compatible runtime (e.g.: `type: none`)
       enableUI: False
+
       # Defaults to True, set False to prevent auto update of ZAP plugins
       updateAddons: True
+
+      # List (comma-separated string or list) of additional addons to install
+      additionalAddons: "ascanrulesBeta"
+
       # If set to True and authentication is oauth2_rtoken: manually download schemas (e.g.: openAPI, GraphQL)
       oauth2ManualDownload: False
 

--- a/config/config-template-zap-mac.yaml
+++ b/config/config-template-zap-mac.yaml
@@ -55,3 +55,7 @@ scanners:
       parameters:
         image: "docker.io/owasp/zap2docker-stable:latest" # for type such as podman
         executable: "/Applications/OWASP ZAP.app/Contents/Java/zap.sh"    # for MacOS, when general.container.type is 'none' only, need to download OWASP ZAP https://www.zaproxy.org/download/
+
+    miscOptions:
+      # List (comma-separated string or list) of additional addons to install
+      additionalAddons: "ascanrulesBeta"

--- a/config/config-template-zap-simple.yaml
+++ b/config/config-template-zap-simple.yaml
@@ -54,3 +54,7 @@ scanners:
     # The list of policies can be found in scanners/zap/policies/
     #activeScan:
     #  policy: "API-scan-minimal"
+
+    miscOptions:
+      # List (comma-separated string or list) of additional addons to install
+      additionalAddons: "ascanrulesBeta"

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -154,6 +154,37 @@ class Zap(RapidastScanner):
 
         return data, filename
 
+    def get_update_command(self):
+        """Returns a list of all options required to update ZAP plugins"""
+
+        if not (
+            self.my_conf("miscOptions.updateAddons")
+            or self.my_conf("miscOptions.additionalAddons")
+        ):
+            return []
+
+        command = [
+            self.my_conf("container.parameters.executable"),
+            *self._get_standard_options(),
+            "-cmd",
+        ]
+        if self.my_conf("miscOptions.updateAddons", default=True):
+            command.append("-addonupdate")
+
+        addons = self.my_conf("miscOptions.additionalAddons", default=[])
+        if isinstance(addons, str):
+            addons = addons.split(",") if len(addons) else []
+        if not isinstance(addons, list):
+            logging.warning(
+                "miscOptions.additionalAddons MUST be either a list or a string of comma-separated values"
+            )
+            addons = []
+
+        for addon in addons:
+            command.extend(["-addoninstall", addon])
+
+        return command
+
     ###############################################################
     # PROTECTED METHODS                                           #
     # Called via Zap or inheritence only                          #


### PR DESCRIPTION
This adds the ability to install new addons, such as active or passive scanners.
Examples of addons can be found there:
https://github.com/zaproxy/zap-extensions/tree/main/addOns

Addons to be installed as configured as such:

```
scanners:
  zap:
    miscOptions:
      additionalAddons: "ascanrulesBeta,sqliplugin"
```

The `additionalAddons` accepts either a list of a string representing the list, but separated by commas

Also, I added `additionalAddons: "ascanrulesBeta"` in all the ZAP templates