### PR TITLE
Add error handling for when zap is not installed

### DIFF
--- a/scanners/zap/zap_none.py
+++ b/scanners/zap/zap_none.py
@@ -2,7 +2,9 @@ import logging
 import os
 import platform
 import pprint
+import shutil
 import subprocess
+import sys
 from shutil import disk_usage
 
 from .zap import MODULE_DIR
@@ -277,7 +279,12 @@ class ZapNone(Zap):
         """
         logging.info("Zap: verifying the viability of ZAP")
 
-        command = [self.my_conf("container.parameters.executable")]
+        cmd = self.my_conf("container.parameters.executable")
+        if shutil.which(cmd) is None:
+            logging.error(f"{cmd} not found in PATH, is ZAP installed?")
+            sys.exit(1)
+
+        command = [cmd]
         command.extend(self._get_standard_options())
         command.extend(["-dir", self.container_home_dir])
         command.append("-cmd")


### PR DESCRIPTION
Before:

```
$ ./rapidast.py --config config.yaml
INFO:Next scanner: 'zap'
INFO:Preparing ZAP configuration
INFO:ZAP NOT configured with any authentication
INFO:Saved Automation Framework in /tmp/rapidast_zap_4b_ulssd/workdir/af.yaml
INFO:Running up the ZAP scanner on the host
INFO:Zap: verifying the viability of ZAP
Traceback (most recent call last):
  File "/home/sfowler/code/rapidast/./rapidast.py", line 223, in <module>
    run()
  File "/home/sfowler/code/rapidast/./rapidast.py", line 208, in run
    ret = run_scanner(name, config, args, scan_exporter)
  File "/home/sfowler/code/rapidast/./rapidast.py", line 100, in run_scanner
    scanner.run()
  File "/home/sfowler/code/rapidast/scanners/zap/zap_none.py", line 107, in run
    self._check_plugin_status()
  File "/home/sfowler/code/rapidast/scanners/zap/zap_none.py", line 286, in _check_plugin_status
    result = subprocess.run(command, check=False, capture_output=True)
  File "/usr/lib64/python3.9/subprocess.py", line 505, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/usr/lib64/python3.9/subprocess.py", line 951, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib64/python3.9/subprocess.py", line 1837, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'zap.sh'
```

After:

```
$ ./rapidast.py --config config.yaml
INFO:Next scanner: 'zap'
INFO:Preparing ZAP configuration
INFO:ZAP NOT configured with any authentication
INFO:Saved Automation Framework in /tmp/rapidast_zap_brlvwf_w/workdir/af.yaml
INFO:Running up the ZAP scanner on the host
INFO:Zap: verifying the viability of ZAP
ERROR:zap.sh not found in PATH, is ZAP installed?
```

`shutil.which()` also does not depend on `which` being installed, e.g. 

```
 # which curl
bash: which: command not found
# python3 -c 'import shutil; print(shutil.which("curl"))'
/usr/bin/curl
```