### PR TITLE
Export to Google Cloud Storage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,8 +41,8 @@ repos:
   # R1710: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
 
   - repo: https://github.com/PyCQA/pylint
-    #rev: v3.0.3
-    rev: v2.17.4
+    rev: v3.0.3
+    #rev: v2.17.4
     hooks:
       - id: pylint
         exclude: ^tests/

--- a/README.md
+++ b/README.md
@@ -172,13 +172,13 @@ In order to do that:
 
 Then the product, as well as an engagement for that product, must be created in your DefectDojo instance. It would not be advised to give the RapiDAST user an "admin" role and simply set `auto_create_context` to True, as it would be both insecure and accident prone (a typo in the product name would let RapiDAST create a new product)
 
-#### DefectDojo configuration in RapiDAST
+#### Exporting data to external services
 
 There are 2 parts to this:
 - First: choose the exporter and configure an authenticating method
 - Second: choose what data to export
 
-The next 2 chapters will describe the 2 exports, and the 3rd one the data to be exported
+The next 2 chapters will describe the 2 exports, and the 3rd one the configuration of data to be exported
 
 
 ##### Using Google Cloud Storage export
@@ -219,30 +219,40 @@ Alternatively, the `REQUESTS_CA_BUNDLE` environment variable can be used to sele
 
 You can either authenticate using a username/password combination, or a token (make sure it is not expired). In either case, you can use the `_from_var` method described in the previous chapter to avoid hardcoding the value in the configuration.
 
-##### Product/engagement/test
+##### Configuration of exported data
 
-Then, RapiDAST needs to know, for each scanner, sufficient information such that it can identify which product/engagement/test to match.
-This is configured in the `zap.scanner.defectDojoExport.parameters` entry. See the `import-scan` or  `reimport-scan` parameters at https://demo.defectdojo.org/api/v2/doc/ for a list of accepted entries.
-Notes:
-    * `engagement` and `test` refer to identifiers, and should be integers (as opposed to `engagement_name` and `test_title`)
-    * If a `test` identifier is provided, RapiDAST will reimport the result to that test. The existing test must be compatible (same file schema, such as ZAP Scan, for example)
-    * If the `product_name` does not exist, the scanner should default to `application.productName`, or `application.shortName`
-    * Tip: the entries common to all scanners can be added to `general.defectDojoExport.parameters`, while the scanner-dependant entries (e.g.: test identifier) can be set in the scanner's configuration (e.g.: `scanners.zap.defectDojoExport.parameters`)
+The data exported follows the Defectdojo methodology of "Product → Engagement → Test" : a test, such as a ZAP scan, belongs to an engagement for a product.
+Its configuration is made under the `scanners.<scanner>.defectDojoExport.parameters` configuration entries. As a baseline, parameters from the Defectdojo `import-scan` and `reimport-scan` are accepted.
+
+For each scan, the logic applied is the following, in order:
+* If a test ID is provided (parameter `test`), this scan will replace the previous one (a "reimport" in Defectdojo)
+* If an engagement ID is provided (parameter `engagement`), this scan will be added as a new test in that existing engagement
+* If an engagement and a product are given by name (`engagement_name` and `product_name` parameters), this scan will be added for that given engagement for the given product
+    - The engagement and the product may be created if they do not exist
+
+In each `defectDojoExport.parameters`, some defaults parameters are applied:
+* `product_name`, in order (the first non empty value found):
+    - `application.productName`
+    - `application.shortName` (this name should not contain non-printable characters, such as spaces)
+* `engagement_name` defaults to `RapiDAST-<product name>-<date>`
+* `scan_type` : filled by the scanner
+* `active`: `True`
+* `verified`: `False`
+
+As a reminder: values from `general` are applied to each scanner.
+
+Here is an example:
 
 ```yaml
-general:
-  defectDojoExport:
-    parameters:
-      productName: "My product"
-      tags: ["RapiDAST"]
-
 scanners:
   zap:
     defectDojoExport:
       parameters:
         test: 34
-        endpoint_to_add: "https://qa.myapp.local/"
+        tags: ["RapiDAST", "ZAP"]
 ```
+
+In the scenario above, the result of the scan will be added to the test ID 34 (i.e.: it will be a reimport), the new test tag list will replace the previous one.
 
 
 ## Execution

--- a/README.md
+++ b/README.md
@@ -174,8 +174,30 @@ Then the product, as well as an engagement for that product, must be created in 
 
 #### DefectDojo configuration in RapiDAST
 
