### PR TITLE
Ajax pid limits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,8 +41,8 @@ repos:
   # R1710: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
 
   - repo: https://github.com/PyCQA/pylint
-    #rev: v3.0.3
-    rev: v2.17.4
+    rev: v3.0.3
+    #rev: v2.17.4
     hooks:
       - id: pylint
         exclude: ^tests/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,8 +41,8 @@ repos:
   # R1710: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
 
   - repo: https://github.com/PyCQA/pylint
-    rev: v3.0.3
-    #rev: v2.17.4
+    #rev: v3.0.3
+    rev: v2.17.4
     hooks:
       - id: pylint
         exclude: ^tests/

--- a/README.md
+++ b/README.md
@@ -569,11 +569,15 @@ Solutions:
 
 ### ZAP's Ajax Spider failing
 
-#### Insufficient shared memory
+#### Insufficient Resources
 
-ZAP's Ajax Spider makes heavy use of shared memory (`/dev/shm/`). When using the RapiDAST image or the ZAP image, the user needs to make sure that sufficient space is available in `/dev/shm/` (in podman, by default, its size is 64MB). A size of 2G would be the minimum recommended. In podman for example, the option would be `--shm-size=2g`.
+Zap's Ajax Spider makes use of a lot of resources, in particular:
+- Shared Memory (`/dev/shm`)
+- processes
 
-ZAP logs that would bring evidence of a lack of shared memory would look like the following:
+If you see evidence of Firefox crashing, either via in the `zap.log` files stored in `session.tar.gz` file (see below for examples of such evidence), or logged by an external crash report (such as `abrtd` for example).
+
+`zap.log` hints for Firefox crashing:
 
 ```
 2024-07-04 11:21:32,061 [ZAP-AjaxSpiderAuto] WARN  SpiderThread - Failed to start browser firefox-headless
@@ -588,6 +592,16 @@ Or the following:
 2024-07-04 12:23:28,027 [ZAP-AjaxSpiderAuto] ERROR UncaughtExceptionLogger - Exception in thread "ZAP-AjaxSpiderAuto"
 java.lang.OutOfMemoryError: unable to create native thread: possibly out of memory or process/resource limits reached
 ```
+
+This issue may also be apparent _outside_ of the spider, in particular, the following error being printed on the RapiDAST output is likely an evidence that the maximum number of concurrent thread is currently reached:
+
+```
+Failed to start thread "Unknown thread" - pthread_create failed (EAGAIN) for attributes: stacksize: 1024k, guardsize: 0k, detached.
+```
+
+Solutions:
+* Selenium, used to control Firefox, uses shared memory (`/dev/shm/`). When using the RapiDAST image or the ZAP image, the user needs to make sure that sufficient space is available in `/dev/shm/` (in podman, by default, its size is 64MB). A size of 2G is the recommended value by the Selenium community. In podman for example, the option would be `--shm-size=2g`.
+* Zap and Firefox can create a huge numbers of threads. Some container engines will default to 2048 concurrent pids, which is not sufficient for the Ajax Spider. Whenever possible, RapiDAST will check if that limit was reached, after the scan is finished, and prints a warning if this happened. In podman, increasing the maximum number of concurrent pids is done via the `--pids-limit=-1` option to prevent any limits.
 
 ## Caveats
 

--- a/scanners/generic/generic.py
+++ b/scanners/generic/generic.py
@@ -78,6 +78,9 @@ class Generic(RapidastScanner):
             # it's a false positive: it's defined in the RapidastScanner class
             self.state = State.ERROR
 
+        # Calling parent RapidastScanner postprocess
+        super().postprocess()
+
     def cleanup(self):
         """Generic Generic cleanup: should be called only via super() inheritance"""
         shutil.rmtree(self.workdir)

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -98,6 +98,9 @@ class Zap(RapidastScanner):
                 # log path is like '/tmp/rapidast_*/zap.log'
                 tar.add(log, f"evidences/zap_logs/{log.split('/')[-1]}")
 
