### PR TITLE
ZAP import accepts types other than "url"

### DIFF
--- a/config/config-template-generic-scan.yaml
+++ b/config/config-template-generic-scan.yaml
@@ -7,7 +7,7 @@ config:
   # This value tells RapiDAST what schema should be used to read this configuration.
   # Therefore you should only change it if you update the configuration to a newer schema
   # It is intended to keep backward compatibility (newer RapiDAST running an older config)
-  configVersion: 5
+  configVersion: 6
 
   # (Optional) configure to export scan results to OWASP Defect Dojo
   #defectDojo:

--- a/config/config-template-multi-scan.yaml
+++ b/config/config-template-multi-scan.yaml
@@ -10,7 +10,7 @@ config:
   # This value tells RapiDAST what schema should be used to read this configuration.
   # Therefore you should only change it if you update the configuration to a newer schema
   # It is intended to keep backward compatibility (newer RapiDAST running an older config)
-  configVersion: 5
+  configVersion: 6
 
 # `application` contains data related to the application, not to the scans.
 application:

--- a/config/config-template-nessus.yaml
+++ b/config/config-template-nessus.yaml
@@ -2,7 +2,7 @@ config:
   # WARNING: `configVersion` indicates the schema version of the config file.
   # This value tells RapiDAST what schema should be used to read this configuration.
   # Therefore you should only change it if you update the configuration to a newer schema
-  configVersion: 5
+  configVersion: 6
 
   # all the results of all scanners will be stored under that location
   # base_results_dir: "./results"

--- a/config/config-template-trivy-image-scan.yaml
+++ b/config/config-template-trivy-image-scan.yaml
@@ -7,7 +7,7 @@ config:
   # This value tells RapiDAST what schema should be used to read this configuration.
   # Therefore you should only change it if you update the configuration to a newer schema
   # It is intended to keep backward compatibility (newer RapiDAST running an older config)
-  configVersion: 5
+  configVersion: 6
 
 # `application` contains data related to the application, not to the scans.
 application:

--- a/config/config-template-trivy-k8s-scan.yaml
+++ b/config/config-template-trivy-k8s-scan.yaml
@@ -7,7 +7,7 @@ config:
   # This value tells RapiDAST what schema should be used to read this configuration.
   # Therefore you should only change it if you update the configuration to a newer schema
   # It is intended to keep backward compatibility (newer RapiDAST running an older config)
-  configVersion: 5
+  configVersion: 6
 
 # `application` contains data related to the application, not to the scans.
 application:

--- a/config/config-template-zap-long.yaml
+++ b/config/config-template-zap-long.yaml
@@ -118,8 +118,10 @@ scanners:
         apiUrl: "<URL to openAPI>"
         # alternative to apiURL: apiFile: "<local path to openAPI file>"
 
-    # A list of URLs can also be provided, from a text file (1 URL per line)
-    importUrlsFromFile: "<path to import URL>"
+    # A list of URLs can also be provided, type supported: 'har', 'modsec2', 'url' (default), 'zap_messages'
+    importUrlsFromFile:
+      type: "url"
+      fileName: "<path to import URL>"
 
     graphql:
       endpoint: "<URL to GraphQL API endpoint>"

--- a/config/config-template-zap-mac.yaml
+++ b/config/config-template-zap-mac.yaml
@@ -10,7 +10,7 @@ config:
   # This value tells RapiDAST what schema should be used to read this configuration.
   # Therefore you should only change it if you update the configuration to a newer schema
   # It is intended to keep backward compatibility (newer RapiDAST running an older config)
-  configVersion: 5
+  configVersion: 6
 
 # `application` contains data related to the application, not to the scans.
 application:

--- a/config/config-template-zap-simple.yaml
+++ b/config/config-template-zap-simple.yaml
@@ -10,7 +10,7 @@ config:
   # This value tells RapiDAST what schema should be used to read this configuration.
   # Therefore you should only change it if you update the configuration to a newer schema
   # It is intended to keep backward compatibility (newer RapiDAST running an older config)
-  configVersion: 5
+  configVersion: 6
 
 # `application` contains data related to the application, not to the scans.
 application:

--- a/config/config-template-zap-tiny.yaml
+++ b/config/config-template-zap-tiny.yaml
@@ -1,5 +1,5 @@
 config:
-  configVersion: 5
+  configVersion: 6
 
 application:
   shortName: "example-1.0"

--- a/configmodel/converter.py
+++ b/configmodel/converter.py
@@ -5,7 +5,7 @@ import configmodel
 
 # WARNING: this needs to be incremented everytime a non-compatible change is made in the configuration.
 # A corresponding function also needs to be written
-CURR_CONFIG_VERSION = 5
+CURR_CONFIG_VERSION = 6
 
 
 def config_converter_dispatcher(func):
@@ -47,6 +47,24 @@ def convert_configmodel(conf):
     version = conf.get("config.configVersion", 0)
     raise RuntimeError(f"There was an error in converting configuration. No convertion available for version {version}")
 
