### PR TITLE
Wrong scan policy name check

### DIFF
--- a/rapidast.py
+++ b/rapidast.py
@@ -100,7 +100,11 @@ def run_scanner(name, config, args, scan_exporter):
         return 1
 
     # Part 2: setup the environment (e.g.: spawn a server)
-    scanner.setup()
+    try:
+        scanner.setup()
+    except Exception as excp:
+        logging.error(f"Failed to set up the scanner: {excp}")
+        return 1
 
     logging.debug(scanner)
 

--- a/rapidast.py
+++ b/rapidast.py
@@ -102,9 +102,9 @@ def run_scanner(name, config, args, scan_exporter):
     # Part 2: setup the environment (e.g.: spawn a server)
     try:
         scanner.setup()
-    except Exception as excp:
+    except Exception as excp:  # pylint: disable=W0718
         logging.error(f"Failed to set up the scanner: {excp}")
-        return 1
+        scanner.state = scanners.State.ERROR
 
     logging.debug(scanner)
 

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -1057,6 +1057,8 @@ class InvalidXMLFileError(RuntimeError):
 def validate_active_scan_policy(policy_path: Path):
     policy_name = policy_path.stem
 
+    logging.info(f"Starting validation of ZAP active scan policy: '{policy_path}'")
+
     if not policy_path.is_file():
         raise PolicyFileNotFoundError(
             f"Policy '{policy_name}' not found in '{policy_path.parent}' directory. "
@@ -1082,3 +1084,5 @@ def validate_active_scan_policy(policy_path: Path):
 
     except ET.ParseError as exc:
         raise InvalidXMLFileError(f"Policy file '{policy_path}' is not a valid XML file") from exc
+
+    logging.info(f"Validation successful for policy file: '{policy_path}'")

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -6,8 +6,10 @@ import pprint
 import re
 import shutil
 import tarfile
+import xml.etree.ElementTree as ET
 from base64 import urlsafe_b64encode
 from collections import namedtuple
+from pathlib import Path
 
 import yaml
 
@@ -637,6 +639,10 @@ class Zap(RapidastScanner):
         if not job["parameters"].get("policy"):
             job["parameters"]["policy"] = "API-scan-minimal"
 
+        validate_active_scan_policy(
+            policy_path=Path(MODULE_DIR) / "policies" / f"{job['parameters']['policy']}.policy",
+        )
+
         self.automation_config["jobs"].append(job)
 
     def _construct_report_af(self, report_format):
@@ -1026,3 +1032,53 @@ def find_context(automation_config, context=Zap.DEFAULT_CONTEXT):
         automation_config["env"]["contexts"] = []
     automation_config["env"]["contexts"].append({"name": context})
     return ensure_default(automation_config["env"]["contexts"][-1])
+
+
+class PolicyFileNotFoundError(FileNotFoundError):
+    """Raised when the policy file is not found."""
+
+
+class MissingConfigurationNodeError(RuntimeError):
+    """Raised when the root <configuration> node is missing"""
+
+
+class MissingPolicyNodeError(RuntimeError):
+    """Raised when the <policy> node inside <configuration> is missing"""
+
+
+class MismatchedPolicyNameError(RuntimeError):
+    """Raised when the <policy> node content does not match the filename"""
+
+
+class InvalidXMLFileError(RuntimeError):
+    """Raised when the policy file is not a valid XML"""
+
+
+def validate_active_scan_policy(policy_path: Path):
+    policy_name = policy_path.stem
+
+    if not policy_path.is_file():
+        raise PolicyFileNotFoundError(
+            f"Policy '{policy_name}' not found in '{policy_path.parent}' directory. "
+            f"Please check the policy name in the configuration"
+        )
+
+    try:
+        tree = ET.parse(policy_path)
+        root = tree.getroot()
+
+        if not root.tag or root.tag != "configuration":
+            raise MissingConfigurationNodeError(f"Missing <configuration> node in '{policy_name}.policy'")
+
+        policy_node = root.find("policy")
+        if policy_node is None:
+            raise MissingPolicyNodeError(f"Missing <policy> node inside <configuration> in '{policy_name}.policy'")
+
+        if policy_node.text.strip() != policy_name:
+            raise MismatchedPolicyNameError(
+                f"The <policy> node in '{policy_name}' does not match the filename. "
+                f"Expected '{policy_name}', but found '{policy_node.text.strip()}'"
+            )
+
+    except ET.ParseError as exc:
+        raise InvalidXMLFileError(f"Policy file '{policy_path}' is not a valid XML file") from exc

--- a/tests/scanners/zap/test_setup.py
+++ b/tests/scanners/zap/test_setup.py
@@ -5,7 +5,9 @@ import pytest
 import requests
 
 import configmodel.converter
+import scanners
 from scanners.zap.zap import find_context
+from scanners.zap.zap import MODULE_DIR
 from scanners.zap.zap_none import ZapNone
 
 # from pytest_mock import mocker
@@ -232,9 +234,9 @@ def test_setup_include_urls(test_config):
     assert "def" in find_context(test_zap.automation_config)["includePaths"]
 
 
-def test_setup_active_scan(test_config):
+def test_setup_active_scan(mocker, test_config):
     test_config.set("scanners.zap.activeScan.maxRuleDurationInMins", 10)
-
+    mocker.patch("scanners.zap.zap.validate_active_scan_policy")
     test_zap = ZapNone(config=test_config)
     test_zap.setup()
 
@@ -244,6 +246,10 @@ def test_setup_active_scan(test_config):
             assert item["parameters"]["maxRuleDurationInMins"] == 10
             assert item["parameters"]["context"] == "Default Context"
             assert item["parameters"]["user"] == ""
+            scanners.zap.zap.validate_active_scan_policy.assert_called_once_with(
+                policy_path=Path(f"{MODULE_DIR}/policies/API-scan-minimal.policy")
+            )
+
             break
     else:
         assert False

--- a/tests/scanners/zap/test_setup.py
+++ b/tests/scanners/zap/test_setup.py
@@ -1,5 +1,7 @@
 import os
 from pathlib import Path
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import pytest
 import requests
@@ -234,9 +236,9 @@ def test_setup_include_urls(test_config):
     assert "def" in find_context(test_zap.automation_config)["includePaths"]
 
 
-def test_setup_active_scan(mocker, test_config):
+@patch("scanners.zap.zap.validate_active_scan_policy")
+def test_setup_active_scan(mock_validate_active_scan_policy, test_config):
     test_config.set("scanners.zap.activeScan.maxRuleDurationInMins", 10)
-    mocker.patch("scanners.zap.zap.validate_active_scan_policy")
     test_zap = ZapNone(config=test_config)
     test_zap.setup()
 
@@ -246,7 +248,7 @@ def test_setup_active_scan(mocker, test_config):
             assert item["parameters"]["maxRuleDurationInMins"] == 10
             assert item["parameters"]["context"] == "Default Context"
             assert item["parameters"]["user"] == ""
-            scanners.zap.zap.validate_active_scan_policy.assert_called_once_with(
+            mock_validate_active_scan_policy.assert_called_once_with(
                 policy_path=Path(f"{MODULE_DIR}/policies/API-scan-minimal.policy")
             )
 

--- a/tests/scanners/zap/test_setup_activescan_policy_validatio.py
+++ b/tests/scanners/zap/test_setup_activescan_policy_validatio.py
@@ -1,12 +1,18 @@
-import pytest
 from pathlib import Path
 
-from scanners.zap.zap import validate_active_scan_policy, PolicyFileNotFoundError, MissingConfigurationNodeError, MissingPolicyNodeError, MismatchedPolicyNameError, InvalidXMLFileError
+import pytest
+
+from scanners.zap.zap import InvalidXMLFileError
+from scanners.zap.zap import MismatchedPolicyNameError
+from scanners.zap.zap import MissingConfigurationNodeError
+from scanners.zap.zap import MissingPolicyNodeError
+from scanners.zap.zap import PolicyFileNotFoundError
+from scanners.zap.zap import validate_active_scan_policy
 
 
 @pytest.fixture
 def valid_policy_file(tmp_path):
-    policy_name = 'policy1'
+    policy_name = "policy1"
     valid_xml_content = """<configuration>
                              <policy>policy1</policy>
                              <setting name="max_connections">100</setting>
@@ -18,7 +24,7 @@ def valid_policy_file(tmp_path):
 
 @pytest.fixture
 def invalid_xml_file(tmp_path):
-    policy_name = 'policy1'
+    policy_name = "policy1"
     invalid_xml_content = """<configuration>
                               <policy>policy2</policy>
                             </configuration>"""  # Mismatched policy name
@@ -31,8 +37,10 @@ def invalid_xml_file(tmp_path):
 def missing_policy_file():
     return Path("/non/existent/path/policy1.policy")
 
+
 def test_valid_policy(valid_policy_file):
     validate_active_scan_policy(valid_policy_file)
+
 
 def test_missing_policy_file(missing_policy_file):
     with pytest.raises(PolicyFileNotFoundError):
@@ -43,32 +51,35 @@ def test_invalid_xml_file(invalid_xml_file):
     with pytest.raises(MismatchedPolicyNameError):
         validate_active_scan_policy(invalid_xml_file)
 
+
 def test_invalid_xml_parse(invalid_xml_file):
     invalid_xml_content = """<configuration>
                                <policy>policy1</policy>
                              </configuration"""  # Missing closing tag
     file_path = invalid_xml_file
     file_path.write_text(invalid_xml_content)
-    
+
     with pytest.raises(InvalidXMLFileError):
         validate_active_scan_policy(file_path)
+
 
 def test_missing_configuration_node(invalid_xml_file):
     invalid_xml_content = """<as>
                                <policy>policy1</policy>
-                             </as>""" 
+                             </as>"""
     file_path = invalid_xml_file
     file_path.write_text(invalid_xml_content)
-    
+
     with pytest.raises(MissingConfigurationNodeError):
         validate_active_scan_policy(file_path)
+
 
 def test_missing_policy_node(invalid_xml_file):
     invalid_xml_content = """<configuration>
                                <po>policy1</po>
-                             </configuration>""" 
+                             </configuration>"""
     file_path = invalid_xml_file
     file_path.write_text(invalid_xml_content)
-    
+
     with pytest.raises(MissingPolicyNodeError):
         validate_active_scan_policy(file_path)

--- a/tests/scanners/zap/test_setup_activescan_policy_validatio.py
+++ b/tests/scanners/zap/test_setup_activescan_policy_validatio.py
@@ -1,0 +1,74 @@
+import pytest
+from pathlib import Path
+
+from scanners.zap.zap import validate_active_scan_policy, PolicyFileNotFoundError, MissingConfigurationNodeError, MissingPolicyNodeError, MismatchedPolicyNameError, InvalidXMLFileError
+
+
+@pytest.fixture
+def valid_policy_file(tmp_path):
+    policy_name = 'policy1'
+    valid_xml_content = """<configuration>
+                             <policy>policy1</policy>
+                             <setting name="max_connections">100</setting>
+                           </configuration>"""
+    file_path = tmp_path / f"{policy_name}.policy"
+    file_path.write_text(valid_xml_content)
+    return file_path
+
+
+@pytest.fixture
+def invalid_xml_file(tmp_path):
+    policy_name = 'policy1'
+    invalid_xml_content = """<configuration>
+                              <policy>policy2</policy>
+                            </configuration>"""  # Mismatched policy name
+    file_path = tmp_path / f"{policy_name}.policy"
+    file_path.write_text(invalid_xml_content)
+    return file_path
+
+
+@pytest.fixture
+def missing_policy_file():
+    return Path("/non/existent/path/policy1.policy")
+
+def test_valid_policy(valid_policy_file):
+    validate_active_scan_policy(valid_policy_file)
+
+def test_missing_policy_file(missing_policy_file):
+    with pytest.raises(PolicyFileNotFoundError):
+        validate_active_scan_policy(missing_policy_file)
+
+
+def test_invalid_xml_file(invalid_xml_file):
+    with pytest.raises(MismatchedPolicyNameError):
+        validate_active_scan_policy(invalid_xml_file)
+
+def test_invalid_xml_parse(invalid_xml_file):
+    invalid_xml_content = """<configuration>
+                               <policy>policy1</policy>
+                             </configuration"""  # Missing closing tag
+    file_path = invalid_xml_file
+    file_path.write_text(invalid_xml_content)
+    
+    with pytest.raises(InvalidXMLFileError):
+        validate_active_scan_policy(file_path)
+
+def test_missing_configuration_node(invalid_xml_file):
+    invalid_xml_content = """<as>
+                               <policy>policy1</policy>
+                             </as>""" 
+    file_path = invalid_xml_file
+    file_path.write_text(invalid_xml_content)
+    
+    with pytest.raises(MissingConfigurationNodeError):
+        validate_active_scan_policy(file_path)
+
+def test_missing_policy_node(invalid_xml_file):
+    invalid_xml_content = """<configuration>
+                               <po>policy1</po>
+                             </configuration>""" 
+    file_path = invalid_xml_file
+    file_path.write_text(invalid_xml_content)
+    
+    with pytest.raises(MissingPolicyNodeError):
+        validate_active_scan_policy(file_path)

--- a/tests/test_rapidast_run_scanner.py
+++ b/tests/test_rapidast_run_scanner.py
@@ -1,13 +1,18 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
 import rapidast
 from rapidast import scanners
 
-def test_run_scanner_setup_failure(mocker):
-    mock_config = mocker.MagicMock()
-    mock_args = mocker.MagicMock()
-    mock_scan_exporter = mocker.MagicMock()
 
-    mock_scanner = mocker.MagicMock()
-    mocker.patch("rapidast.scanners.str_to_scanner", return_value=lambda config, name: mock_scanner)
+@patch("rapidast.scanners.str_to_scanner")
+def test_run_scanner_setup_failure(mock_str_to_scanner):
+    mock_config = MagicMock()
+    mock_args = MagicMock()
+    mock_scan_exporter = MagicMock()
+
+    mock_scanner = MagicMock()
+    mock_str_to_scanner.return_value = lambda config, name: mock_scanner
 
     mock_scanner.setup.side_effect = Exception("Setup failed")
 
@@ -15,25 +20,27 @@ def test_run_scanner_setup_failure(mocker):
 
     assert result == 1
     mock_scanner.setup.assert_called_once()
+    assert mock_scanner.state == scanners.State.ERROR
 
 
-def test_run_scanner_setup_success(mocker):
+@patch("rapidast.scanners.str_to_scanner")
+def test_run_scanner_setup_success(mock_str_to_scanner):
     def update_state(state):
         mock_scanner.state = state
-    
+
     def update_state_ready():
         update_state(scanners.State.READY)
 
     def update_state_processed():
         update_state(scanners.State.PROCESSED)
-        
-    mock_config = mocker.MagicMock()
-    mock_args = mocker.MagicMock()
-    mock_scan_exporter = mocker.MagicMock()
 
-    mock_scanner = mocker.MagicMock()
-    mocker.patch("rapidast.scanners.str_to_scanner", return_value=lambda config, name: mock_scanner)
-        
+    mock_config = MagicMock()
+    mock_args = MagicMock()
+    mock_scan_exporter = MagicMock()
+
+    mock_scanner = MagicMock()
+    mock_str_to_scanner.return_value = lambda config, name: mock_scanner
+
     mock_scanner.setup.side_effect = update_state_ready
     mock_scanner.postprocess.side_effect = update_state_processed
 

--- a/tests/test_rapidast_run_scanner.py
+++ b/tests/test_rapidast_run_scanner.py
@@ -7,6 +7,11 @@ from rapidast import scanners
 
 @patch("rapidast.scanners.str_to_scanner")
 def test_run_scanner_setup_failure(mock_str_to_scanner):
+    """
+    Test that if an exception is raised during scanner.setup, the run_scanner method
+    catches the exception and correctly updates the scanner's state to 'ERROR'
+    """
+
     mock_config = MagicMock()
     mock_args = MagicMock()
     mock_scan_exporter = MagicMock()
@@ -25,6 +30,12 @@ def test_run_scanner_setup_failure(mock_str_to_scanner):
 
 @patch("rapidast.scanners.str_to_scanner")
 def test_run_scanner_setup_success(mock_str_to_scanner):
+    """
+    Test that if scanner.setup completes successfully, the run_scanner method
+    continues with the process. Since run_scanner performs multiple actions after 
+    setup, all subsequent actions are mocked to focus on validating that the function
+    returns a successful result (0)
+    """
     def update_state(state):
         mock_scanner.state = state
 

--- a/tests/test_rapidast_run_scanner.py
+++ b/tests/test_rapidast_run_scanner.py
@@ -1,0 +1,43 @@
+import rapidast
+from rapidast import scanners
+
+def test_run_scanner_setup_failure(mocker):
+    mock_config = mocker.MagicMock()
+    mock_args = mocker.MagicMock()
+    mock_scan_exporter = mocker.MagicMock()
+
+    mock_scanner = mocker.MagicMock()
+    mocker.patch("rapidast.scanners.str_to_scanner", return_value=lambda config, name: mock_scanner)
+
+    mock_scanner.setup.side_effect = Exception("Setup failed")
+
+    result = rapidast.run_scanner("mock_name", mock_config, mock_args, mock_scan_exporter)
+
+    assert result == 1
+    mock_scanner.setup.assert_called_once()
+
+
+def test_run_scanner_setup_success(mocker):
+    def update_state(state):
+        mock_scanner.state = state
+    
+    def update_state_ready():
+        update_state(scanners.State.READY)
+
+    def update_state_processed():
+        update_state(scanners.State.PROCESSED)
+        
+    mock_config = mocker.MagicMock()
+    mock_args = mocker.MagicMock()
+    mock_scan_exporter = mocker.MagicMock()
+
+    mock_scanner = mocker.MagicMock()
+    mocker.patch("rapidast.scanners.str_to_scanner", return_value=lambda config, name: mock_scanner)
+        
+    mock_scanner.setup.side_effect = update_state_ready
+    mock_scanner.postprocess.side_effect = update_state_processed
+
+    result = rapidast.run_scanner("mock_name", mock_config, mock_args, mock_scan_exporter)
+
+    assert result == 0
+    mock_scanner.setup.assert_called_once()

--- a/tests/test_rapidast_run_scanner.py
+++ b/tests/test_rapidast_run_scanner.py
@@ -35,6 +35,7 @@ def test_run_scanner_setup_success(mock_str_to_scanner):
     Subsequent actions are mocked to focus on ensuring `run_scanner` returns a successful
     result (0)
     """
+
     def update_state(state):
         mock_scanner.state = state
 

--- a/tests/test_rapidast_run_scanner.py
+++ b/tests/test_rapidast_run_scanner.py
@@ -8,8 +8,8 @@ from rapidast import scanners
 @patch("rapidast.scanners.str_to_scanner")
 def test_run_scanner_setup_failure(mock_str_to_scanner):
     """
-    Test that if an exception is raised during scanner.setup, the run_scanner method
-    catches the exception and correctly updates the scanner's state to 'ERROR'
+    Test that if an exception occurs during `scanner.setup`, the `run_scanner` method
+    catches the exception, returns 1, and updates the scanner's state to 'ERROR'
     """
 
     mock_config = MagicMock()
@@ -31,10 +31,9 @@ def test_run_scanner_setup_failure(mock_str_to_scanner):
 @patch("rapidast.scanners.str_to_scanner")
 def test_run_scanner_setup_success(mock_str_to_scanner):
     """
-    Test that if scanner.setup completes successfully, the run_scanner method
-    continues with the process. Since run_scanner performs multiple actions after 
-    setup, all subsequent actions are mocked to focus on validating that the function
-    returns a successful result (0)
+    Test that if `scanner.setup` is successful, `run_scanner` continues as expected.
+    Subsequent actions are mocked to focus on ensuring `run_scanner` returns a successful
+    result (0)
     """
     def update_state(state):
         mock_scanner.state = state


### PR DESCRIPTION
Add checks to validate the ZAP active scan policy name. It ensures the policy file exists, has a valid XML structure, and that the `<policy>` node matches the file name.

The XML is parsed using the [xml.etree.ElementTree](https://docs.python.org/3/library/xml.etree.elementtree.html#module-xml.etree.ElementTree) module, which may not be secure against maliciously crafted data. However, the policy files are expected to be trusted, either provided by Rapidast itself or directly by the end user. While switching to a more secure package like [defusedxml](https://pypi.org/project/defusedxml/) is an option, I didn't see a need to introduce this additional dependency.

The policies are stored in the directory `$MODULE_DIR/policies/`, regardless of whether ZAP is running in a container. The main difference is that when running in a container, this directory is [copied](https://github.com/RedHatProductSecurity/rapidast/blob/development/scanners/zap/zap_podman.py#L89) to a container-specific folder to make the policies accessible within the container. However, the validation checks can still be performed at the host level.

The `validate_active_scan_policy` function raises custom exceptions for any failed checks. This approach makes errors easy to detect and allows easy testing in the unit tests without needing to inspect the content of the exception. 
 








