### PR TITLE
Add workflow to add new git tags to images on quay.io

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -17,9 +17,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    # https://github.com/redhat-actions/buildah-build#readme
     steps:
     - uses: actions/checkout@v4
+    # https://github.com/redhat-actions/buildah-build#readme
     - name: Build container image
       id: build-image
       uses: redhat-actions/buildah-build@v2

--- a/.github/workflows/tag-image.yml
+++ b/.github/workflows/tag-image.yml
@@ -1,0 +1,33 @@
+name: Tag image on quay.io
+
+env:
+  IMAGE_NAME: "rapidast"
+  IMAGE_REGISTRY: quay.io/redhatproductsecurity
+  IMAGE_REGISTRY_USER: ${{ secrets.IMAGE_REGISTRY_USER }}
+  IMAGE_REGISTRY_PASSWORD: ${{ secrets.IMAGE_REGISTRY_PASSWORD }}
+
+on:
+  push:
+    tags: ["*"]
+
+jobs:
+
+  tag-image:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    # https://github.com/redhat-actions/podman-login
+    - name: Log in to quay.io
+      uses: redhat-actions/podman-login@v1
+      with:
+        registry: ${{ env.IMAGE_REGISTRY }}
+        username: ${{ env.IMAGE_REGISTRY_USER }}
+        password: ${{ env.IMAGE_REGISTRY_PASSWORD }}
+
+    - name: Tag image
+      run: |
+          # tag existing image on quay.io that has :<commit> tag with :<new> gh tag
+          SRC=${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          DST=${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+          skopeo copy docker://${SRC} docker://${DST}


### PR DESCRIPTION
Tricky to test this without merging.

- skopeo looks to be installed by default already on ubuntu runners: https://github.com/actions/runner-images/blob/22a8b4c4acd38579dd6bd5c2fcb5b7c492161ea7/images/ubuntu/Ubuntu2404-Readme.md?plain=1#L96
- `github.ref` can be a branch name or a tag, however the `on.push.tags` section should enforce that this workflow only runs on new tags
- assumes that image has already been pushed to quay.io with `:<commit>` tag