### PR TITLE
[ZAP] AjaxSpider and activeScan accept any params

### DIFF
--- a/config/config-template-zap-long.yaml
+++ b/config/config-template-zap-long.yaml
@@ -66,7 +66,7 @@ general:
     #
     # "browser" authentication will use firefox in the background to generate cookies
     #  - verifyUrl must return an error if the user is not logged in
-    #type: "browser"   
+    #type: "browser"
     #parameters:
     #  username: "user"
     #  password: "mypassw0rd"
@@ -135,6 +135,9 @@ scanners:
       url: ""        # url to start spidering from, default: application.url set above
 
     spiderAjax:
+      # The list of parameters: https://www.zaproxy.org/docs/desktop/addons/ajax-spider/automation/
+      #maxCrawlStates: 10   # this may be useful when running in a memory limited environment (default: 0 unlimited)
+      #maxCrawlDepth: 10    # default: unlimited
       maxDuration: 0 # in minutes, default: 0 unlimited
       url: ""        # url to start spidering from, default: application.url set above
       browserId: firefox-headless
@@ -145,6 +148,10 @@ scanners:
       disabledRules: "2,10015,10024,10027,10054,10096,10109,10112"
 
     activeScan:
+      # The list of parameters: https://www.zaproxy.org/docs/desktop/addons/ajax-spider/automation/
+      #maxRuleDurationInMins: max scan time for each Rule (default: unlimited)
+      #maxScanDurationInMins: max scan time for the entire scan. Useful for debugging automation
+      #
       # If no policy is chosen, a default ("API-scan-minimal") will be selected
       # The list of policies can be found in scanners/zap/policies/
       policy:  "API-scan-minimal"

--- a/scanners/__init__.py
+++ b/scanners/__init__.py
@@ -33,11 +33,18 @@ class RapidastScanner:
         # this temporary directory
         self.main_temp_dir = None
 
+    def absolute_conf_path(self, path):
+        """Handy shortcut to get an absolute path into a scanner's config parameter.
+        WARNING: currently, `path` MUST be in string for (e.g.: `spiderAjax.parameters.maxCrawlDepth`)
+        """
+        return f"scanners.{self.ident}.{path}"
+
     def my_conf(self, path, *args, **kwargs):
         """Handy shortcut to get the scanner's configuration.
         Only for within `scanners.<scanner>`
+        WARNING: currently, `path` MUST be in string for (e.g.: `spiderAjax.parameters.maxCrawlDepth`)
         """
