### PR TITLE
test that openapi job is not added when no openapi config exists

### DIFF
--- a/tests/scanners/zap/test_setup.py
+++ b/tests/scanners/zap/test_setup.py
@@ -64,11 +64,12 @@ def test_setup_no_api_config(test_config):
     # openapi job is not added when no openapi config exists
     test_config.delete("scanners.zap.apiScan")
     test_zap = ZapNone(config=test_config)
-    
+
     test_zap.setup()
-    
+
     for item in test_zap.automation_config["jobs"]:
         assert item["type"] != "openapi"
+
 
 ## Testing Authentication methods ##
 ### Handling Authentication is different depending on the container.type so it'd be better to have test cases separately
@@ -444,4 +445,3 @@ def test_setup_export_site_tree(test_config, pytestconfig):
     assert add_variable_script["parameters"]["name"] == run_variable_script["parameters"]["name"]
     assert add_variable_script["parameters"]["inline"]
     assert add_variable_script["parameters"]["engine"] == "ECMAScript : Graal.js"
-


### PR DESCRIPTION
This PR adds a test to ensure that the OpenAPI job is not added when **no** OpenAPI configuration is present. This behavior was introduced in [!160](https://github.com/RedHatProductSecurity/rapidast/pull/160/files), but a test for this specific scenario was not included at that time.

