### PR TITLE
Fix Helm chart permission issue

### DIFF
--- a/containerize/Containerfile
+++ b/containerize/Containerfile
@@ -58,10 +58,5 @@ RUN chmod -R g+w /opt/rapidast
 RUN useradd -u 1000 -d /home/rapidast -m -s /bin/bash -G dast rapidast
 RUN echo rapidast:rapidast | chpasswd
 
-# for compability to run with latest Helm chart with RapiDAST v2.2.0 or before
-RUN mkdir /home/rapidast/.ZAP
-RUN ln -sfn  /opt/rapidast/scanners/zap/policies /home/rapidast/.ZAP/policies
-RUN chown -R rapidast:rapidast /home/rapidast
-
 USER rapidast
-WORKDIR /home/rapidast
+WORKDIR /opt/rapidast

--- a/containerize/Containerfile
+++ b/containerize/Containerfile
@@ -54,6 +54,9 @@ RUN groupadd dast
 RUN chown -R :dast /opt/rapidast
 RUN chmod -R g+w /opt/rapidast
 
+# Allow a user of random UID(e.g. on OpenShift) to create a custom scan policy file
+RUN chmod -R a+w /opt/rapidast/scanners/zap/policies
+
 
 RUN useradd -u 1000 -d /home/rapidast -m -s /bin/bash -G dast rapidast
 RUN echo rapidast:rapidast | chpasswd

--- a/helm/chart/templates/_helpers.tpl
+++ b/helm/chart/templates/_helpers.tpl
@@ -46,7 +46,7 @@ template:
       # Since Helm configmap cannot handle the dash character but the policy name undner  scanPolicyXML' in 'values.yaml' is 'helm-custom-scan', the dest file name of the copy command is 'helm-custom-scan.policy'.
       # This file will be used if the rapidast config specifies 'helm-custom-scan' for the activeScan policy.
       # Otherwise, '/home/rapidast/.ZAP/policies/API-scan-minimal.policy' will be used by default.
-      command: ["sh", "-c", "cp /helm/config/helmcustomscan.policy /home/rapidast/.ZAP/policies/helm-custom-scan.policy && rapidast.py --config /helm/config/rapidastconfig.yaml"]
+      command: ["sh", "-c", "cp /helm/config/helmcustomscan.policy /opt/rapidast/scanners/zap/policies/helm-custom-scan.policy && rapidast.py --config /helm/config/rapidastconfig.yaml"]
       imagePullPolicy: {{ .Values.image.pullPolicy }}
       resources:
         {{- toYaml .Values.resources | nindent 8 }}


### PR DESCRIPTION
Fix https://github.com/RedHatProductSecurity/rapidast/issues/153.

Now the policy is copied into /opt/rapidast/scanners/zap/policies directly. 