### PR TITLE
[image] re-add gtk3 package dependencies

### DIFF
--- a/containerize/Containerfile
+++ b/containerize/Containerfile
@@ -62,7 +62,8 @@ COPY ./containerize/container_default_config.yaml /opt/rapidast/rapidast-default
 COPY ./containerize/path_rapidast.sh /etc/profile.d/rapidast.sh
 
 ### Install RapiDAST requirements, globally, so that it's available to any user
-RUN microdnf install -y --setopt=install_weak_deps=0 java-11-openjdk shadow-utils gtk3 dbus-glib procps git nodejs npm && \
+RUN microdnf install -y --setopt=install_weak_deps=0 java-11-openjdk shadow-utils dbus-glib procps git nodejs npm && \
+  microdnf install -y gtk3 && \
   microdnf clean all -y && rm -rf /var/cache/dnf /tmp/*  && \
   python3 -m ensurepip --upgrade && \
   pip3 install --no-cache-dir -r /opt/rapidast/requirements.txt && \


### PR DESCRIPTION
A side effect of earlier commit b280f37 is that gtk3 weak dependencies were no longer installed while building the RapiDAST image.

As a result, firefox would refuses to start.

This commit re-add gtk3 dependency installation.

If we need to reduce the image size, we would probably need to select which dependencies to install, one by one (there are a lot, though)