### PR TITLE
handling socket_timeout

### DIFF
--- a/scanners/generic/tools/oobtkube.py
+++ b/scanners/generic/tools/oobtkube.py
@@ -212,8 +212,10 @@ def start_socket_listener(port, shared_queue, data_received, stop_event, duratio
 
             break
 
-    except TimeoutError:
-        logging.debug("Timeout reached. Stopping the server.")
+    except socket.timeout:
+        logging.info(
+            "Socket timeout reached as the test duration expired. Stopping the server."
+        )
         pass
 
     except Exception as e:


### PR DESCRIPTION
Handling socket.timeout properly, to prevent error messages from occurring, when the test is finished with the test duration.