+        # Calling parent RapidastScanner postprocess
+        super().postprocess()
+
     def data_for_defect_dojo(self):
         """Returns a tuple containing:
         1) Metadata for the test (dictionary)

--- a/scanners/zap/zap_none.py
+++ b/scanners/zap/zap_none.py
@@ -150,6 +150,7 @@ class ZapNone(Zap):
     def postprocess(self):
         logging.info("Running postprocess for the ZAP Host environment")
 
+        # Calling parent ZapScanner postprocess
         super().postprocess()
 
         if not self.state == State.ERROR:
@@ -199,7 +200,7 @@ class ZapNone(Zap):
             # Assume we're regulated by cgroup v2
             try:
                 with open("/sys/fs/cgroup/pids.max", encoding="utf-8") as f:
-                    pid_val = f.readline()
+                    pid_val = f.readline().rstrip()
                     if pid_val == "max" or int(pid_val) > 10000:
                         logging.debug(
                             f"cgroup v2 has a sufficient pid limit: {pid_val}"

--- a/scanners/zap/zap_podman.py
+++ b/scanners/zap/zap_podman.py
@@ -165,6 +165,7 @@ class ZapPodman(Zap):
             return
 
         self.podman.add_option("--shm-size", "2g")
+        self.podman.add_option("--pids-limit", "-1")
 
         # Regular Ajax setup
         super()._setup_ajax_spider()

--- a/tests/scanners/zap/test_setup_none.py
+++ b/tests/scanners/zap/test_setup_none.py
@@ -1,5 +1,6 @@
 # test specifically designed for ZAP in None mode (testing zap_none.py)
 from collections import namedtuple
+from unittest.mock import mock_open
 from unittest.mock import patch
 
 import pytest
@@ -30,9 +31,15 @@ def test_none_handling_ajax(mock_warning, mock_disk_usage, mock_system, test_con
     DiskUsage = namedtuple("DiskUsage", ["total"])
     mock_disk_usage.return_value = DiskUsage(total=64 * 1024 * 1024)
 
-    test_zap._setup_ajax_spider()
+    # Fake a CGroup V2 environment
+    with patch("builtins.open", mock_open(read_data="42")) as mock_pidsmax:
+        test_zap._setup_ajax_spider()
 
+    mock_pidsmax.assert_called_once_with("/sys/fs/cgroup/pids.max", encoding="utf-8")
     mock_warning.assert_any_call(
-        "Insufficient shared memory to run an Ajax Spider correctly. "
+        "Number of threads may be too low for SpiderAjax: cgroupv2 pids.max=42"
+    )
+    mock_warning.assert_any_call(
+        "Insufficient shared memory to run an Ajax Spider correctly (67108864 bytes). "
         "Make sure that /dev/shm/ is at least 1GB in size [ideally at least 2GB]"
     )

--- a/tests/scanners/zap/test_setup_none.py
+++ b/tests/scanners/zap/test_setup_none.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 
 import configmodel
+from scanners import State
 from scanners.zap.zap_none import ZapNone
 
 
@@ -43,3 +44,23 @@ def test_none_handling_ajax(mock_warning, mock_disk_usage, mock_system, test_con
         "Insufficient shared memory to run an Ajax Spider correctly (67108864 bytes). "
         "Make sure that /dev/shm/ is at least 1GB in size [ideally at least 2GB]"
     )
+
+
+@patch("scanners.zap.zap_none.logging.warning")
+@patch("scanners.zap.zap.shutil.copytree")
+@patch("scanners.zap.zap.tarfile")
+def test_zap_none_postprocess(mock_tarfile, mock_copytree, mock_warning, test_config):
+    test_zap = ZapNone(config=test_config)
+
+    # Fake a CGroup V2 environment
+    with patch("builtins.open", mock_open(read_data="max 2\n")) as mock_pidsevents:
+        test_zap.postprocess()
+
+    mock_pidsevents.assert_called_once_with(
+        "/sys/fs/cgroup/pids.events", encoding="utf-8"
+    )
+    mock_warning.assert_any_call(
+        "Scanner may have been throttled by CGroupv2 PID limits: pids.events reports max 2"
+    )
+
+    assert test_zap.state == State.PROCESSED

--- a/tests/scanners/zap/test_setup_podman.py
+++ b/tests/scanners/zap/test_setup_podman.py
@@ -194,6 +194,8 @@ def test_podman_handling_ajax(test_config):
     cli = test_zap.podman.get_complete_cli()
     i = cli.index("--shm-size")
     assert cli[i + 1] == "2g"
+    i = cli.index("--pids-limit")
+    assert cli[i + 1] == "-1"
 
 
 def test_podman_handling_plugins(test_config):


### PR DESCRIPTION
Another issue that I have successfully diagnosed is the thread throttling. By default, podman appears to prevent more than 2048 concurrent pids (threads). This results in Firefox crashing during the spider, or the active scan failing.

To put it in perspective: an Ajax Spider + active scan of VAPI peaked at 3330 concurrent threads (i.e.: in podman, Zap would not be able to spider the application flawlessly because of that throttle which regularly crashed firefox).

Changes:
1) in podman mode, remove this limitation when Zap has a AjaxSpider job
2) in none, look for and warn, if the maximum number of pids is below 10.000
3) in the postprocess of any scan, try to look for evidence of the maximum pid number being reached, and prints a warning if that happened
4) updated the Troubleshooting part of the README.
5) updated the tests to reflect the above.