### PR TITLE
Base results dir

### DIFF
--- a/helm/chart/templates/_helpers.tpl
+++ b/helm/chart/templates/_helpers.tpl
@@ -54,7 +54,7 @@ template:
       - name: config-volume
         mountPath: /helm/config
       - name: results-volume
-        mountPath: /zap/results/
+        mountPath: /opt/rapidast/results
     volumes:
       - name: config-volume
         configMap:

--- a/helm/chart/templates/_helpers.tpl
+++ b/helm/chart/templates/_helpers.tpl
@@ -54,7 +54,7 @@ template:
       - name: config-volume
         mountPath: /helm/config
       - name: results-volume
-        mountPath: /home/rapidast/results/
+        mountPath: /zap/results/
     volumes:
       - name: config-volume
         configMap:

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -39,6 +39,9 @@ rapidastConfig: |
     # It is intended to keep backward compatibility (newer RapiDAST running an older config)
     configVersion: 4
 
+    # all the results of all scanners will be stored under that location
+    base_results_dir: "/zap/results"
+
   # `application` contains data related to the application, not to the scans.
   application:
     shortName: "MyApp-1.0"

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -39,9 +39,6 @@ rapidastConfig: |
     # It is intended to keep backward compatibility (newer RapiDAST running an older config)
     configVersion: 4
 
-    # all the results of all scanners will be stored under that location
-    base_results_dir: "/zap/results"
-
   # `application` contains data related to the application, not to the scans.
   application:
     shortName: "MyApp-1.0"

--- a/helm/results.sh
+++ b/helm/results.sh
@@ -29,7 +29,7 @@ spec:
       imagePullPolicy: Always
       volumeMounts:
         - name: results-volume
-          mountPath: /zap/results/
+          mountPath: /opt/rapidast/results
       resources:
         limits:
           cpu: 100m
@@ -46,5 +46,5 @@ EOF
 kubectl --kubeconfig=./kubeconfig apply -f $TMP_DIR/$RANDOM_NAME
 rm $TMP_DIR/$RANDOM_NAME
 kubectl --kubeconfig=./kubeconfig wait --for=condition=Ready pod/$RANDOM_NAME
-kubectl --kubeconfig=./kubeconfig cp $RANDOM_NAME:/zap/results $RESULTS_DIR
+kubectl --kubeconfig=./kubeconfig cp $RANDOM_NAME:/opt/rapidast/results $RESULTS_DIR
 kubectl --kubeconfig=./kubeconfig delete pod $RANDOM_NAME


### PR DESCRIPTION
Since the working directory changed to [/opt/rapidast](https://github.com/RedHatProductSecurity/rapidast/blob/9bbd22d20c12fcc0e2feb0333907a0b1c8781e9d/containerize/Containerfile#L81), need to either update the helm results file to match or update the _helpers and values files to all mount/reference the same path (currently misaligned between /home/rapidast/results and /zap/results) among the files


Current results file path: https://github.com/RedHatProductSecurity/rapidast/blob/9bbd22d20c12fcc0e2feb0333907a0b1c8781e9d/helm/results.sh#L32

I'm not for or against either path, just need to be consistent. I went with /zap/results but can easily change, had to add the base_results_dir into the helm config 

