### PR TITLE
Disable the comment inj rule which is not using oast

### DIFF
--- a/scanners/zap/policies/Operator-scan.policy
+++ b/scanners/zap/policies/Operator-scan.policy
@@ -91,8 +91,8 @@
             <level>OFF</level>
         </p90019>
         <p90020>
-            <enabled>true</enabled>
-            <level>DEFAULT</level>
+            <enabled>false</enabled>
+            <level>OFF</level>
         </p90020>
         <p90021>
             <enabled>false</enabled>


### PR DESCRIPTION
Since the command injection rule is not using OAST yet, it is not effective when scanning Operators.