+
+@convert_configmodel.register(5)
+def convert_from_version_5_to_6(old):
+    """Returns a *copy* of the original rapidast config file, but updated to v6
+    scanner.zap.importUrlsFromFile is now a dictionary, not a string
+    """
+    new = copy.deepcopy(old)
+
+    for key in old.conf["scanners"]:
+        if key.startswith("zap") and old.exists(f"scanners.{key}.importUrlsFromFile"):
+            new.delete(f"scanners.{key}.importUrlsFromFile") # start from fresh
+            new.set(f"scanners.{key}.importUrlsFromFile.fileName", old.get(f"scanners.{key}.importUrlsFromFile"))
+            new.set(f"scanners.{key}.importUrlsFromFile.type", "url")
+
+    # Finally, set the correct version number
+    new.set("config.configVersion", 6)
+
+    return new
 
 @convert_configmodel.register(4)
 def convert_from_version_4_to_5(old):

--- a/configmodel/converter.py
+++ b/configmodel/converter.py
@@ -57,7 +57,7 @@ def convert_from_version_5_to_6(old):
 
     for key in old.conf["scanners"]:
         if key.startswith("zap") and old.exists(f"scanners.{key}.importUrlsFromFile"):
-            new.delete(f"scanners.{key}.importUrlsFromFile") # start from fresh
+            new.delete(f"scanners.{key}.importUrlsFromFile")  # start from fresh
             new.set(f"scanners.{key}.importUrlsFromFile.fileName", old.get(f"scanners.{key}.importUrlsFromFile"))
             new.set(f"scanners.{key}.importUrlsFromFile.type", "url")
 
@@ -65,6 +65,7 @@ def convert_from_version_5_to_6(old):
     new.set("config.configVersion", 6)
 
     return new
