### PR TITLE
[containerfile] optimize image size

### DIFF
--- a/containerize/Containerfile
+++ b/containerize/Containerfile
@@ -2,42 +2,41 @@
 # Build RapiDAST image
 #####
 
-# build and install scanners in advance (more scanners will be added)
+# Prepare dependencies
+FROM registry.access.redhat.com/ubi9-minimal AS deps
+
+RUN microdnf install -y tar gzip bzip2 java-11-openjdk
+
+## ZAP, build and install scanners in advance (more scanners will be added)
+RUN mkdir -p /opt/zap /tmp/zap && \
+  curl -sfL 'https://github.com/zaproxy/zaproxy/releases/download/v2.13.0/ZAP_2.13.0_Linux.tar.gz' | tar zxvf - -C /tmp/zap && \
+  mv -T /tmp/zap/ZAP_2.13.0 /opt/zap && \
+  ### Update add-ons
+  /opt/zap/zap.sh -cmd -silent -addonupdate && \
+  ### Copy them to installation directory
+  cp /root/.ZAP/plugin/*.zap /opt/zap/plugin/ || :
+
+## Firefox, for Ajax
+RUN mkdir -p /opt/firefox /tmp/firefox && \
+  curl -sfL 'https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=linux64&lang=en-US' | tar xjvf - -C /tmp/firefox && \
+  mv -T /tmp/firefox/firefox /opt/firefox
+
+# Copy artifacts from deps to build RapiDAST
 FROM registry.access.redhat.com/ubi9-minimal
 
-RUN microdnf install -y procps tar gzip shadow-utils java-11-openjdk git
-
-## ZAP
-RUN mkdir /opt/zap
-RUN mkdir -p /tmp/zap
-RUN curl -sfL https://github.com/zaproxy/zaproxy/releases/download/v2.13.0/ZAP_2.13.0_Linux.tar.gz | tar zxvf - -C /tmp/zap
-RUN mv -T /tmp/zap/ZAP_2.13.0 /opt/zap
-ENV PATH $PATH:/opt/zap/:/opt/rapidast/
-
-### Update add-ons
-RUN zap.sh -cmd -silent -addonupdate
-### Copy them to installation directory
-RUN cp /root/.ZAP/plugin/*.zap /opt/zap/plugin/ || :
-
-# Firefox, for Ajax
-RUN microdnf install -y tar bzip2 gtk3 dbus-glib
-RUN mkdir /opt/firefox
-RUN mkdir -p /tmp/firefox
-RUN curl -sfL  'https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=linux64&lang=en-US' | tar xjvf - -C /tmp/firefox
-RUN mv -T /tmp/firefox/firefox /opt/firefox
-ENV PATH $PATH:/opt/firefox/
+COPY --from=deps /opt/zap /opt/zap
+COPY --from=deps /opt/firefox /opt/firefox
+ENV PATH $PATH:/opt/zap/:/opt/rapidast/:/opt/firefox/
 
 ## RapiDAST
 RUN mkdir /opt/rapidast
-
-COPY ./rapidast.py /opt/rapidast/
+COPY ./rapidast.py ./requirements.txt /opt/rapidast/
 COPY ./scanners/ /opt/rapidast/scanners/
 COPY ./tools/ /opt/rapidast/tools/
 COPY ./exports/ /opt/rapidast/exports/
 COPY ./configmodel/ /opt/rapidast/configmodel/
 COPY ./utils/ /opt/rapidast/utils/
 COPY ./config/ /opt/rapidast/config/
-COPY ./requirements.txt /opt/rapidast/
 
 ### Overload default config (set 'none' as default container type)
 COPY ./containerize/container_default_config.yaml /opt/rapidast/rapidast-defaults.yaml
@@ -46,20 +45,19 @@ COPY ./containerize/container_default_config.yaml /opt/rapidast/rapidast-default
 COPY ./containerize/path_rapidast.sh /etc/profile.d/rapidast.sh
 
 ### Install RapiDAST requirements, globally, so that it's available to any user
-RUN python3 -m ensurepip --upgrade
-RUN pip3 install -r /opt/rapidast/requirements.txt
+RUN microdnf install -y --setopt=install_weak_deps=0 java-11-openjdk shadow-utils gtk3 dbus-glib procps git && \
+  microdnf clean all -y && rm -rf /var/cache/dnf /tmp/*  && \
+  python3 -m ensurepip --upgrade && \
+  pip3 install --no-cache-dir -r /opt/rapidast/requirements.txt
 
 ### Allow the `dast` usergroup to make modifications to rapidast
-RUN groupadd dast
-RUN chown -R :dast /opt/rapidast
-RUN chmod -R g+w /opt/rapidast
-
-# Allow a user of random UID(e.g. on OpenShift) to create a custom scan policy file
-RUN chmod -R a+w /opt/rapidast/scanners/zap/policies
-
-
-RUN useradd -u 1000 -d /home/rapidast -m -s /bin/bash -G dast rapidast
-RUN echo rapidast:rapidast | chpasswd
+RUN groupadd dast && \
+  chown -R :dast /opt/rapidast && \
+  chmod -R g+w /opt/rapidast && \
+  ### Allow a user of random UID(e.g. on OpenShift) to create a custom scan policy file
+  chmod -R a+w /opt/rapidast/scanners/zap/policies && \
+  useradd -u 1000 -d /home/rapidast -m -s /bin/bash -G dast rapidast && \
+  echo rapidast:rapidast | chpasswd
 
 USER rapidast
 WORKDIR /opt/rapidast


### PR DESCRIPTION
Try to fix https://github.com/RedHatProductSecurity/rapidast/issues/164.

What changed:
- Use multi-stage builds
  - stage `deps` for prepare dependencies artifact
  - main stage will `COPY --from=deps`
- Minimize image layers
  - Merge multiple lines of `RUN`/`COPY` into one
- Remove cache after packages installed, commands like:
  - `microdnf clean all -y && rm -rf /var/cache/dnf /tmp/*`
  - add flag `--setopt=install_weak_deps=0` to `microdnf install`
  - add flag `--no-cache-dir` to `pip3 install`

What didn't change:
- Didn't introduce breaking changes; just make some updates to chores.

After this implementation, the size will be reduced from [1.24GB](https://quay.io/repository/redhatproductsecurity/rapidast/tag/latest) to [671MB](https://quay.io/repository/rh-ee-yuewu/rapidast/tag/test).