### PR TITLE
Switch from the Nashorn engine to Graal.js for executing the the export-site-tree script

### DIFF
--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -414,7 +414,7 @@ class Zap(RapidastScanner):
             "parameters": {
                 "action": "add",
                 "type": "standalone",
-                "engine": "ECMAScript : Oracle Nashorn",
+                "engine": "ECMAScript : Graal.js",
                 "name": "export-site-tree",
                 "file": f"{scripts_dir}/export-site-tree.js",
             },

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -393,8 +393,6 @@ class Zap(RapidastScanner):
                 "action": "add",
                 "type": "standalone",
                 "name": "export-site-tree-filename-global-var",
-                # Setting the engine to Oracle Nashorn causes the script to fail because
-                # the engine can't be found when using inline scripts. Not sure why this happens
                 "engine": "ECMAScript : Graal.js",
                 "inline": f"""
                 org.zaproxy.zap.extension.script.ScriptVars.setGlobalVar('siteTreeFileName','{self.SITE_TREE_FILENAME}')

--- a/tests/scanners/zap/test_setup.py
+++ b/tests/scanners/zap/test_setup.py
@@ -433,7 +433,7 @@ def test_setup_export_site_tree(test_config, pytestconfig):
 
     assert add_script["parameters"]["name"] == run_script["parameters"]["name"]
     assert add_script["parameters"]["file"] == f"{pytestconfig.rootpath}/scanners/zap/scripts/export-site-tree.js"
-    assert add_script["parameters"]["engine"] == "ECMAScript : Oracle Nashorn"
+    assert add_script["parameters"]["engine"] == "ECMAScript : Graal.js"
 
     assert add_variable_script["parameters"]["name"] == run_variable_script["parameters"]["name"]
     assert add_variable_script["parameters"]["inline"]


### PR DESCRIPTION
Fixes: https://github.com/RedHatProductSecurity/rapidast/issues/232

The Nashorn engine supports only a limited set of ES6 features, which has resulted in the issue reported [here](https://github.com/RedHatProductSecurity/rapidast/issues/232). This issue was reproduced with OpenJDK 11 but not with OpenJDK 17. The Nashorn engine was deprecated in JDK 11(JEP [335](https://openjdk.org/jeps/335)) and removed in JDK 15 (JEP [372](https://openjdk.org/jeps/372)). This explains why ZAP fails when using the Nashorn engine with inline scripts in OpenJDK 17; the engine cannot be found in this context. However, the same version of OpenJDK works when the script is not inline.

To prevent similar issues in the future, I have switched to the Graal.js engine. Since the release of ZAP 2.14, Graal.js has been the recommended JavaScript engine. For more information, please see [this](https://www.zaproxy.org/blog/2023-10-12-zap-2-14-0/#graal-js-add-on-access)