+
 
 @convert_configmodel.register(4)
 def convert_from_version_4_to_5(old):

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -387,9 +387,13 @@ class Zap(RapidastScanner):
         The filename of the import will always be copied in the `container_work_dir` as importUrls.txt
         """
         # Basic job config. The `type` parameter will be set later
-        job = {"name": "import", "type": "import", "parameters": {"fileName": f"{self.container_work_dir}/importUrls.txt"}}
+        job = {
+            "name": "import",
+            "type": "import",
+            "parameters": {"fileName": f"{self.container_work_dir}/importUrls.txt"},
+        }
 
-        types = ('har', 'modsec2', 'url', 'zap_messages')
+        types = ("har", "modsec2", "url", "zap_messages")
 
         source = ""  # Location of the import file on the host
 

--- a/tests/configmodel/older-schemas/v5.yaml
+++ b/tests/configmodel/older-schemas/v5.yaml
@@ -10,7 +10,7 @@ config:
   # This value tells RapiDAST what schema should be used to read this configuration.
   # Therefore you should only change it if you update the configuration to a newer schema
   # It is intended to keep backward compatibility (newer RapiDAST running an older config)
-  configVersion: 6
+  configVersion: 5
 
   # all the results of all scanners will be stored under that location
   base_results_dir: "./results"
@@ -118,10 +118,8 @@ scanners:
         apiUrl: "<URL to openAPI>"
         # alternative to apiURL: apiFile: "<local path to openAPI file>"
 
-    # A list of URLs can also be provided, type supported: 'har', 'modsec2', 'url' (default), 'zap_messages'
-    importUrlsFromFile:
-      type: "url"
-      fileName: "<path to import URL>"
+    # A list of URLs can also be provided, from a text file (1 URL per line)
+    importUrlsFromFile: "<path to import URL>"
 
     graphql:
       endpoint: "<URL to GraphQL API endpoint>"

--- a/tests/configmodel/test_convert.py
+++ b/tests/configmodel/test_convert.py
@@ -52,6 +52,21 @@ def generate_config_v4():
     except yaml.YAMLError as exc:
         raise RuntimeError(f"Unable to load TEST file {path}") from exc
 
+@pytest.fixture(name="config_v5")
+def generate_config_v5():
+    path = "tests/configmodel/older-schemas/v5.yaml"
+    try:
+        with open(path) as file:
+            return configmodel.RapidastConfigModel(yaml.safe_load(file))
+    except yaml.YAMLError as exc:
+        raise RuntimeError(f"Unable to load TEST file {path}") from exc
+
+def test_v5_to_v6(config_v5):
+    oldconf = config_v5
+    newconf = configmodel.converter.convert_from_version_5_to_6(oldconf)
+
+    # Check that new importUrlsFromFile is a dictionary and contains a fileName matching the old importUrlsFromFile
+    assert newconf.get("scanners.zap.importUrlsFromFile.fileName", "x") == oldconf.get("scanners.zap.importUrlsFromFile", "y")
 
 def test_v4_to_v5(config_v4):
     oldconf = config_v4

--- a/tests/configmodel/test_convert.py
+++ b/tests/configmodel/test_convert.py
@@ -52,6 +52,7 @@ def generate_config_v4():
     except yaml.YAMLError as exc:
         raise RuntimeError(f"Unable to load TEST file {path}") from exc
 
+
 @pytest.fixture(name="config_v5")
 def generate_config_v5():
     path = "tests/configmodel/older-schemas/v5.yaml"
@@ -61,12 +62,16 @@ def generate_config_v5():
     except yaml.YAMLError as exc:
         raise RuntimeError(f"Unable to load TEST file {path}") from exc
 
+
 def test_v5_to_v6(config_v5):
     oldconf = config_v5
     newconf = configmodel.converter.convert_from_version_5_to_6(oldconf)
 
     # Check that new importUrlsFromFile is a dictionary and contains a fileName matching the old importUrlsFromFile
-    assert newconf.get("scanners.zap.importUrlsFromFile.fileName", "x") == oldconf.get("scanners.zap.importUrlsFromFile", "y")
+    assert newconf.get("scanners.zap.importUrlsFromFile.fileName", "x") == oldconf.get(
+        "scanners.zap.importUrlsFromFile", "y"
+    )
+
 
 def test_v4_to_v5(config_v4):
     oldconf = config_v4

--- a/tests/scanners/zap/test_setup.py
+++ b/tests/scanners/zap/test_setup.py
@@ -206,12 +206,47 @@ def test_setup_authentication_auth_rtoken_preauth(test_config):
 
 
 def test_setup_import_urls(test_config):
-    # trick: set this very file as import
-    test_config.set("scanners.zap.importUrlsFromFile", __file__)
+    # trick: use is the current pytest as import file
 
+    # 1- Test backward compatible behaviour
+    test_config.set("scanners.zap.importUrlsFromFile", __file__)
     test_zap = ZapNone(config=test_config)
     test_zap.setup()
     assert Path(test_zap.host_work_dir, "importUrls.txt").is_file()
+    for item in test_zap.automation_config["jobs"]:
+        if item["type"] == "import":
+            assert item["parameters"]["type"] == "url"
+            break
+    else:
+        assert False
+
+    # 2- Test new config style, with type "har"
+    test_config.set("scanners.zap.importUrlsFromFile", {"type": "har", "fileName": __file__})
+    test_zap = ZapNone(config=test_config)
+    test_zap.setup()
+    for item in test_zap.automation_config["jobs"]:
+        if item["type"] == "import":
+            assert item["parameters"]["type"] == "har"
+            break
+    else:
+        assert False
+
+    # 3- Test new config style, defaulting to "url" type
+    test_config.set("scanners.zap.importUrlsFromFile", {"fileName": __file__})
+    test_zap = ZapNone(config=test_config)
+    test_zap.setup()
+    for item in test_zap.automation_config["jobs"]:
+        if item["type"] == "import":
+            assert item["parameters"]["type"] == "url"
+            break
+    else:
+        assert False
+
+    # 4- Test new config style, with an unexisting type
+    test_config.set("scanners.zap.importUrlsFromFile", {"type": "doesntexist", "fileName": __file__})
+    test_zap = ZapNone(config=test_config)
+    with pytest.raises(ValueError) as exc:
+        test_zap.setup()
 
 
 def test_setup_exclude_urls(test_config):

--- a/tests/scanners/zap/test_setup.py
+++ b/tests/scanners/zap/test_setup.py
@@ -208,19 +208,7 @@ def test_setup_authentication_auth_rtoken_preauth(test_config):
 def test_setup_import_urls(test_config):
     # trick: use is the current pytest as import file
 
-    # 1- Test backward compatible behaviour
-    test_config.set("scanners.zap.importUrlsFromFile", __file__)
-    test_zap = ZapNone(config=test_config)
-    test_zap.setup()
-    assert Path(test_zap.host_work_dir, "importUrls.txt").is_file()
-    for item in test_zap.automation_config["jobs"]:
-        if item["type"] == "import":
-            assert item["parameters"]["type"] == "url"
-            break
-    else:
-        assert False
-
-    # 2- Test new config style, with type "har"
+    # 1- Test importUrlsFromFile, with type "har"
     test_config.set("scanners.zap.importUrlsFromFile", {"type": "har", "fileName": __file__})
     test_zap = ZapNone(config=test_config)
     test_zap.setup()
@@ -231,7 +219,7 @@ def test_setup_import_urls(test_config):
     else:
         assert False
 
-    # 3- Test new config style, defaulting to "url" type
+    # 2- Test that importUrlsFromFile defaults to "url" type
     test_config.set("scanners.zap.importUrlsFromFile", {"fileName": __file__})
     test_zap = ZapNone(config=test_config)
     test_zap.setup()
@@ -242,7 +230,7 @@ def test_setup_import_urls(test_config):
     else:
         assert False
 
-    # 4- Test new config style, with an unexisting type
+    # 3- Test that importUrlsFromFile fails if the type is incorrect
     test_config.set("scanners.zap.importUrlsFromFile", {"type": "doesntexist", "fileName": __file__})
     test_zap = ZapNone(config=test_config)
     with pytest.raises(ValueError) as exc:


### PR DESCRIPTION
config:

```
importUrlsFromFile:
  type: one of 'har', 'modsec2', 'url' (default), 'zap_messages'
  fileName: path to file
```

default remains "url", and previous config style (`importUrlsFromFile` is a string) remains supported