-##### Authentication
-First, RapiDAST needs to be able to authenticate itself to a DefectDojo service. This is a typical configuration:
+There are 2 parts to this:
+- First: choose the exporter and configure an authenticating method
+- Second: choose what data to export
+
+The next 2 chapters will describe the 2 exports, and the 3rd one the data to be exported
+
+
+##### Using Google Cloud Storage export
+
+This simply stores the data as a compressed tarball in a Google Cloud Storage bucket.
+
+```yaml
+config:
+  # Defect dojo configuration
+  googleCloudStorage:
+    keyFile: "/path/to/GCS/key"                           # optional: path to the GCS key file (alternatively: use GOOGLE_APPLICATION_CREDENTIALS)
+    bucketName: "<name-of-GCS-bucket-to-export-to>"       # Mandatory
+    directory: "<override-of-default-directory>"          # Optional directory where the credentials have write access, defaults to `RapiDAST-<product>`
+```
+
+
+##### Directly to Defect Dojo
+
+RapiDAST will send the results directly to a DefectDojo service. This is a typical configuration:
 
 ```yaml
 config:
@@ -226,8 +248,8 @@ scanners:
 ## Execution
 
 Once you have created a configuration file, you can run a scan with it.
-```
-$ rapidast.py --config <your-config.yaml>
+```sh
+$ rapidast.py --config "<your-config.yaml>"
 ```
 
 There are more options.
@@ -535,7 +557,7 @@ com.fasterxml.jackson.dataformat.yaml.JacksonYAMLParseException: The incoming YA
  at [Source: (StringReader); line: 49813, column: 50]
 ```
 
-Solutions: 
+Solutions:
 * If you are using a Swagger v2 definition, try converting it to v3 (OpenAPI)
 * Set a `maxYamlCodePoints` Java proprety with a big value, which can be passed using environment variables (via the `config.environ.envFile` config entry): `_JAVA_OPTIONS=-DmaxYamlCodePoints=99999999`
 

--- a/config/config-template-zap-long.yaml
+++ b/config/config-template-zap-long.yaml
@@ -23,7 +23,7 @@ config:
   googleCloudStorage:
     keyFile: "/path/to/GCS/key"                           # optional: path to the GCS key file (alt.: use GOOGLE_APPLICATION_CREDENTIALS)
     bucketName: "<name-of-GCS-bucket-to-export-to>"       # Mandatory
-    directory: "<override-of-default-directory>"          # Optional, default will be computed if empty
+    directory: "<override-of-default-directory>"          # Optional, defaults to `RapiDAST-{app_name}`
 
 
 

--- a/config/config-template-zap-long.yaml
+++ b/config/config-template-zap-long.yaml
@@ -19,16 +19,13 @@ config:
   environ:
     envFile: "path/to/env/file"
 
-  # (Optional) configure to export scan results to OWASP Defect Dojo
-  defectDojo:
-    url: "https://mydefectdojo.example.com/"
-    # ssl: True|False|/path/to/CA/bundle (default: True). for SSL verification
-    ssl: True
-    authorization:
-      username: "rapidast"
-      password: "password"
-        # or
-      token: "abc"
+  # Export to Google Cloud Storage
+  googleCloudStorage:
+    keyFile: "/path/to/GCS/key"                           # optional: path to the GCS key file (alt.: use GOOGLE_APPLICATION_CREDENTIALS)
+    bucketName: "<name-of-GCS-bucket-to-export-to>"       # Mandatory
+    directory: "<override-of-default-directory>"          # Optional, default will be computed if empty
+
+
 
 # `application` contains data related to the application, not to the scans.
 application:
@@ -75,6 +72,28 @@ general:
     #   podman: RapiDAST orchestrates each scanner on its own using podman
     # When undefined, relies on rapidast-defaults.yaml, or `none` if nothing is set
     #type: "none"
+
+  # (Optional) configure to export the results to Defect Dojo.
+  # WARNING: requires an export to be configured: either config.googleCloudStorage or config.defectDojo
+  defectDojoExport:
+    # Parameters contain data that will directly be sent as parameters to DefectDojo's import/reimport endpoints.
+    # For example: commit tag, version, push_to_jira, etc.
+    # See https://demo.defectdojo.org/api/v2/doc/ for a list of possibilities
+    # The minimum set of data is whatever is needed to identify which engagement/test needs to be chosen.
+    # If neither a test ID (`test` parameter), nor product_name and engagement_name were provided, sane default will be attempted:
+    #   - product_name chosen from either application.productName or application.shortName
+    #   - engagement_name:  "RapiDAST" [this way the same engagement will always be chosen, regardless of the scanner]
+    parameters:
+      product_name: "My Product"
+      engagement_name: "RapiDAST"
+      # - or -
+      #engagement: 3   # engagement ID
+      # - or -
+      #test_title: "ZAP"
+      # - or -
+      #test: 5       # test ID, that will force "reimport" mode
+      # additional options, see https://demo.defectdojo.org/api/v2/doc/ for list
+      auto_create_context: False  # Optional. set to True to auto-create engagement (requires product_name and engagement_name)
 
 # `scanners' is a section that configures scanning options
 scanners:
