### PR TITLE
Export the ZAP site tree as a JSON file

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,2 +1,5 @@
 [TYPECHECK]
 generated-members=logging.verbose
+
+[main]
+max-module-lines=1100

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,2 @@
 [TYPECHECK]
 generated-members=logging.verbose
-
-[main]
-max-module-lines=1100

--- a/scanners/zap/scripts/export-site-tree.js
+++ b/scanners/zap/scripts/export-site-tree.js
@@ -1,0 +1,56 @@
+/**
+ * Script to traverse the site tree and export node information to a JSON file
+ *
+ * This script retrieves the root of the site tree from the current ZAP session,
+ * traverses each child node, and collects relevant information such as node name,
+ * HTTP method, and status code. The collected data is then written to a JSON file 
+ * named 'zap_site_tree.json' in the session's results directory
+ */
+
+var File = Java.type('java.io.File');
+var FileWriter = Java.type('java.io.FileWriter');
+var BufferedWriter = Java.type('java.io.BufferedWriter');
+
+function listChildren(node, resultList) {
+    for (var j = 0; j < node.getChildCount(); j++) {
+        listChildren(node.getChildAt(j), resultList);
+    }
+
+    if (node.getChildCount() == 0) {
+        var href = node.getHistoryReference();
+        var nodeInfo = {};
+        nodeInfo["name"] = node.getHierarchicNodeName();
+
+        if (href != null) {
+            nodeInfo["method"] = href.getMethod();
+            nodeInfo["status"] = href.getStatusCode();
+        } else {
+            nodeInfo["method"] = "No History Reference";
+            nodeInfo["status"] = "No History Reference";
+        }
+
+        resultList.push(nodeInfo);
+    }
+}
+
+try {
+    var root = model.getSession().getSiteTree().getRoot();
+    var resultList = [];
+    
+    listChildren(root, resultList);
+
+    var jsonOutput = JSON.stringify(resultList, null, 4);  
+    
+    var defaultResultsDir = model.getSession().getSessionFolder();
+    var outputFilePath = new File(defaultResultsDir, "zap_site_tree.json").getAbsolutePath();
+
+    var file = new File(outputFilePath);
+    var writer = new BufferedWriter(new FileWriter(file));
+    writer.write(jsonOutput);
+    writer.close();
+
+    print("Site tree data has been written to: " + outputFilePath);
+
+} catch (e) {
+    print("An error occurred: " + e);
+}

--- a/scanners/zap/scripts/export-site-tree.js
+++ b/scanners/zap/scripts/export-site-tree.js
@@ -3,7 +3,7 @@
  *
  * This script retrieves the root of the site tree from the current ZAP session,
  * traverses each child node, and collects relevant information such as node name,
- * HTTP method, and status code. The collected data is then written to a JSON file 
+ * HTTP method, and status code. The collected data is then written to a JSON file
  * named 'zap_site_tree.json' in the session's results directory
  */
 
