### PR TITLE
added initial code to use authentication config for nessus

### DIFF
--- a/rapidast.py
+++ b/rapidast.py
@@ -65,6 +65,8 @@ def load_config(config_file_location: str) -> Dict[str, Any]:
     return yaml.safe_load(load_config_file(config_file_location))
 
 
+# pylint: disable=R0911
+# too many return statements
 def run_scanner(name, config, args, scan_exporter):
     """given the config `config`, runs scanner `name`.
     Returns:
@@ -94,8 +96,12 @@ def run_scanner(name, config, args, scan_exporter):
     # Part 1: create a instance based on configuration
     try:
         scanner = class_(config, name)
-    except OSError as excp:
-        logging.error(excp)
+    except OSError as e:
+        logging.error(f"Caught exception: {e}")
+        logging.error(f"Ignoring failed Scanner `{name}` of type `{typ}`")
+        return 1
+    except RuntimeError as e:
+        logging.error(f"Caught exception: {e}")
         logging.error(f"Ignoring failed Scanner `{name}` of type `{typ}`")
         return 1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests >= 2.27.1
 google.cloud.storage >= 2.17.0
 git+https://github.com/sfowl/py-nessus-pro.git@41abc31 # custom fork without selenium
 dacite >= 1.8.1
+kubernetes >= 31.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ requests >= 2.27.1
 google.cloud.storage >= 2.17.0
 git+https://github.com/sfowl/py-nessus-pro.git@41abc31 # custom fork without selenium
 dacite >= 1.8.1
-kubernetes >= 31.0.0

--- a/scanners/nessus/nessus_none.py
+++ b/scanners/nessus/nessus_none.py
@@ -77,12 +77,7 @@ class Nessus(RapidastScanner):
         self.cfg = dacite.from_dict(data_class=NessusConfig, data=nessus_config_section)
         self._sleep_interval: int = 10
 
-        # the Exception log will be output in rapidast.py
-        # pylint: disable=W0706
-        try:
-            self.authenticated = self.authentication_factory()
-        except RuntimeError:
-            raise
+        self.authenticated = self.authentication_factory()
 
         self._connect()
 

--- a/scanners/nessus/nessus_none.py
+++ b/scanners/nessus/nessus_none.py
@@ -114,7 +114,10 @@ class Nessus(RapidastScanner):
     @generic_authentication_factory()
     def authentication_factory(self):
         """This is the default function, attached to error reporting"""
-        raise RuntimeError(f"The authentication option is not supported: {self.cfg.authentication}")
+        raise RuntimeError(
+            f"The authentication option is not supported. "
+            f"Input - type: {self.cfg.authentication.type}, params: {self.cfg.authentication.parameters}"
+        )
 
     @authentication_factory.register(None)
     def authentication_set_anonymous(self):

--- a/scanners/nessus/nessus_none.py
+++ b/scanners/nessus/nessus_none.py
@@ -15,6 +15,7 @@ from py_nessus_pro import PyNessusPro
 from configmodel import RapidastConfigModel
 from scanners import RapidastScanner
 from scanners import State
+from scanners.authentication_factory import generic_authentication_factory
 from scanners.nessus.tools.convert_nessus_csv_to_sarif import convert_csv_to_sarif
 
 
@@ -62,10 +63,18 @@ class Nessus(RapidastScanner):
         nessus_config_section = config.subtree_to_dict(f"scanners.{ident}")
         if nessus_config_section is None:
             raise ValueError("'scanners.nessus' section not in config")
-        # self.auth_config = config.subtree_to_dict("general.authentication")  # creds for target hosts
+        self.auth_config = config.subtree_to_dict("scanners.nessus.authentication")  # creds for target hosts
         # XXX self.config is already a dict with raw config values
         self.cfg = dacite.from_dict(data_class=NessusConfig, data=nessus_config_section)
         self._sleep_interval: int = 10
+
+        # the Exception log will be output in rapidast.py
+        # pylint: disable=W0706
+        try:
+            self.authenticated = self.authentication_factory()
+        except RuntimeError:
+            raise
+
         self._connect()
 
     def _connect(self):
@@ -92,6 +101,25 @@ class Nessus(RapidastScanner):
         if self._scan_id is None:
             raise RuntimeError("scan_id is None")
         return self._scan_id
+
+    @generic_authentication_factory()
+    def authentication_factory(self):
+        """This is the default function, attached to error reporting"""
+        raise RuntimeError(f"No valid authenticator found for {self}")
+
+    @authentication_factory.register(None)
+    def authentication_set_anonymous(self):
+        """No authentication: don't do anything"""
+        logging.info("NOT configured with any authentication")
+        return False
+
+    @authentication_factory.register("http_header")
+    def authentication_set_http_header_auth(self):
+        """
+        Nessus Professional doesn't support HTTP header (e.g. Authorization: Bearer token) auth
+        """
+
+        raise RuntimeError("http_header authentication is not supported in Nessus Professional.")
 
     def setup(self):
         logging.debug(f"Creating new scan named {self.cfg.scan.folder}/{self.cfg.scan.name}")