@@ -168,27 +187,3 @@ scanners:
       overrideConfigs:
         - formhandler.fields.field(0).fieldId=namespace
         - formhandler.fields.field(0).value=default
-
-
-    # (Optional) configure to export scan results to OWASP Defect Dojo.
-    # `config.defectDojo` must be configured first.
-    defectDojoExport:
-      type: "reimport" # choose between: import, reimport, False (disable export). Default (or other content): re-import if test is set
-      # Parameters contain data that will directly be sent as parameters to DefectDojo's import/reimport endpoints.
-      # For example: commit tag, version, push_to_jira, etc.
-      # See https://demo.defectdojo.org/api/v2/doc/ for a list of possibilities
-      # The minimum set of data is whatever is needed to identify which engagement/test needs to be chosen.
-      # If neither a test ID (`test` parameter), nor product_name and engagement_name were provided, sane default will be attempted:
-      #   - product_name chosen from either application.productName or application.shortName
-      #   - engagement_name:  "RapiDAST" [this way the same engagement will always be chosen, regardless of the scanner]
-      parameters:
-        product_name: "My Product"
-        engagement_name: "RapiDAST"
-        # - or -
-        #engagement: 3   # engagement ID
-        # - or -
-        #test_title: "ZAP"
-        # - or -
-        #test: 5       # test ID, that will force "reimport" mode
-        # additional options, see https://demo.defectdojo.org/api/v2/doc/ for list
-        auto_create_context: False  # Optional. set to True to auto-create engagement (requires product_name and engagement_name)

--- a/configmodel/__init__.py
+++ b/configmodel/__init__.py
@@ -176,6 +176,14 @@ class RapidastConfigModel:
 
         deep_dict_merge(sub_conf, merge, preserve)
 
+    def get_official_app_name(self):
+        """ Shortcut: 
+        Return a string corresponding to how the application should be called
+        Based on the configuratoin.
+        Prefer the full product name, but defer to short name if unavailable
+        """
+        return self.get("application.ProductName") or self.get("application.shortName")
+
     def __repr__(self):
         return pformat(vars(self), indent=4, width=1)
 

--- a/exports/defect_dojo.py
+++ b/exports/defect_dojo.py
@@ -159,7 +159,7 @@ class DefectDojo:
         )
 
     def import_scan(self, data, filename):
-        """Import to an existing engagement."""
+        """export to an existing engagement, via the `import-scan` endpoint."""
 
         if not data.get("engagement") and not (
             data.get("engagement_name") and data.get("product_name")
@@ -172,7 +172,7 @@ class DefectDojo:
             f"{self.base_url}/api/v2/import-scan/", data, filename
         )
 
