### PR TITLE
Add actions pipeline

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,33 @@
+name: RapiDAST
+
+on:
+  push:
+    branches: ["development", "main"]
+  pull_request:
+    branches: ["development", "main"]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.9"
+    - name: Install dependencies
+      run: |
+        python3 -m ensurepip --upgrade
+        pip install --no-cache-dir -r requirements.txt -r requirements-dev.txt
+    - name: Lint with pre-commit hook
+      continue-on-error: true # XXX temporary, until all code linted
+      run: |
+        pre-commit run --all-files
+    - name: Test with pytest
+      run: |
+        pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,10 +24,10 @@ jobs:
       run: |
         python3 -m ensurepip --upgrade
         pip install --no-cache-dir -r requirements.txt -r requirements-dev.txt
+    - name: Test with pytest
+      run: |
+        pytest
     - name: Lint with pre-commit hook
       continue-on-error: true # XXX temporary, until all code linted
       run: |
         pre-commit run --all-files
-    - name: Test with pytest
-      run: |
-        pytest


### PR DESCRIPTION
Adds basic Actions CI pipeline.

* Linting step currently fails because there are yet-to-be-linted files, so temporarily `continue-on-error` is set for this step
*  ubuntu base because GH hosted runner options are limited: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners
* python3.9 because that is the version installed in the ubi9 based rapidast container image