### PR TITLE
Support generic scanning in 'none' container type mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,8 @@ repos:
   # R1705: Unnecessary "elif" after "return", remove the leading "el" from "elif" (no-else-return)
   # R1710: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
   - repo: https://github.com/PyCQA/pylint
-    rev: v3.0.3
+    #rev: v3.0.3
+    rev: v2.17.4
     hooks:
       - id: pylint
         exclude: ^tests/

--- a/README.md
+++ b/README.md
@@ -386,9 +386,21 @@ scanners:
 
 #### Generic scanner
 
-(`*.container.type: podman` type only) RapiDAST can run other scanning tools as well as ZAP when running RapiDAST with podman.  It is possible to request RapiDAST to run a command in a podman image, using the `generic` plugin.
+RapiDAST can run other scanning tools as well as ZAP. It is possible to request RapiDAST to run a command and process stdout results, using the `generic` plugin.
 
-For example, to run [Trivy](https://github.com/aquasecurity/trivy) and make it scan itself, and store its output as a result:
+The following is an example to run a command or a tool in the host where a RapiDAST scan runs:
+
+```yaml
+scanners:
+  generic:
+    results: "*stdout"
+
+    # this config is used when container.type is not 'podman'
+    toolDir: scanners/generic/tools
+    inline: "echo 'any scan'"
+```
+
+The following is another example to run a [Trivy](https://github.com/aquasecurity/trivy) scan using the container image:
 
 ```yaml
 scanners:

--- a/config/config-template-generic-scan.yaml
+++ b/config/config-template-generic-scan.yaml
@@ -33,13 +33,17 @@ scanners:
     # This config can be combined into ZAP scan config file if the 'podman' container type is used for it too
 
     # A path to file or directory where results are stored on the host. Note this needs to be used along with the 'volumes' configuration
-    results: "/path/to/results"   # if None or "*stdout", the command's standard output is selected
+    # results: "/path/to/results"   # if None or "*stdout", the command's standard output is selected
 
-    container:
-      type: "podman"    # currently, only "podman" type is supported
-      parameters:
+    # this config is used when container.type is not 'podman'
+    # toolDir: scanners/generic/tools
+    # inline: "<command to run>"
+
+    # this config is only used when container.type is 'podman'
+    # container:
+        #parameters:
         # Mandatory: image name to run
-        image: "<container image name>"
+        #image: "<container image name>"
 
         # Optional: command to run. By default, the image's ENTRYPOINT will be run
         #command: "<command to run in the container>"

--- a/config/config-template-multi-scan.yaml
+++ b/config/config-template-multi-scan.yaml
@@ -61,9 +61,14 @@ scanners:
     # A path to file or directory where results are stored on the host. Note this needs to be used along with the 'volumes' configuration
     results: "*stdout"   # if None or "*stdout", the command's standard output is selected
 
-    container:
-      type: "podman"    # currently, only "podman" type is supported
-      parameters:
+    # this config is used when container.type is not 'podman'
+    # toolDir: scanners/generic/tools
+    # inline: "<command to run>"
+
+    # this config is only used when container.type is 'podman'
+    #container:
+      #type: "podman"    # currently, only "podman" type is supported
+      #parameters:
         # Mandatory: image name to run
-        image: "<container image name>"
-        command: "<command to run in the container>" # Optional: By default, the image's ENTRYPOINT will be run
+        #image: "<container image name>"
+        #command: "<command to run in the container>" # Optional: By default, the image's ENTRYPOINT will be run

--- a/scanners/generic/generic_none.py
+++ b/scanners/generic/generic_none.py
@@ -1,0 +1,174 @@
+import logging
+import pprint
+import shlex
+import subprocess
+
+from scanners import State
+from scanners.generic.generic import Generic
+
+CLASSNAME = "GenericNone"
+
+
+pp = pprint.PrettyPrinter(indent=4)
+
+
+class GenericNone(Generic):
+    ###############################################################
+    # PRIVATE CONSTANTS                                           #
+    # Accessed by genericNone only                                  #
+    ###############################################################
+    DEFAULT_GENERIC_TOOL_DIR = "scanners/generic/tools/"
+    ###############################################################
+    # PROTECTED CONSTANTS                                         #
+    # Accessed by parent generic object                               #
+    ###############################################################
+
+    def __init__(self, config, ident="generic"):
+        """Initialize all vars based on the config.
+        The code of the function only deals with the "no container" layer, the "generic" layer is handled by super()
+        """
+
+        logging.debug("Initializing a local instance of the generic scanner")
+
+        self.generic_cli = ""
+        self.state = State.UNCONFIGURED
+        self.tool_dir = self.DEFAULT_GENERIC_TOOL_DIR
+
+        super().__init__(config, ident)
+
+    ###############################################################
+    # PUBLIC METHODS                                              #
+    # Accessed by RapiDAST                                        #
+    # + MUST be implemented                                       #
+    # + SHOULD call super().<method>                              #
+    # + list: setup(), run(), postprocess(), cleanup()            #
+    ###############################################################
+
+    def setup(self):
+        """Prepares everything:
+        - the command line to run
+        - environment variables
+        - files & directory
+
+        The code of the function only deals with the "no container" layer
+        """
+
+        if self.state != State.UNCONFIGURED:
+            raise RuntimeError(
+                f"generic_none setup encountered an unexpected state: {self.state}"
+            )
+
+        self._setup_generic_cli()
+
+        logging.debug(f"tool_dir is set to {self.tool_dir}")
+        self.tool_dir = self.my_conf("toolDir", self.DEFAULT_GENERIC_TOOL_DIR)
+
+        super().setup()
+
+        if self.state != State.ERROR:
+            self.state = State.READY
+
+    def run(self):
+        """If the state is READY, run the final run command.
+        There is no need to call super() here.
+        """
+        logging.info("Running up the generic scanner")
+        if not self.state == State.READY:
+            raise RuntimeError("[generic SCANNER]: ERROR, not ready to run")
+
+        cli = self.generic_cli
+
+        # The result is stdout if "results" is undefined or `*stdout`
+        stdout_store = (
+            subprocess.PIPE
+            if not self.my_conf("results") or self.my_conf("results") == "*stdout"
+            else None
+        )
+
+        # DO STUFF
+
+        logging.info(f"Running a generic scan with the following command:\n{cli}")
+
+        # run the command in the tool_dir
+
+        scanning_stdout_results = ""
+        with subprocess.Popen(
+            cli,
+            cwd=self.tool_dir,
+            stdout=stdout_store,
+            bufsize=1,
+            universal_newlines=True,
+        ) as scanning:
+            if stdout_store:
+                logging.debug("Storing standard output")
+                for line in scanning.stdout:
+                    print(line, end="")
+                    scanning_stdout_results += line
+        logging.debug(
+            f"generic returned the following:\n=====\n{pp.pformat(scanning)}\n====="
+        )
+
+        if scanning.returncode in self.my_conf(
+            "container.parameters.validReturns", [0]
+        ):
+            logging.info(
+                f"The generic process finished correctly, and exited with code {scanning.returncode}"
+            )
+            self.state = State.DONE
+        else:
+            logging.warning(
+                f"The generic process did not finish correctly, and exited with code {scanning.returncode}"
+            )
+            self.state = State.ERROR
+
+        # If we captured an output, let's save it into a temporary file, and use that as a new result parameter
+        if stdout_store:
+            report_path = f"{self.workdir}/stdout-report.txt"
+            with open(report_path, "w", encoding="utf-8") as results:
+                results.write(scanning_stdout_results)
+            # Now that the result is a file, change the config to point to it
+            logging.debug(
+                f"Overloading {self.ident} config result parameter to {report_path}"
+            )
+            self.set_my_conf("results", value=report_path, overwrite=True)
+
+    def postprocess(self):
+        logging.info("Running postprocess for the generic environment")
+        if not self.state == State.DONE:
+            raise RuntimeError(
+                "No post-processing as generic has not successfully run yet."
+            )
+
+        super().postprocess()
+
+        if not self.state == State.ERROR:
+            self.state = State.PROCESSED
+
+    def cleanup(self):
+        logging.info("Running cleanup for the generic environment")
+
+        if not self.state == State.PROCESSED:
+            raise RuntimeError("No cleanning up as generic did not processed results.")
+
+        super().cleanup()
+
+        if not self.state == State.ERROR:
+            self.state = State.CLEANEDUP
+
+    ###############################################################
+    # PROTECTED METHODS                                           #
+    # Accessed by generic parent only                                 #
+    # + MUST be implemented                                       #
+    ###############################################################
+
+    def _setup_generic_cli(self):
+        """
+        Generate the main generic command line (not the container command).
+        Uses super() to generate the generic part of the command
+        """
+
+        self.generic_cli = self.my_conf("inline")
+        if isinstance(self.generic_cli, str):
+            self.generic_cli = shlex.split(self.generic_cli)
+
+        logging.debug(f"generic will run with: {self.generic_cli}")

--- a/scanners/generic/tools/generic_sample_script.sh
+++ b/scanners/generic/tools/generic_sample_script.sh
@@ -1,0 +1,52 @@
+#/bin/sh
+# RapiDAST generic scan tool example
+# Any script or tool can be used for scanning, but ideally it is recommended to provide results in SARIF for further integration
+
+cat <<DELIM
+{
+   "runs": [
+      {
+         "results": [
+            {
+               "level": "error",
+               "locations": [
+                  {
+                     "physicalLocation": {
+                        "artifactLocation": {
+                           "uri": "target_artifact"
+                        }
+                     }
+                  }
+               ],
+               "message": {
+                  "text": "A vulnerability FOUND"
+               },
+               "ruleId": "RAPIDAST00001"
+            }
+         ],
+         "tool": {
+            "driver": {
+               "name": "rapidast_generic_tool",
+               "rules": [
+                  {
+                     "id": "RAPIDAST00001",
+                     "defaultConfiguration": {
+                        "level": "error"
+                     },
+                     "name": "A vulnerability FOUND",
+                     "shortDescription": {
+                        "text": "A vulnerability FOUND"
+                     }
+                  }
+
+               ],
+               "version": "0.0.1"
+            }
+         }
+      }
+   ],
+   "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+   "version": "2.1.0"
+}
+
+DELIM

--- a/tests/scanners/generic/test_generic.py
+++ b/tests/scanners/generic/test_generic.py
@@ -1,6 +1,7 @@
 import pytest
 
 import configmodel
+from scanners.generic.generic_none import GenericNone
 from scanners.generic.generic_podman import GenericPodman
 
 
@@ -29,3 +30,21 @@ def test_generic_podman_volume(test_config):
     scanner = GenericPodman(config=test_config)
     scanner.setup()
     assert {"--volume", "abc:def"}.issubset(set(scanner.podman.get_complete_cli()))
+
+
+def test_generic_none_inline(test_config):
+    test_config.set("scanners.generic.inline", "tmp_cmd")
+
+    scanner = GenericNone(config=test_config)
+    scanner.setup()
+    assert scanner.generic_cli[0] == "tmp_cmd"
+
+
+def test_generic_none_tool_dir(test_config):
+    scanner = GenericNone(config=test_config)
+    assert scanner.tool_dir == "scanners/generic/tools/"
+
+    test_config.set("scanners.generic.toolDir", "/tmp/tooldir")
+    scanner = GenericNone(config=test_config)
+    scanner.setup()
+    assert scanner.tool_dir == "/tmp/tooldir"


### PR DESCRIPTION
Now RapiDAST can run any commands in the host when container.type is **NOT** 'podman'  (i.e 'none' mode)

- config template is default to 'none' mode
- new options: see the proposed config template file.
  - `toolDir`: where scripts and tools are placed  ( this dir will be used as working directory when the inline command is run )
  -  `inline`: command to run (see the config template file)
- the original 'container.parameters' options will be only applied when container.type **is** 'podman'  