-    def import_or_reimport_scan(self, data, filename):
+    def export_scan(self, data, filename):
         """Decide wether to import or reimport. Based on:
         - If the data contains a test ID ("test"): it's a reimport
         - Otherwise import

--- a/exports/google_cloud_storage.py
+++ b/exports/google_cloud_storage.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+import datetime
+import json
+import logging
+import os
+import random
+import string
+import tarfile
+import uuid
+from io import BytesIO
+from io import StringIO
+
+from google.cloud import storage
+
+
+class GoogleCloudStorage:
+    """
+    Sends the results to a Google Cloud Storage bucket, for future use in DefectDojo
+    """
+
+    def __init__(self, bucket_name, app_name, directory=None, keyfile=None):
+        if keyfile:
+            client = storage.Client.from_service_account_json(keyfile)
+        else:
+            client = storage.Client()
+        self.bucket = client.get_bucket(bucket_name)
+        self.directory = directory or f"RapiDAST-{app_name}"
+        self.app_name = app_name
+
+    def create_metadata(self, data):
+        """
+        Given a dictionary of key/values corresponding to Defectdojo's `import-scan` parameters,
+        return a Metadata dictionary
+        """
+        metadata = {
+            "scan_type": data["scan_type"],
+            "uuid": str(uuid.uuid1()),
+            "test_description": "This test was executed by RapiDAST",
+            "import_data": data,
+        }
+
+        return metadata
+
+    def export_scan(self, data, filename):
+        """
+        Send the scan to GCS
+
+        Params:
+        data: a dictionary of key/values corresponding to Defectdojo's `import-scan` parameters
+        filename: path to the file containing scan
+
+        """
+        if not data or not filename:
+            # missing data means nothing to do
+            logging.debug("Insufficient data for Defect Dojo")
+            return 1
+
+        metadata = self.create_metadata(data)
+
+        logging.info(
+            f"GoogleCloudStorage: sending {filename}. UUID: {metadata['uuid']}"
+        )
+
+        # export data as a metadata.json file
+        json_stream = StringIO()
+        json.dump(metadata, json_stream)
+        json_stream = BytesIO(json_stream.getvalue().encode("utf-8"))
+        json_stream.seek(0)
+
+        # create a tar containing: "scans/<filename>" and metadata.json
+        tar_stream = BytesIO()
+        with tarfile.open(fileobj=tar_stream, mode="w:gz") as tar:
+            # add the metadata
+            info = tarfile.TarInfo(name="metadata.json")
+            info.size = len(json_stream.getvalue())
+            tar.addfile(tarinfo=info, fileobj=json_stream)
+
+            # add the scan
+            tar.add(name=filename, arcname=f"scans/{os.path.basename(filename)}")
+        tar_stream.seek(0)
+
+        # generate the blob filename
+        unique_id = "{}-RapiDAST-{}-{}.tgz".format(  # pylint: disable=C0209
+            datetime.datetime.now(tz=datetime.timezone.utc).isoformat(),
+            self.app_name,
+            "".join(
+                random.choices(
+                    string.ascii_letters + string.ascii_uppercase + string.digits, k=6
+                )
+            ),
+        )
+        blob_name = self.directory + "/" + unique_id
+
+        # push to GCS
+        blob = self.bucket.blob(blob_name)
+        with blob.open(mode="wb") as dest:
+            dest.write(tar_stream.getbuffer())

--- a/exports/google_cloud_storage.py
+++ b/exports/google_cloud_storage.py
@@ -15,7 +15,7 @@ from google.cloud import storage
 
 class GoogleCloudStorage:
     """
-    Sends the results to a Google Cloud Storage bucket, for future use in DefectDojo
+    Sends the results to a Google Cloud Storage bucket
     """
 
     def __init__(self, bucket_name, app_name, directory=None, keyfile=None):
@@ -51,7 +51,7 @@ class GoogleCloudStorage:
         """
         if not data or not filename:
             # missing data means nothing to do
-            logging.debug("Insufficient data for Defect Dojo")
+            logging.debug("Insufficient data")
             return 1
 
         metadata = self.create_metadata(data)

--- a/exports/google_cloud_storage.py
+++ b/exports/google_cloud_storage.py
@@ -35,7 +35,6 @@ class GoogleCloudStorage:
         metadata = {
             "scan_type": data["scan_type"],
             "uuid": str(uuid.uuid1()),
-            "test_description": "This test was executed by RapiDAST",
             "import_data": data,
         }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 python-dotenv >= 1.0.0
 pyyaml >= 6.0
 requests >= 2.27.1
+google.cloud.storage >= 2.17.0

--- a/scanners/generic/generic.py
+++ b/scanners/generic/generic.py
@@ -101,31 +101,9 @@ class Generic(RapidastScanner):
         filename = f"{self.results_dir}/{sarif_filename}"
         logging.debug(f"export {filename} to defect dojo")
 
-        # default, mandatory values (which can be overloaded)
-        data = {
-            "scan_type": "SARIF",
-            "active": True,
-            "verified": False,
-        }
+        data = {"scan_type": "SARIF"}
 
-        # lists of configured import parameters
-        params_root = "defectDojoExport.parameters"
-        import_params = self.my_conf(params_root, default={}).keys()
-
-        # overload that list onto the defaults
-        for param in import_params:
-            data[param] = self.my_conf(f"{params_root}.{param}")
-
-        if data.get("test") is None:
-            # No test ID provided, so we need to make sure there is enough info
-            # But we can't make it default (they should not be filled if there is a test ID
-            if not data.get("product_name"):
-                data["product_name"] = self.config.get(
-                    "application.ProductName"
-                ) or self.config.get("application.shortName")
-            if not data.get("engagement_name"):
-                data["engagement_name"] = "RapiDAST"
-        return data, filename
+        return (self._fill_up_data_for_defect_dojo(data), filename)
 
     ###############################################################
     # PROTECTED METHODS                                           #
@@ -152,13 +130,6 @@ class Generic(RapidastScanner):
     # PRIVATE METHODS                                             #
     # Those are called only from Generic itself                   #
     ###############################################################
