### PR TITLE
Improved startup time

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,9 +449,9 @@ Example: `podman pod create --userns=keep-id:uid=1000,gid=1000 myApp_Pod`
 
 This is useful for debugging.  Set `scanners.zap.miscOptions.enableUI: True` (default: False).  Then, the ZAP desktop will run with GUI on your host and show the progress of scanning.
 
-+ Disable add-on updates:
++ Enable add-on updates:
 
-Set `scanners.zap.miscOptions.updateAddons: False` (default: True). Then, ZAP will update its addons first and run the scan.
+Set `scanners.zap.miscOptions.updateAddons: True` (default: False). ZAP will first update its addons and then run the scan.
 
 + Install additional addons:
 

--- a/config/config-template-zap-long.yaml
+++ b/config/config-template-zap-long.yaml
@@ -188,7 +188,7 @@ scanners:
       # EnableUI (default: false), requires a compatible runtime (e.g.: `type: none`)
       enableUI: False
 
-      # Defaults to True, set False to prevent auto update of ZAP plugins
+      # Defaults to False, set True to force auto update of ZAP plugins
       updateAddons: True
 
       # List (comma-separated string or list) of additional addons to install

--- a/e2e-tests/manifests/rapidast-vapi-configmap.yaml
+++ b/e2e-tests/manifests/rapidast-vapi-configmap.yaml
@@ -30,7 +30,7 @@ data:
         miscOptions:
           # enableUI (default: false), requires a compatible runtime (e.g.: flatpak or no containment)
           #enableUI: True
