### PR TITLE
handle a few cases when apiScan is setup

### DIFF
--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -417,6 +417,13 @@ class Zap(RapidastScanner):
     def _setup_api(self):
         """Prepare an openapi job and append it to the job list"""
 
+        api_scan = self.my_conf("apiScan")
+
+        if not api_scan:
+            # this case is normal when a user wants to test with spider, without openapi files
+            logging.debug("No API scan config exists")
+            return
+
         openapi = {"name": "openapi", "type": "openapi", "parameters": {}}
         api_url = self.my_conf("apiScan.apis.apiUrl")
         api_file = self.my_conf("apiScan.apis.apiFile")
@@ -432,9 +439,11 @@ class Zap(RapidastScanner):
 
             openapi["parameters"]["apiFile"] = container_openapi_file
         else:
-            logging.warning("No API defined in the config, in apiScan.api")
-        # default target: main URL, or can be overridden in apiScan
+            raise ValueError(
+                "No apiUrl or apiFile is defined in the config, in apiScan.apis"
+            )
 
+        # default target: main URL, or can be overridden in apiScan
         openapi["parameters"]["targetUrl"] = self._append_slash_to_url(
             self.my_conf("apiScan.target") or self.config.get("application.url")
         )

--- a/tests/scanners/zap/test_setup.py
+++ b/tests/scanners/zap/test_setup.py
@@ -48,6 +48,26 @@ def test_setup_openapi(test_config):
         assert False
 
 
+def test_setup_no_api_config(test_config):
+    # test ValueError is raised when neither apiUrl nor apiFile exists
+    test_config.set("scanners.zap.apiScan", "target")
+    test_zap = ZapNone(config=test_config)
+
+    with pytest.raises(ValueError):
+        test_zap.setup()
+
+    # the following must not raise error as apiUrl has been now defined
+    test_config.set("scanners.zap.apiScan.apis.apiUrl", "http://random.com")
+    test_zap = ZapNone(config=test_config)
+
+    test_zap.setup()
+
+    test_config.set("scanners.zap.apiScan.apis.apiFile", "api_file")
+    test_zap = ZapNone(config=test_config)
+
+    test_zap.setup()
+
+
 ## Testing Authentication methods ##
 ### Handling Authentication is different depending on the container.type so it'd be better to have test cases separately
 


### PR DESCRIPTION
- Handle properly when apiScan is not necessary. Now, no 'openapi' job is going to be created in af.yaml
- Add error handling when apiUrl or apiFile is not specified