-
-    def _should_export_to_defect_dojo(self):
-        """Return a truthful value if Defect Dojo export is configured and not disbaled"""
-        return (
-            self.my_conf("defectDojoExport", default=False) is not False
-            and self.my_conf("defectDojoExport.type", default=False) is not False
-        )
 
     ###############################################################
     # MAGIC METHODS                                               #

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -133,9 +133,7 @@ class Zap(RapidastScanner):
             # No test ID provided, so we need to make sure there is enough info
             # But we can't make it default (they should not be filled if there is a test ID
             if not data.get("product_name"):
-                data["product_name"] = self.config.get(
-                    "application.ProductName"
-                ) or self.config.get("application.shortName")
+                data["product_name"] = self.config.get_official_app_name()
             if not data.get("engagement_name"):
                 data["engagement_name"] = "RapiDAST"
 
@@ -595,8 +593,13 @@ class Zap(RapidastScanner):
     def _should_export_to_defect_dojo(self):
         """Return a truthful value if Defect Dojo export is configured and not disbaled"""
         return (
-            self.my_conf("defectDojoExport", default=False) is not False
-            and self.my_conf("defectDojoExport.type", default=False) is not False
+            ( (self.my_conf("defectDojoExport.parameters.product_name") or
+               self.config.get_official_app_name())
+               and
+              self.my_conf("defectDojoExport.parameters.engagement_name") 
+            ) or
+            self.my_conf("defectDojoExport.parameters.engagement") or
+            self.my_conf("defectDojoExport.parameters.test")
         )
 
     def _setup_report(self):

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -99,7 +99,7 @@ class Zap(RapidastScanner):
                 tar.add(log, f"evidences/zap_logs/{log.split('/')[-1]}")
 
     def data_for_defect_dojo(self):
-        """Return a tuple containing:
+        """Returns a tuple containing:
         1) Metadata for the test (dictionary)
         2) Path to the result file (string)
         For additional info regarding the metadata, see the `import-scan`/`reimport-scan`
@@ -114,30 +114,9 @@ class Zap(RapidastScanner):
         # the XML report is supposed to have been forcefully added, and expected to exist
         filename = f"{self.results_dir}/zap-report.xml"
 
-        # default, mandatory values (which can be overloaded)
-        data = {
-            "scan_type": "ZAP Scan",
-            "active": True,
-            "verified": False,
-        }
+        data = {"scan_type": "ZAP Scan"}
 
-        # lists of configured import parameters
-        params_root = "defectDojoExport.parameters"
-        import_params = self.my_conf(params_root, default={}).keys()
-
-        # overload that list onto the defaults
-        for param in import_params:
-            data[param] = self.my_conf(f"{params_root}.{param}")
-
-        if data.get("test") is None:
-            # No test ID provided, so we need to make sure there is enough info
-            # But we can't make it default (they should not be filled if there is a test ID
-            if not data.get("product_name"):
-                data["product_name"] = self.config.get_official_app_name()
-            if not data.get("engagement_name"):
-                data["engagement_name"] = "RapiDAST"
-
-        return data, filename
+        return (self._fill_up_data_for_defect_dojo(data), filename)
 
     def get_update_command(self):
         """Returns a list of all options required to update ZAP plugins"""
@@ -590,18 +569,6 @@ class Zap(RapidastScanner):
 
         return report_af
 
-    def _should_export_to_defect_dojo(self):
-        """Return a truthful value if Defect Dojo export is configured and not disbaled"""
-        return (
-            ( (self.my_conf("defectDojoExport.parameters.product_name") or
-               self.config.get_official_app_name())
-               and
-              self.my_conf("defectDojoExport.parameters.engagement_name") 
-            ) or
-            self.my_conf("defectDojoExport.parameters.engagement") or
-            self.my_conf("defectDojoExport.parameters.test")
-        )
-
     def _setup_report(self):
         """Adds the report to the job list. This should be called last"""
 
@@ -623,7 +590,7 @@ class Zap(RapidastScanner):
 
         # DefectDojo requires XML report type
         if self._should_export_to_defect_dojo():
-            logging.debug("ZAP report: ensures XML report for Defect Dojo")
+            logging.debug("ZAP report: ensures XML report for Export")
             formats.add("xml")
 
         appended = 0


### PR DESCRIPTION
This commit adds a new export.
It re-uses the original DefectDojo export.

configuration:

```yaml
config:
  googleCloudStorage:
    keyFile: "<path-to-ondisk-GCS-key>"
    bucketName: "<bucket-name>"
    directory: "<optional-directory-name>"

general:
  defectDojoExport:
    parameters:
      # values for defectdojo's import-scan endpoint
```

Note: the generic scanner hasn't been tested yet