-        return self.config.get(f"scanners.{self.ident}.{path}", *args, **kwargs)
+        return self.config.get(self.absolute_conf_path(path), *args, **kwargs)
 
     def set_my_conf(self, path, *args, **kwargs):
         """Handy shortcut to set the scanner's configuration.

--- a/tests/configmodel/test_configmodel.py
+++ b/tests/configmodel/test_configmodel.py
@@ -1,3 +1,4 @@
+import copy
 import os
 
 import pytest
@@ -29,6 +30,64 @@ def generate_some_nested_config():
         "nothing": None,
         "falsekey": False,
     }
+
+
+@pytest.fixture(name="nested_with_var")
+def generate_some_nested_config_with_var():
+    os.environ["SECRETKEY"] = "ABC"
+    return {
+        "key1": "value1",
+        "key2": {"key21": "value21"},
+        "key3": "value3",
+        "key4": "value4",
+        "nested": {
+            "morenested": {
+                "key3": "nestedvalue",
+                "secretkey_from_var": "SECRETKEY",
+                "nestnest": {"leaf": "value"},
+            }
+        },
+        "nothing": None,
+        "falsekey": False,
+    }
+
+
+def test_subtree_to_dict(nested_with_var):
+    myconf = RapidastConfigModel(nested_with_var)
+
+    # make a "backup" of the original config, to look for unexpected modification
+    original = copy.deepcopy(myconf.conf)
+
+    d = myconf.subtree_to_dict("nested.morenested")
+    expected = {
+        "key3": "nestedvalue",
+        "secretkey": "ABC",
+        "nestnest": {"leaf": "value"},
+    }
+    assert d == expected
+    # also verify that the original config dictionary was not modified
+    assert original == myconf.conf
+
+    # same test, one layer up
+    d = myconf.subtree_to_dict("nested")
+    expected = {
+        "morenested": {
+            "key3": "nestedvalue",
+            "secretkey": "ABC",
+            "nestnest": {"leaf": "value"},
+        }
+    }
+    assert d == expected
+    # also verify that the original config dictionary was not modified
+    assert original == myconf.conf
+
+    # pointing to a non-dictionary generates a KeyError
+    with pytest.raises(KeyError):
+        myconf.subtree_to_dict("key1")
+
+    # pointing to a non existing entry return an empty dict
+    d = myconf.subtree_to_dict("nested.foo")
+    assert d == None
 
 
 def test_configmodel_exists(some_nested_config):

--- a/tests/configmodel/test_configmodel.py
+++ b/tests/configmodel/test_configmodel.py
@@ -45,7 +45,8 @@ def generate_some_nested_config_with_var():
                 "key3": "nestedvalue",
                 "secretkey_from_var": "SECRETKEY",
                 "nestnest": {"leaf": "value"},
-            }
+            },
+            "list": [1, 2, 3, {"foo_from_var": "SECRETKEY"}, 4, 5],
         },
         "nothing": None,
         "falsekey": False,
@@ -75,7 +76,8 @@ def test_subtree_to_dict(nested_with_var):
             "key3": "nestedvalue",
             "secretkey": "ABC",
             "nestnest": {"leaf": "value"},
-        }
+        },
+        "list": [1, 2, 3, {"foo": "ABC"}, 4, 5],
     }
     assert d == expected
     # also verify that the original config dictionary was not modified

--- a/tests/scanners/zap/test_setup.py
+++ b/tests/scanners/zap/test_setup.py
@@ -248,19 +248,40 @@ def test_setup_include_urls(test_config):
     assert "def" in find_context(test_zap.automation_config)["includePaths"]
 
 
+def test_setup_active_scan(test_config):
+    test_config.set("scanners.zap.activeScan.maxRuleDurationInMins", 10)
+
+    test_zap = ZapNone(config=test_config)
+    test_zap.setup()
+
+    for item in test_zap.automation_config["jobs"]:
+        if item["type"] == "activeScan":
+            assert item["parameters"]["policy"] == "API-scan-minimal"
+            assert item["parameters"]["maxRuleDurationInMins"] == 10
+            assert item["parameters"]["context"] == "Default Context"
+            assert item["parameters"]["user"] == ""
+            break
+    else:
+        assert False
+
+
 def test_setup_ajax(test_config):
     test_config.set("scanners.zap.spiderAjax.maxDuration", 10)
     test_config.set("scanners.zap.spiderAjax.url", "http://test.com")
     test_config.set("scanners.zap.spiderAjax.browserId", "chrome-headless")
+    test_config.set("scanners.zap.spiderAjax.maxCrawlState", 3)
 
     test_zap = ZapNone(config=test_config)
     test_zap.setup()
 
     for item in test_zap.automation_config["jobs"]:
         if item["type"] == "spiderAjax":
+            assert item["parameters"]["context"] == "Default Context"
             assert item["parameters"]["maxDuration"] == 10
+            assert item["parameters"]["user"] == ""
             assert item["parameters"]["url"] == "http://test.com"
             assert item["parameters"]["browserId"] == "chrome-headless"
+            assert item["parameters"]["maxCrawlState"] == 3
             break
     else:
         assert False


### PR DESCRIPTION
Added ability to apply any parameters to AjaxSpider and ActiveScan jobs. This could eventually be extended to all jobs.

To achieve that:
- added a configModel function to get a subtree from the config. Just in case: this subtree also applies all the `_from_var` entries
- used that in activeScan and ajaxSpider to get all parameters

Regarding the tests:
- activeScan & ajaxSpider remains compatible with previous test, so minor change were applied
- test for configModel.subtree_to_dict has been added