-          # Defaults to True, set False to prevent auto update of ZAP plugins
+          # Defaults to False, set True to force auto update of ZAP plugins
           updateAddons: False
           # additionalAddons: ascanrulesBeta
           # If set to True and authentication is oauth2_rtoken and api.apiUrl is set, download the API outside of ZAP

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -191,6 +191,9 @@ class Zap(RapidastScanner):
         """
         self.zap_cli.extend(self._get_standard_options())
 
+        # Addon update has already been done, if enabled. Prevent a new check for update
+        self.zap_cli.append("-silent")
+
         # Create a session, to store them as evidence
         self.zap_cli.extend(["-newsession", f"{self.container_work_dir}/session_data/session"])
 

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -151,7 +151,7 @@ class Zap(RapidastScanner):
             *self._get_standard_options(),
             "-cmd",
         ]
-        if self.my_conf("miscOptions.updateAddons", default=True):
+        if self.my_conf("miscOptions.updateAddons"):
             command.append("-addonupdate")
 
         addons = self.my_conf("miscOptions.additionalAddons", default=[])

--- a/scanners/zap/zap_none.py
+++ b/scanners/zap/zap_none.py
@@ -106,8 +106,6 @@ class ZapNone(Zap):
         if not self.state == State.READY:
             raise RuntimeError("[ZAP SCANNER]: ERROR, not ready to run")
 
-        # self._check_plugin_status()
-
         # temporary workaround: cleanup addon state
         # see https://github.com/zaproxy/zaproxy/issues/7590#issuecomment-1308909500
         statefile = f"{self.host_home_dir}/add-ons-state.xml"
@@ -260,7 +258,7 @@ class ZapNone(Zap):
 
         command = self.get_update_command()
         if not command:
-            logging.debug("Skpping addon handling: no install, no update")
+            logging.debug("Skipping addon handling: no install, no update")
             return
         # manually specify directory
         command.extend(["-dir", self.container_home_dir])
@@ -272,53 +270,6 @@ class ZapNone(Zap):
             logging.warning(
                 f"ZAP did not handle the addon requirements correctly, and exited with code {result.returncode}"
             )
-
-    def _check_plugin_status(self):
-        """MacOS workaround for "The mandatory add-on was not found" error
-        See https://github.com/zaproxy/zaproxy/issues/7703
-        """
-        logging.info("Zap: verifying the viability of ZAP")
-
-        cmd = self.my_conf("container.parameters.executable")
-        if shutil.which(cmd) is None:
-            logging.error(f"{cmd} not found in PATH, is ZAP installed?")
-            sys.exit(1)
-
-        command = [cmd]
-        command.extend(self._get_standard_options())
-        command.extend(["-dir", self.container_home_dir])
-        command.append("-cmd")
-
-        logging.debug(f"ZAP create home command: {command}")
-        result = subprocess.run(command, check=False, capture_output=True)
-        if result.returncode == 0:
-            logging.debug("ZAP appears to be in a correct state")
-        elif result.stderr.find(bytes("The mandatory add-on was not found:", "ascii")) > 0:
-            logging.info("Missing mandatory plugins. Fixing")
-            url_root = "https://github.com/zaproxy/zap-extensions/releases/download"
-            anonymous_download(
-                url=f"{url_root}/callhome-v0.6.0/callhome-release-0.6.0.zap",
-                dest=f"{self.host_home_dir}/plugin/callhome-release-0.6.0.zap",
-                proxy=self.my_conf("proxy", default=None),
-            )
-            anonymous_download(
-                url=f"{url_root}/network-v0.9.0/network-beta-0.9.0.zap",
-                dest=f"{self.host_home_dir}/plugin/network-beta-0.9.0.zap",
-                proxy=self.my_conf("proxy", default=None),
-            )
-            logging.info("Workaround: installing all addons")
-
-            command = [self.my_conf("container.parameters.executable")]
-            command.extend(self._get_standard_options())
-            command.extend(["-dir", self.container_home_dir])
-            command.append("-cmd")
-            command.append("-addoninstallall")
-
-            logging.debug(f"ZAP: installing all addons: {command}")
-            result = subprocess.run(command, check=False)
-
-        else:
-            logging.warning(f"ZAP appears to be in a incorrect state. Error: {result.stderr}")
 
     def _create_home_if_needed(self):
         """Some tools (most notably: ZAP's Ajax Spider with Firefox) require a writable home directory.

--- a/scanners/zap/zap_none.py
+++ b/scanners/zap/zap_none.py
@@ -2,15 +2,12 @@ import logging
 import os
 import platform
 import pprint
-import shutil
 import subprocess
-import sys
 from shutil import disk_usage
 
 from .zap import MODULE_DIR
 from .zap import Zap
 from scanners import State
-from scanners.downloaders import anonymous_download
 from scanners.path_translators import make_mapping_for_scanner
 
 CLASSNAME = "ZapNone"

--- a/scanners/zap/zap_none.py
+++ b/scanners/zap/zap_none.py
@@ -106,7 +106,7 @@ class ZapNone(Zap):
         if not self.state == State.READY:
             raise RuntimeError("[ZAP SCANNER]: ERROR, not ready to run")
 
-        self._check_plugin_status()
+        # self._check_plugin_status()
 
         # temporary workaround: cleanup addon state
         # see https://github.com/zaproxy/zaproxy/issues/7590#issuecomment-1308909500

--- a/tests/scanners/zap/test_setup_podman.py
+++ b/tests/scanners/zap/test_setup_podman.py
@@ -185,10 +185,5 @@ def test_podman_handling_plugins(test_config):
     assert "pluginB" in test_zap.get_update_command()
 
     shell = test_zap._handle_plugins()
-    assert len(shell) == 3
-    assert shell[0] == "sh"
-    assert shell[1] == "-c"
-    assert re.search(
-        "^zap.sh .* -cmd -addonupdate -addoninstall pluginA -addoninstall pluginB; .*",
-        shell[2],
-    )
+    assert_shell = ["zap.sh", "-config", "network.connection.httpProxy.enabled=false", "-config", "network.localServers.mainProxy.port=47691", "-cmd", "-addonupdate", "-addoninstall", "pluginA", "-addoninstall", "pluginB"]
+    assert shell == assert_shell

--- a/tests/scanners/zap/test_setup_podman.py
+++ b/tests/scanners/zap/test_setup_podman.py
@@ -185,5 +185,17 @@ def test_podman_handling_plugins(test_config):
     assert "pluginB" in test_zap.get_update_command()
 
     shell = test_zap._handle_plugins()
-    assert_shell = ["zap.sh", "-config", "network.connection.httpProxy.enabled=false", "-config", "network.localServers.mainProxy.port=47691", "-cmd", "-addonupdate", "-addoninstall", "pluginA", "-addoninstall", "pluginB"]
+    assert_shell = [
+        "zap.sh",
+        "-config",
+        "network.connection.httpProxy.enabled=false",
+        "-config",
+        "network.localServers.mainProxy.port=47691",
+        "-cmd",
+        "-addonupdate",
+        "-addoninstall",
+        "pluginA",
+        "-addoninstall",
+        "pluginB",
+    ]
     assert shell == assert_shell


### PR DESCRIPTION
3 changes:
- disable the "fake" run, which should no longer be necessary
- changed default behavior of `updateAddons` from True to False (including documentation update)
- When running the scan, disable check for addon update (using the `-silent` option)

e2e test time statistics (limited to only VAPI test) :

→ original code (updateAddons is overridden to False during the e2e tests):

1 passed, 2 deselected in 215.03s (0:03:35)
1 passed, 2 deselected in 220.85s (0:03:40)
1 passed, 2 deselected in 328.86s (0:05:28)
1 passed, 2 deselected in 368.89s (0:06:08) 

→ disable the "fake" run : 

1 passed, 2 deselected in 199.90s (0:03:19) 
1 passed, 2 deselected in 197.37s (0:03:17) 
1 passed, 2 deselected in 191.93s (0:03:11)

→ disable the "fake" run + use `-silent`:

1 passed, 2 deselected in 64.06s (0:01:04)
1 passed, 2 deselected in 36.08s
1 passed, 2 deselected in 44.79s 
1 passed, 2 deselected in 48.89s

NOTE: the time varies from run to run even when using the same image, so these statistic might not be very valuable, but still seem to show improvements.