### PR TITLE
Replace kubectl auth whoami check with auth can-i

### DIFF
--- a/tests/scanners/generic/tools/test_data_oobtkube/pod.yaml
+++ b/tests/scanners/generic/tools/test_data_oobtkube/pod.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: foo
+spec:
+  containers:
+  - image: bar
+    name: foo

--- a/tests/scanners/generic/tools/test_oobtkube.py
+++ b/tests/scanners/generic/tools/test_oobtkube.py
@@ -1,9 +1,12 @@
 import logging
+import os
 from unittest.mock import patch
 
 import pytest
 
 from scanners.generic.tools import oobtkube
+
+TEST_DATA_DIR = "tests/scanners/generic/tools/test_data_oobtkube/"
 
 
 @pytest.fixture
@@ -48,3 +51,11 @@ def test_find_leaf_keys_and_test(mock_system, test_data, caplog):
     assert (
         mock_system.call_count == 6
     )  # Each leaf key runs `sed` and `kubectl` commands (2 calls per key)
+
+
+def test_parse_resource_yaml():
+    path = os.path.join(TEST_DATA_DIR, "pod.yaml")
+    obj_data = oobtkube.parse_obj_data(path)
+    assert obj_data["kind"] == "Pod"
+    assert isinstance(obj_data["spec"], dict)
+    assert isinstance(obj_data["metadata"], dict)


### PR DESCRIPTION
`kube auth whoami` fails on some openshift clusters when selfsubjectreviews API is not available whilst `oc whoami` succeeds on such clusters because it uses additional API queries.

```
$ kubectl -v=6 auth whoami
I0902 11:55:21.654909 3927156 loader.go:395] Config loaded from file:  /home/<user>/.kube/config
I0902 11:55:22.543234 3927156 round_trippers.go:553] POST https://<foo>.openshiftapps.com:6443/apis/authentication.k8s.io/v1/selfsubjectreviews 404 Not Found in 887 milliseconds
I0902 11:55:22.953965 3927156 round_trippers.go:553] POST https://<foo>.openshiftapps.com:6443/apis/authentication.k8s.io/v1beta1/selfsubjectreviews 404 Not Found in 410 milliseconds
I0902 11:55:23.254357 3927156 round_trippers.go:553] POST https://<foo>.openshiftapps.com:6443/apis/authentication.k8s.io/v1alpha1/selfsubjectreviews 404 Not Found in 300 milliseconds
error: the selfsubjectreviews API is not enabled in the cluster
enable APISelfSubjectReview feature gate and authentication.k8s.io/v1alpha1 or authentication.k8s.io/v1beta1 API
```

VS

```
$ oc -v=6 whoami
I0902 11:56:55.690860 3927447 loader.go:395] Config loaded from file:  /home/<user>/.kube/config
I0902 11:56:56.553309 3927447 round_trippers.go:553] POST https://<foo>.openshiftapps.com:6443/apis/authentication.k8s.io/v1/selfsubjectreviews 404 Not Found in 861 milliseconds
I0902 11:56:56.553935 3927447 whoami.go:99] selfsubjectreview request error the server could not find the requested resource, falling back to user object
I0902 11:56:56.927577 3927447 round_trippers.go:553] GET https://<foo>.openshiftapps.com:6443/apis/user.openshift.io/v1/users/~ 200 OK in 373 milliseconds
<user>
```
Using `oc whoami` instead of `kubectl auth whoami` might be a viable fix, however currently the `oc` binary is not included in the rapidast container image and all other oobtkube comands use `kubectl`.

Instead this PR replaces `auth whoami` with `auth can-i create <resource>` to test specifically if the user has sufficient permission to create resources of the provided type, because create verbs are used during testing. This requires parsing the resource file slightly earlier in oobtkube.py's processing to get the resource type. This should fix the problem of trying to use the selfsubjectreviews API.