@@ -36,11 +36,11 @@ function listChildren(node, resultList) {
 try {
     var root = model.getSession().getSiteTree().getRoot();
     var resultList = [];
-    
+
     listChildren(root, resultList);
 
-    var jsonOutput = JSON.stringify(resultList, null, 4);  
-    
+    var jsonOutput = JSON.stringify(resultList, null, 4);
+
     var defaultResultsDir = model.getSession().getSessionFolder();
     var outputFilePath = new File(defaultResultsDir, "zap_site_tree.json").getAbsolutePath();
 

--- a/scanners/zap/scripts/export-site-tree.js
+++ b/scanners/zap/scripts/export-site-tree.js
@@ -4,12 +4,22 @@
  * This script retrieves the root of the site tree from the current ZAP session,
  * traverses each child node, and collects relevant information such as node name,
  * HTTP method, and status code. The collected data is then written to a JSON file
- * named 'zap_site_tree.json' in the session's results directory
+ * named 'zap-site-tree.json' in the session's results directory
  */
 
 var File = Java.type('java.io.File');
 var FileWriter = Java.type('java.io.FileWriter');
 var BufferedWriter = Java.type('java.io.BufferedWriter');
+
+const defaultFileName = "zap-site-tree.json";
+
+try {
+    var fileName = org.zaproxy.zap.extension.script.ScriptVars.getGlobalVar('siteTreeFileName') || defaultFileName;
+
+} catch (e) {
+    var fileName = defaultFileName;
+    print("Error retrieving 'siteTreeFileName': " + e.message + ". Using default value: '" + defaultFileName);
+}
 
 function listChildren(node, resultList) {
     for (var j = 0; j < node.getChildCount(); j++) {
@@ -42,7 +52,7 @@ try {
     var jsonOutput = JSON.stringify(resultList, null, 4);
 
     var defaultResultsDir = model.getSession().getSessionFolder();
-    var outputFilePath = new File(defaultResultsDir, "zap_site_tree.json").getAbsolutePath();
+    var outputFilePath = new File(defaultResultsDir, fileName).getAbsolutePath();
 
     var file = new File(outputFilePath);
     var writer = new BufferedWriter(new FileWriter(file));

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 import glob
 import logging
 import os

--- a/tests/scanners/zap/test_copy_site_tree.py
+++ b/tests/scanners/zap/test_copy_site_tree.py
@@ -1,0 +1,44 @@
+import os
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from scanners.zap.zap_none import ZapNone
+import configmodel
+
+
+@pytest.fixture(scope="function")
+def test_config():
+    return configmodel.RapidastConfigModel({"application": {"url": "http://example.com"}})
+
+
+@patch("os.path.exists")
+@patch("scanners.zap.zap.shutil.copy")
+@patch("scanners.zap.zap.shutil.copytree")
+@patch("scanners.zap.zap.tarfile")
+def test_zap_none_postprocess_copy_site_tree_path(mock_tarfile, mock_copytree, mock_copy, mock_exists, test_config):
+    mock_exists.return_value = True
+    
+    test_zap = ZapNone(config=test_config)
+    with patch.object(test_zap, '_copy_site_tree') as mock_copy_site_tree:
+        test_zap.postprocess()
+        mock_copy_site_tree.assert_called_once()
+
+@patch('os.path.exists')
+@patch('shutil.copy')
+def test_copy_site_tree_success(mock_copy, mock_exists, test_config):
+    mock_exists.return_value = True
+    test_zap = ZapNone(config=test_config)
+    test_zap._copy_site_tree()
+    
+    mock_copy.assert_called_once_with(os.path.join(test_zap.host_work_dir, 'session_data/zap_site_tree.json'), test_zap.results_dir)
+
+@patch('os.path.exists')
+@patch('shutil.copy')
+def test_copy_site_tree_file_not_found(mock_copy, mock_exists, test_config):
+    mock_exists.return_value = False
+    test_zap = ZapNone(config=test_config)
+    test_zap._copy_site_tree()
+    
+    assert not mock_copy.called
+    

--- a/tests/scanners/zap/test_copy_site_tree.py
+++ b/tests/scanners/zap/test_copy_site_tree.py
@@ -1,10 +1,11 @@
 import os
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import pytest
 
-from scanners.zap.zap_none import ZapNone
 import configmodel
+from scanners.zap.zap_none import ZapNone
 
 
 @pytest.fixture(scope="function")
@@ -18,27 +19,30 @@ def test_config():
 @patch("scanners.zap.zap.tarfile")
 def test_zap_none_postprocess_copy_site_tree_path(mock_tarfile, mock_copytree, mock_copy, mock_exists, test_config):
     mock_exists.return_value = True
-    
+
     test_zap = ZapNone(config=test_config)
-    with patch.object(test_zap, '_copy_site_tree') as mock_copy_site_tree:
+    with patch.object(test_zap, "_copy_site_tree") as mock_copy_site_tree:
         test_zap.postprocess()
         mock_copy_site_tree.assert_called_once()
 
-@patch('os.path.exists')
-@patch('shutil.copy')
+
+@patch("os.path.exists")
+@patch("shutil.copy")
 def test_copy_site_tree_success(mock_copy, mock_exists, test_config):
     mock_exists.return_value = True
     test_zap = ZapNone(config=test_config)
     test_zap._copy_site_tree()
-    
-    mock_copy.assert_called_once_with(os.path.join(test_zap.host_work_dir, 'session_data/zap_site_tree.json'), test_zap.results_dir)
 
-@patch('os.path.exists')
-@patch('shutil.copy')
+    mock_copy.assert_called_once_with(
+        os.path.join(test_zap.host_work_dir, "session_data/zap_site_tree.json"), test_zap.results_dir
+    )
+
+
+@patch("os.path.exists")
+@patch("shutil.copy")
 def test_copy_site_tree_file_not_found(mock_copy, mock_exists, test_config):
     mock_exists.return_value = False
     test_zap = ZapNone(config=test_config)
     test_zap._copy_site_tree()
-    
+
     assert not mock_copy.called
-    

--- a/tests/scanners/zap/test_copy_site_tree.py
+++ b/tests/scanners/zap/test_copy_site_tree.py
@@ -34,7 +34,7 @@ def test_copy_site_tree_success(mock_copy, mock_exists, test_config):
     test_zap._copy_site_tree()
 
     mock_copy.assert_called_once_with(
-        os.path.join(test_zap.host_work_dir, "session_data/zap_site_tree.json"), test_zap.results_dir
+        os.path.join(test_zap.host_work_dir, f"session_data/{ZapNone.SITE_TREE_FILENAME}"), test_zap.results_dir
     )
 
 

--- a/tests/scanners/zap/test_setup.py
+++ b/tests/scanners/zap/test_setup.py
@@ -416,15 +416,25 @@ def test_setup_export_site_tree(test_config, pytestconfig):
 
     add_script = None
     run_script = None
+    add_variable_script = None
+    run_variable_script = None
 
     for item in test_zap.automation_config["jobs"]:
         if item["name"] == "export-site-tree-add":
             add_script = item
         if item["name"] == "export-site-tree-run":
             run_script = item
+        if item["name"] == "export-site-tree-filename-global-var-add":
+            add_variable_script = item
+        if item["name"] == "export-site-tree-filename-global-var-run":
+            run_variable_script = item
 
-    assert add_script and run_script
+    assert add_script and run_script and add_variable_script and run_variable_script
 
     assert add_script["parameters"]["name"] == run_script["parameters"]["name"]
     assert add_script["parameters"]["file"] == f"{pytestconfig.rootpath}/scanners/zap/scripts/export-site-tree.js"
     assert add_script["parameters"]["engine"] == "ECMAScript : Oracle Nashorn"
+
+    assert add_variable_script["parameters"]["name"] == run_variable_script["parameters"]["name"]
+    assert add_variable_script["parameters"]["inline"]
+    assert add_variable_script["parameters"]["engine"] == "ECMAScript : Graal.js"

--- a/tests/scanners/zap/test_setup.py
+++ b/tests/scanners/zap/test_setup.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import re
 from pathlib import Path
 
@@ -404,3 +405,26 @@ def test_get_update_command(test_config):
     assert "-addonupdate" in test_zap.get_update_command()
     assert "pluginA" in test_zap.get_update_command()
     assert "pluginB" in test_zap.get_update_command()
+
+
+# Export Site Tree
+
+
+def test_setup_export_site_tree(test_config, pytestconfig):
+    test_zap = ZapNone(config=test_config)
+    test_zap.setup()
+
+    add_script = None
+    run_script = None
+
+    for item in test_zap.automation_config["jobs"]:
+        if item["name"] == "export-site-tree-add":
+            add_script = item
+        if item["name"] == "export-site-tree-run":
+            run_script = item
+
+    assert add_script and run_script
+
+    assert add_script["parameters"]["name"] == run_script["parameters"]["name"]
+    assert add_script["parameters"]["file"] == f"{pytestconfig.rootpath}/scanners/zap/scripts/export-site-tree.js"
+    assert add_script["parameters"]["engine"] == "ECMAScript : Oracle Nashorn"


### PR DESCRIPTION
This PR adds functionality to export the ZAP the list of scanned URLs generated during a scan, into a JSON file. This JSON file will be accessible in the RapiDAST results directory. 

The ZAP automation framework is used to run jobs that install and execute a custom JavaScript script. This script exports the ZAP site tree, including the scanned URLs, to a JSON file in the session directory. During RapiDAST's post-processing, the JSON file is copied to the results directory for easy access and analysis.

Initially, I planned to use Python for the ZAP script, but that would require installing additional Python scripting add-ons in ZAP, so I decided to stick with JavaScript which was already supported. It seems that ZAP [supports](https://github.com/zaproxy/zaproxy/wiki/InternalScripting) two JavaScript engines: Rhino and Nashorn. I chose Nashorn to maintain consistency with other scripts that already use this engine, with no additional considerations. 