### PR TITLE
Bump trivy to resolve CVEs

### DIFF
--- a/containerize/Containerfile
+++ b/containerize/Containerfile
@@ -26,11 +26,6 @@ RUN mkdir -p /opt/firefox /tmp/firefox && \
 RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
   install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 
-## Trivy (https://github.com/aquasecurity/trivy/)
-# Use install.sh to easily specify a particular version & implicitely verify integrity
-RUN curl -LO --create-dirs --output-dir /tmp/trivy/  https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh && \
-  bash /tmp/trivy/install.sh -b /tmp/trivy/ v0.49.1
-
 ## redocly (https://github.com/Redocly/redocly-cli)
 RUN mkdir -p /tmp/redocly/node_modules && npm install --prefix /tmp/redocly @redocly/cli@1.9.1
 
@@ -40,8 +35,9 @@ FROM registry.access.redhat.com/ubi9-minimal
 COPY --from=deps /opt/zap /opt/zap
 COPY --from=deps /opt/firefox /opt/firefox
 COPY --from=deps /usr/local/bin/kubectl /usr/local/bin/kubectl
-COPY --from=deps /tmp/trivy/trivy /usr/local/bin/trivy
 COPY --from=deps /tmp/redocly/node_modules /opt/redocly/node_modules
+
+RUN rpm -ivh https://github.com/aquasecurity/trivy/releases/download/v0.54.1/trivy_0.54.1_Linux-64bit.rpm
 
 ENV PATH $PATH:/opt/zap/:/opt/rapidast/:/opt/firefox/
 


### PR DESCRIPTION
This bumps the version of trivy from 0.49.1 to 0.54.1, to resolve critical CVE detections found on quay.io:

![image](https://github.com/user-attachments/assets/1969b156-5a7f-4bc1-ae19-fd73924bc54e)


This change also replaces the install method with the one documented here:

https://aquasecurity.github.io/trivy/v0.56/getting-started/installation/#rhelcentos-official

Why version 0.54.1?

Version 0.54.0 is the first version after 0.49.1 to include both of the critical CVE fixes. 0.54.1 includes a few additional patches. Based on [changelog](https://github.com/aquasecurity/trivy/blob/main/CHANGELOG.md) it looks like there can be breaking in changes in minor releases (y-stream), so I have tried to be conservative and minimise the number of versions we jump ahead.

This change will likely need some manul testing before it lands in a stable release.