### PR TITLE
convert_trivy_k8s_to_sarif takes data from STDIN

### DIFF
--- a/config/config-template-trivy-k8s-scan.yaml
+++ b/config/config-template-trivy-k8s-scan.yaml
@@ -40,7 +40,7 @@ scanners:
     # 'inline' is used when container.type is not 'podman'
     # 'toolDir' specifies the default directory where inline scripts are located
     #toolDir: scanners/generic/tools
-    inline: "trivy k8s --kubeconfig=/home/rapidast/.kube/config -n default pod --scanners=misconfig --report all --format json -o /tmp/k8s_result.json && python3 convert_trivy_k8s_to_sarif.py -f /tmp/k8s_result.json"
+    inline: "trivy k8s --kubeconfig=/home/rapidast/.kube/config -n default pod --scanners=misconfig --report all --format json | convert_trivy_k8s_to_sarif.py"
 
     container:
       parameters:

--- a/containerize/Containerfile
+++ b/containerize/Containerfile
@@ -55,6 +55,9 @@ COPY ./configmodel/ /opt/rapidast/configmodel/
 COPY ./utils/ /opt/rapidast/utils/
 COPY ./config/ /opt/rapidast/config/
 
+### Add generic tools in the PATH
+COPY ./scanners/generic/tools/convert_trivy_k8s_to_sarif.py /usr/local/bin/
+
 ### Overload default config (set 'none' as default container type)
 COPY ./containerize/container_default_config.yaml /opt/rapidast/rapidast-defaults.yaml
 

--- a/scanners/generic/tools/convert_trivy_k8s_to_sarif.py
+++ b/scanners/generic/tools/convert_trivy_k8s_to_sarif.py
@@ -3,21 +3,28 @@
 #
 # Convert a Trivy k8s json result to SARIF format(stdout).
 # A usage example (see options in the code):
-#  $ convert_trivy_k8s_to_sarify.py -f <input.json> [--log-level=DEBUG]
+#  $ convert_trivy_k8s_to_sarify.py [-f <input.json>] [--log-level=DEBUG]
+# If `-f` is absent, or its value is `-`, JSON data will be read from STDIN
 #
 #
 import argparse
 import json
+import sys
 import logging
 
 
 def read_json_block(json_file):
     """
-    Read JSON data from a file.
+    Read JSON data from a file, or from STDIN.
     """
-    with open(json_file, "r", encoding="utf-8") as f:
-        json_data = json.load(f)
-    return json_data
+    if json_file is None or json_file == "-":
+        logging.debug("Reading input from STDIN")
+        data = sys.stdin.read()
+    else:
+        logging.debug(f"Reading input from '{json_file}'")
+        with open(json_file, "r", encoding="utf-8") as f:
+            data = f.read()
+    return json.loads(data)
 
 
 def convert_json_to_sarif(json_data):
@@ -101,8 +108,9 @@ def main():
         "-f",
         "--filename",
         type=str,
-        required=True,
-        help="Path to JSON file",
+        required=False,
+        default=None,
+        help="Path to JSON file (if absent or '-': read from STDIN)",
     )
     parser.add_argument(
         "--log-level",

--- a/tests/scanners/generic/tools/test_convert_trivy_k8s.py
+++ b/tests/scanners/generic/tools/test_convert_trivy_k8s.py
@@ -3,7 +3,7 @@ import json
 
 import pytest
 
-from scanners.generic.tools.convert_trivy_k8s_to_sarif import convert_json_to_sarif
+from scanners.generic.tools.convert_trivy_k8s_to_sarif import convert_json_to_sarif, read_json_block
 
 TEST_DATA_DIR = "tests/scanners/generic/tools/test_data_convert_trivy_k8s/"
 
@@ -18,6 +18,13 @@ def _assert_default_sarif_info(sarif):
         return False
 
     return True
+
+def test_read_json_block():
+    json_file = TEST_DATA_DIR + "sample-single-result.json"
+    json_assert = json.load(open(json_file))
+
+    json_test = read_json_block(json_file)
+    assert json_test == json_assert
 
 
 def test_convert_json_to_sarif():


### PR DESCRIPTION
Modify convert_trivy_k8s_to_sarif.py such that it can take data from STDIN if the `-f` argument is either missing or `-`.

Also:
- added a small test for read_json_block
- allow convert_trivy_k8s_to_sarif.py to be run directly: - chmod +x convert_trivy_k8s_to_sarif.py - in container image: copy it in the PATH
- modified the config-template-trivy-k8s-scan.yaml template accordingly