--- a/tests/scanners/nessus/test_nessus.py
+++ b/tests/scanners/nessus/test_nessus.py
@@ -35,14 +35,8 @@ class TestNessus:
         config_data = rapidast.load_config("config/config-template-nessus.yaml")
         config = configmodel.RapidastConfigModel(config_data)
 
-        authentication = {"type": "http_header", "parameters": {"name": "Authorizaiton", "value": "123"}}
-        config.set("scanners.nessus.authentication", authentication)
-
-        with pytest.raises(RuntimeError, match="http_header authentication is not supported in Nessus Professional"):
-            test_nessus = Nessus(config=config)
-
         authentication = {"type": "invalid", "parameters": {"name": "Authorizaiton", "value": "123"}}
         config.set("scanners.nessus.authentication", authentication)
 
-        with pytest.raises(RuntimeError, match="No valid authenticator found"):
+        with pytest.raises(RuntimeError, match="The authentication option is not supported"):
             test_nessus = Nessus(config=config)

--- a/tests/scanners/nessus/test_nessus.py
+++ b/tests/scanners/nessus/test_nessus.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 from unittest.mock import patch
 
+import pytest
 import requests
 
 import configmodel
@@ -22,3 +23,26 @@ class TestNessus:
         test_nessus = Nessus(config=config)
         assert test_nessus is not None
         assert test_nessus.nessus_client is not None
+
+    @patch("py_nessus_pro.PyNessusPro._authenticate")
+    @patch("requests.Session.request")
+    def test_setup_nessus_auth(self, mock_get, auth):
+        # All this mocking is for PyNessusPro.__init__() which attempts to connect to Nessus
+        mock_get.return_value = Mock(spec=requests.Response)
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.text = '{"token": "foo", "folders": []}'
+
+        config_data = rapidast.load_config("config/config-template-nessus.yaml")
+        config = configmodel.RapidastConfigModel(config_data)
+
+        authentication = {"type": "http_header", "parameters": {"name": "Authorizaiton", "value": "123"}}
+        config.set("scanners.nessus.authentication", authentication)
+
+        with pytest.raises(RuntimeError, match="http_header authentication is not supported in Nessus Professional"):
+            test_nessus = Nessus(config=config)
+
+        authentication = {"type": "invalid", "parameters": {"name": "Authorizaiton", "value": "123"}}
+        config.set("scanners.nessus.authentication", authentication)
+
+        with pytest.raises(RuntimeError, match="No valid authenticator found"):
+            test_nessus = Nessus(config=config)


### PR DESCRIPTION
added initial code to handle the existing 'authentication' config options for Nessus.

- No authentication will affect nothing
- invalid value for authentication will result in RuntimeError
  - for now, all authentication type except for 'http_header' will result in RuntimeError with an error log, as authentication methods are yet to be implemented at a later time
  - 'http_header' type for authentication will result in RuntimeError with a different specific error log as Nessus doesn't support it.

