### PR TITLE
[ZAP] accepts report.format as string

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
   # R1705: Unnecessary "elif" after "return", remove the leading "el" from "elif" (no-else-return)
   # R1710: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
   - repo: https://github.com/PyCQA/pylint
-    rev: v2.17.4
+    rev: v3.0.3
     hooks:
       - id: pylint
         exclude: ^tests/

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -622,7 +622,13 @@ class Zap(RapidastScanner):
             "xml": ReportFormat("traditional-xml-plus", "zap-report.xml"),
         }
 
-        formats = set(self.my_conf("report.format", {"json"}))
+        formats = self.my_conf("report.format", {"json"})
+        # handle case where user provides a string
+        if isinstance(formats, str):
+            formats = [formats]
+        # remove duplicates
+        formats = set(formats)
+
         # DefectDojo requires XML report type
         if self._should_export_to_defect_dojo():
             logging.debug("ZAP report: ensures XML report for Defect Dojo")

--- a/tests/scanners/zap/test_setup.py
+++ b/tests/scanners/zap/test_setup.py
@@ -318,6 +318,51 @@ def test_setup_report_format(test_config, result_format, expected_template):
         assert False
 
 
+def test_setup_report_string_format(test_config):
+    test_config.set("scanners.zap.report.format", "xml")
+
+    test_zap = ZapNone(config=test_config)
+    test_zap.setup()
+
+    count = 0
+    for item in test_zap.automation_config["jobs"]:
+        if item["type"] == "report":
+            assert item["parameters"]["template"] == "traditional-xml-plus"
+            count += 1
+
+    assert count == 1
+
+
+def test_setup_report_default_format(test_config):
+    test_zap = ZapNone(config=test_config)
+    test_zap.setup()
+
+    count = 0
+    for item in test_zap.automation_config["jobs"]:
+        if item["type"] == "report":
+            assert item["parameters"]["template"] == "traditional-json-plus"
+            count += 1
+
+    assert count == 1
+
+
+def test_setup_report_several_formats(test_config):
+    test_config.set("scanners.zap.report.format", ["xml", "json"])
+    test_zap = ZapNone(config=test_config)
+    test_zap.setup()
+
+    count = 0
+    for item in test_zap.automation_config["jobs"]:
+        if item["type"] == "report":
+            assert item["parameters"]["template"] in {
+                "traditional-json-plus",
+                "traditional-xml-plus",
+            }
+            count += 1
+
+    assert count == 2
+
+
 # Misc tests
 
 


### PR DESCRIPTION
Previously, when `report.format` was provided as a string instead of a list, it would be forced into a list (i.e.: "xml" becomes the list ["x", "m", "l"], and since none of them are valid, it will just do the default one).

Because `format` is singular, it might be expected that a user provides a string instead of a list with a single element.
If this happens, the string is now turned into a list of a single element.

Also: update pre_commit's pylint version.
The previous version was no longer compatible with python version 3.12. Resulting in pre_commit crash.