### PR TITLE
Crawl fail openshift

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,8 +41,8 @@ repos:
   # R1710: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
 
   - repo: https://github.com/PyCQA/pylint
-    #rev: v3.0.3
-    rev: v2.17.4
+    rev: v3.0.3
+    #rev: v2.17.4
     hooks:
       - id: pylint
         exclude: ^tests/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,8 +41,8 @@ repos:
   # R1710: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
 
   - repo: https://github.com/PyCQA/pylint
-    rev: v3.0.3
-    #rev: v2.17.4
+    #rev: v3.0.3
+    rev: v2.17.4
     hooks:
       - id: pylint
         exclude: ^tests/

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -98,17 +98,6 @@ class Zap(RapidastScanner):
                 # log path is like '/tmp/rapidast_*/zap.log'
                 tar.add(log, f"evidences/zap_logs/{log.split('/')[-1]}")
 
-    def cleanup(self):
-        """Generic ZAP cleanup: should be called only via super() inheritance
-        Deletes home and work directory
-        """
-
-        logging.debug(
-            f"Deleting temp directories {self.host_work_dir} and {self.host_home_dir}"
-        )
-        shutil.rmtree(self.host_work_dir)
-        shutil.rmtree(self.host_home_dir)
-
     def data_for_defect_dojo(self):
         """Return a tuple containing:
         1) Metadata for the test (dictionary)

--- a/scanners/zap/zap_none.py
+++ b/scanners/zap/zap_none.py
@@ -91,6 +91,9 @@ class ZapNone(Zap):
         if self.state != State.ERROR:
             self.state = State.READY
 
+        # Change HOME if needed
+        self._create_home_if_needed()
+
     def run(self):
         """If the state is READY, run the final run command on the local machine
         There is no need to call super() here.
@@ -270,3 +273,14 @@ class ZapNone(Zap):
             logging.warning(
                 f"ZAP appears to be in a incorrect state. Error: {result.stderr}"
             )
+
+    def _create_home_if_needed(self):
+        """Some tools (most notably: ZAP's Ajax Spider with Firefox) require a writable home directory.
+        When RapiDAST is run in Openshift, the user's home is /, which is not writable.
+        In that case, create a temporary directory and redirect $HOME to that directory
+        """
+        # test if HOME is writable. In that case, nothing needs to be done
+        if os.access(os.environ["HOME"], os.W_OK):
+            return
+        os.environ["HOME"] = self._create_temp_dir("home")
+        logging.debug(f"Replaced HOME directory, to {os.environ['HOME']}")


### PR DESCRIPTION
Simplify creation of temporary directories in the scanners.

And also add the ability for zap_none to change the HOME directory to such a temporary directory.

This is because Firefox needs to create ~/.firefox. But in Openshift, we're getting a user created on the fly, without a home directory (i.e.: home directory is `/`, which is not writable)