### PR TITLE
[ZAP] really disable passive scan when it's off

### DIFF
--- a/tests/scanners/zap/test_setup_podman.py
+++ b/tests/scanners/zap/test_setup_podman.py
@@ -32,6 +32,14 @@ def test_setup_basic(test_config):
         == "http://example.com/"
     )
 
+    # Test that a passive scan is added with all rules actively disabled
+    for item in test_zap.automation_config["jobs"]:
+        if item["type"] == "passiveScan-config":
+            assert item["parameters"]["disableAllRules"] == True
+            break
+    else:
+        assert False
+
 
 ## Testing Authentication methods ##
 


### PR DESCRIPTION
Regardless of whether passive-scan is added or not in the Automation Framework, ZAP will always do the passive scan.

Which means that when no passive-scan was added to RapiDAST configuration, a default scan was running instead.

This fixes it, by adding a passive scan, but with all rules disabled.

Also added pytest