### PR TITLE
Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+## all changes will assign members from below team as reviewers
+* @RedHatProductSecurity/rapidast-admin


### PR DESCRIPTION
To auto-assign reviewers. 

This should hopefully work once merged into target branches, so e.g. once merged into development branch, PRs into development should get auto-assigned etc

Currently team is just 3 members, but that is because I'm not an admin of the RedHatProductSecurity org, so I can't add more members - I'll ping an admin to add @ccronca .