### PR TITLE
fix bug in config redaction

### DIFF
--- a/rapidast.py
+++ b/rapidast.py
@@ -149,6 +149,8 @@ def dump_redacted_config(config_file_location: str, destination_dir: str) -> boo
 
         logging.info(f"Redacting sensitive information from configuration {config_file_location}")
         for key in config.keys():
+            if not isinstance(config[key], dict):
+                continue
             if config[key].get("authentication") and config[key]["authentication"].get("parameters"):
                 for param in config[key]["authentication"]["parameters"]:
                     config[key]["authentication"]["parameters"][param] = "*****"


### PR DESCRIPTION
Follow up to ee14d55d5820a379c25f41405a8b6f083ce0ea1e

Before:

```
$ ./rapidast.py  --config ./config/config-flags.yaml
INFO:Starting the redaction and dumping process for the configuration file: {config_file_location}
INFO:Created destination directory: ./results/flags-1.0/DAST-20241030-092322-RapiDAST-flags-1.0
INFO:Redacting sensitive information from configuration ./config/config-flags.yaml
Traceback (most recent call last):
  File "/home/sfowler/code/rapidast/./rapidast.py", line 286, in <module>
    run()
  File "/home/sfowler/code/rapidast/./rapidast.py", line 226, in run
    dump_rapidast_redacted_configs(config_file, full_result_dir_path)
  File "/home/sfowler/code/rapidast/./rapidast.py", line 177, in dump_rapidast_redacted_configs
    if not dump_redacted_config(main_config_file_location, destination_dir):
  File "/home/sfowler/code/rapidast/./rapidast.py", line 152, in dump_redacted_config
    if config[key].get("authentication") and config[key]["authentication"].get("parameters"):
AttributeError: 'NoneType' object has no attribute 'get'
```

After:

```
$ ./rapidast.py  --config ./config/config-flags.yaml
INFO:Starting the redaction and dumping process for the configuration file: {config_file_location}
INFO:Created destination directory: ./results/flags-1.0/DAST-20241030-092330-RapiDAST-flags-1.0
INFO:Redacting sensitive information from configuration ./config/config-flags.yaml
INFO:Saving redacted configuration to ./results/flags-1.0/DAST-20241030-092330-RapiDAST-flags-1.0/config-flags.yaml
INFO:Redacted configuration saved successfully
INFO:Next scanner: 'zap'
INFO:Preparing ZAP configuration
INFO:ZAP NOT configured with any authentication
INFO:Saved Automation Framework in /tmp/rapidast_zap_fb_5l4xq/workdir/af.yaml
INFO:Running up the ZAP scanner on the host
INFO:Zap: verifying the viability of ZAP
ERROR:zap.sh not found in PATH, is ZAP installed?
```