### PR TITLE
Fix typo when setting browserId in _setup_ajax_spider

### DIFF
--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -541,7 +541,7 @@ class Zap(RapidastScanner):
         # Set some RapiDAST-centric defaults
         # Unless overwritten, browser should be Firefox-headless, since RapiDAST only has that
         if not job["parameters"].get("browserId"):
-            job["parameters"]["policy"] = "firefox-headless"
+            job["parameters"]["browserId"] = "firefox-headless"
 
         # Add to includePaths to the context
         if params.get("url"):


### PR DESCRIPTION
This PR fixes a typo introduced during a recent minor refactor. When `browserID` was not set, the incorrect parameter `policy` was used instead of the correct `browserID`.

The issue seems to be introduced as part of this PR: https://github.com/RedHatProductSecurity/rapidast/pull/212
