### PR TITLE
[defectdojo] Adding SSL verification management

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,11 +147,18 @@ config:
   # Defect dojo configuration
   defectDojo:
     url: "https://mydefectdojo.example.com/"
+    ssl: [True | False | "/path/to/CA"]
     authorization:
       username: "rapidast_productname"
       password: "password"
       # alternatively, a `token` entry can be set in place of username/password
 ```
+
+the `ssl` parameter is provided as Requests' `verify` parameter. It can be either:
+- True: SSL verification is mandatory, against the default CA bundle
+- False: SSL verification is not mandatory (but prints a warning if it fails)
+- /path/to/CA: a bundle of CAs to verify from
+Alternatively, the `REQUESTS_CA_BUNDLE` environment variable can be used to select a CA bundle file. If nothing is provided, the default value will be `True`
 
 You can either authenticate using a username/password combination, or a token (make sure it is not expired). In either case, you can use the `_from_var` method described in previous chapter to avoid hardcoding the value in the configuration.
 

--- a/rapidast.py
+++ b/rapidast.py
@@ -196,9 +196,16 @@ def run():
     if config.get("config.defectDojo.url"):
         defect_d = DefectDojo(
             config.get("config.defectDojo.url"),
-            config.get("config.defectDojo.authorization.username"),
-            config.get("config.defectDojo.authorization.password"),
+            {
+                "username": config.get(
+                    "config.defectDojo.authorization.username", default=""
+                ),
+                "password": config.get(
+                    "config.defectDojo.authorization.password", default=""
+                ),
+            },
             config.get("config.defectDojo.authorization.token"),
+            config.get("config.defectDojo.ssl", default=True),
         )
 
     # Run all scanners

--- a/tests/test_defectdojo_integration.py
+++ b/tests/test_defectdojo_integration.py
@@ -21,7 +21,23 @@ def test_dd_auth_and_set_token_no_username():
 def test_dd_auth_and_set_token_non_existent_url():
     # assuming 127.0.0.1:12345 is non-existent
     defect_d = DefectDojo(
-        "https://127.0.0.1:12345", "random_username", "random_password", "random_token"
+        "https://127.0.0.1:12345",
+        {"username": "random_username", "password": "random_password"},
+        "random_token",
     )
     with pytest.raises(requests.exceptions.ConnectionError):
         defect_d._auth_and_set_token()
+
+
+def test_dd_parameters():
+    defect_d = DefectDojo("https://127.0.0.1:12345", token="random_token")
+
+    assert defect_d.params["timeout"] == DefectDojo.DD_CONNECT_TIMEOUT
+    with pytest.raises(KeyError):
+        defect_d.params["verify"]
+
+    defect_d = DefectDojo(
+        "https://127.0.0.1:12345", token="random_token", ssl="CAbundle"
+    )
+    assert defect_d.params["timeout"] == DefectDojo.DD_CONNECT_TIMEOUT
+    assert defect_d.params["verify"] == "CAbundle"


### PR DESCRIPTION
Either:
- REQUESTS_CA_BUNDLE points to the CA bundle
- `config.defectDojo.ssl` is:
  + False: verification is optional
  + True: verification is mandatory (default behavior)
  + path to CA bundle: verification is mandatory, and this bundle is used