### PR TITLE
Use ZAP's Browser authentication method

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ This method describes the HTTP Basic Authorization Header. The username and pass
 This method describes the HTTP generic header. The name and value must be provided in plaintext.
     + authentication type: `http_header`
     + parameters:
-        * `name`: the header name added to every request. By default is `Authorization` 
+        * `name`: the header name added to every request. By default is `Authorization`
         * `value` or `value_from_var` (the environment variable with the secret)
 
 - Cookie Authentication:
@@ -127,6 +127,15 @@ This method describes authentication via Cookie header. The cookie name and valu
     + parameters:
         * `name`
         * `value`
+
+- Browser authentication method
+This method uses firefox in the background to load a login page and fill in username/password, and will retrieve and set the session cookies accordingly.
+    + authentication type: `browser`
+    + parameters:
+        * `username`
+        * `password`
+        * `loginPageUrl`: the URL to the login page (either the full URL, or relative to the `application.url` value)
+        * `verifyUrl`: a URL that "proves" the user is authenticated (either the full URL, or relative to the `application.url` value). This URL must return a success if the user is correctly authenticated, and an error otherwise.
 
 
 ### Advanced configuration

--- a/config/config-template-zap-long.yaml
+++ b/config/config-template-zap-long.yaml
@@ -63,6 +63,15 @@ general:
     #parameters:
     #  name: "cookie name"
     #  value: "cookie value"
+    #
+    # "browser" authenticatoin will use firefox in the background to generate cookies
+    #  - verifyUrl must return an error if the user is not logged in
+    #type: "browser"   
+    #parameters:
+    #  username: "user"
+    #  password: "mypassw0rd"
+    #  loginPageUrl: "https://myapp/login"
+    #  verifyUrl: "https://myapp/user/info"
 
 
   container:

--- a/config/config-template-zap-long.yaml
+++ b/config/config-template-zap-long.yaml
@@ -64,7 +64,7 @@ general:
     #  name: "cookie name"
     #  value: "cookie value"
     #
-    # "browser" authenticatoin will use firefox in the background to generate cookies
+    # "browser" authentication will use firefox in the background to generate cookies
     #  - verifyUrl must return an error if the user is not logged in
     #type: "browser"   
     #parameters:

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -429,7 +429,7 @@ class Zap(RapidastScanner):
         - authentication.parameters.verifyUrl
         - application.url
         """
-        verify_url =  self.my_conf(f"authentication.parameters.verifyUrl")
+        verify_url = self.my_conf("authentication.parameters.verifyUrl")
         if verify_url:
             if not verify_url.startswith("http"):
                 verify_url = self.config.get("application.url") + verify_url
@@ -439,11 +439,13 @@ class Zap(RapidastScanner):
         job = {
             "name": "requestor",
             "type": "requestor",
-            "parameters": { "user": Zap.USER if self.authenticated else "" },
-            "request":  [ {
-                "name": "Verify server availability",
-                "url": verify_url,
-            } ] ,
+            "parameters": {"user": Zap.USER if self.authenticated else ""},
+            "request": [
+                {
+                    "name": "Verify server availability",
+                    "url": verify_url,
+                }
+            ],
         }
         self.automation_config["jobs"].append(job)
 
@@ -651,10 +653,9 @@ class Zap(RapidastScanner):
             "parameters": {
                 "format": "Long",
                 "summaryFile": f"{self.container_work_dir}/summary.json",
-            }
+            },
         }
         self.automation_config["jobs"].append(job)
-
 
     def _save_automation_file(self):
         """Save the Automation dictionary as YAML in the container"""
@@ -742,7 +743,7 @@ class Zap(RapidastScanner):
         return False
 
     @authentication_factory.register("browser")
-    def authentication_set_oauth2_rtoken(self):
+    def authentication_set_browser(self):
         """Configure authentication via a form filled in using the browser, as smartly as possible
         In order to achieve that:
         - Configure the context to use "Browser based authentication"
@@ -756,10 +757,10 @@ class Zap(RapidastScanner):
         username = self.my_conf(f"{params_path}.username")
         password = self.my_conf(f"{params_path}.password")
 
-        loginPageUrl = self.my_conf(f"{params_path}.loginPageUrl")
-        if not loginPageUrl.startswith("http"):
-            loginPageUrl = self.config.get("application.url") + loginPageUrl
-        verify_url =  self.my_conf(f"{params_path}.verifyUrl")
+        login_page_url = self.my_conf(f"{params_path}.loginPageUrl")
+        if not login_page_url.startswith("http"):
+            login_page_url = self.config.get("application.url") + login_page_url
+        verify_url = self.my_conf(f"{params_path}.verifyUrl")
         if not verify_url.startswith("http"):
             verify_url = self.config.get("application.url") + verify_url
 
@@ -767,9 +768,9 @@ class Zap(RapidastScanner):
         context_["authentication"] = {
             "method": "browser",
             "parameters": {
-                "loginPageUrl": loginPageUrl,
+                "loginPageUrl": login_page_url,
                 "loginPageWait": 2,
-                "browserId": "firefox-headless"
+                "browserId": "firefox-headless",
             },
             "verification": {
                 "method": "poll",
@@ -785,10 +786,12 @@ class Zap(RapidastScanner):
             "method": "cookie",
             "parameters": {},
         }
-        context_["users"] = [ {
-            "name": Zap.USER,
-            "credentials": {"username": username, "password": password},
-        } ]
+        context_["users"] = [
+            {
+                "name": Zap.USER,
+                "credentials": {"username": username, "password": password},
+            }
+        ]
         return True
 
     @authentication_factory.register("oauth2_rtoken")


### PR DESCRIPTION
ZAP supports a "browser" authentication system. We are using Firefox-headless to login the user and get a cookie.

It's quite experimental at the moment, but seems to work.

Also added a "requestor" job, to try making sure that ZAP can access the website. However, it currently does not work as expected.