### PR TITLE
Replace deprecated provision-env-with-ephemeral-namespace task

### DIFF
--- a/.tekton/integration-test.yaml
+++ b/.tekton/integration-test.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: rapidast-e2e
@@ -54,13 +54,11 @@ spec:
           - name: revision
             value: main
           - name: pathInRepo
-            value: task/provision-env-with-ephemeral-namespace/0.1/provision-env-with-ephemeral-namespace.yaml
+            value: task/eaas-provision-space/0.1/eaas-provision-space.yaml
       params:
-        - name: KONFLUXNAMESPACE
-          value: $(context.pipelineRun.namespace)
-        - name: PIPELINERUN_NAME
+        - name: ownerName
           value: $(context.pipelineRun.name)
-        - name: PIPELINERUN_UID
+        - name: ownerUid
           value: $(context.pipelineRun.uid)
 
     - name: copy-nessus-secret
@@ -103,13 +101,11 @@ spec:
           - name: revision
             value: main
           - name: pathInRepo
-            value: task/provision-env-with-ephemeral-namespace/0.1/provision-env-with-ephemeral-namespace.yaml
+            value: task/eaas-provision-space/0.1/eaas-provision-space.yaml
       params:
-        - name: KONFLUXNAMESPACE
-          value: $(context.pipelineRun.namespace)
-        - name: PIPELINERUN_NAME
+        - name: ownerName
           value: $(context.pipelineRun.name)
-        - name: PIPELINERUN_UID
+        - name: ownerUid
           value: $(context.pipelineRun.uid)
 
     # XXX integrations tests can't reference Tasks in the same PR AFAICT

--- a/e2e-tests/manifests/rapidast-oobtkube-configmap.yaml
+++ b/e2e-tests/manifests/rapidast-oobtkube-configmap.yaml
@@ -21,25 +21,15 @@ data:
         results: "/tmp/oobtkube.sarif.json"   # if None or "*stdout", the command's standard output is selected
         # toolDir: scanners/generic/tools
         inline: "python3 oobtkube.py --log-level debug -d 60 -p 6000 -i rapidast-oobtkube -f /opt/rapidast/config/cr_example.yaml | tee /tmp/oobtkube.sarif.json"
-  # XXX using tekton Task because it has:
-  # - a resource type that has a .spec field (required by oobtkube script)
-  # - fields in .spec that are arbitrary string (.spec.description)
-  # this could be replaced later with something more common like a ConfigMap,
-  # once oobtkube can test non .spec values
+  # ConfigMap is used as target because it is a default resource
   cr_example.yaml: |+
-    apiVersion: tekton.dev/v1
-    kind: Task
+    apiVersion: v1
+    kind: ConfigMap
     metadata:
       name: vulnerable
-    spec:
-      description: foobar
-      params:
-        - name: foo
-          type: string
-      steps:
-      - image: foo
-        name: foo
-        script: foo
+    data:
+      foo: bar
+      target: foobar
 
 kind: ConfigMap
 metadata:

--- a/e2e-tests/manifests/task-controller-deployment.yaml
+++ b/e2e-tests/manifests/task-controller-deployment.yaml
@@ -3,32 +3,32 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-  name: task-controller
+  name: cm-controller
   labels:
-    app: task-controller
+    app: cm-controller
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: task-controller
+      app: cm-controller
   template:
     metadata:
       labels:
-        app: task-controller
+        app: cm-controller
     spec:
       containers:
-      # simulates a custom controller that monitors for tekton Tasks named "vulnerable"
+      # simulates a custom controller that monitors for tekton ConfigMaps named "vulnerable"
       # and tries to execute a deliberate command injection
-      # Tasks are chosen only because they have a field in .spec that can be arbitrary string
+      # ConfigMaps are chosen only because they are a default resource
       - command:
         - bash
         - -c
         - |
           while true; do
             sleep 1
-            sh -c "$(oc get task/vulnerable -o=jsonpath='{.spec.description}')"
+            sh -c "$(oc get configmap/vulnerable -o=jsonpath='{.data.target}')"
           done
         image: registry.redhat.io/openshift4/ose-cli:latest
         imagePullPolicy: Always
-        name: task-controller
+        name: cm-controller
       serviceAccountName: ${SERVICEACCOUNT} # required to read Tasks from API server


### PR DESCRIPTION
Replaces the [`provision-env-with-ephemeral-namespace`](https://github.com/konflux-ci/build-definitions/tree/main/task/provision-env-with-ephemeral-namespace/0.1) task, which was deprecated 2025-01-17 with the [`eaas-provision-space`](https://github.com/konflux-ci/build-definitions/tree/main/task/eaas-provision-space/0.1) task. This also required modifying the oobtkube e2e test, as tekton Task CRDs are not available in the namespaces provisioned with the new Task type, instead ConfigMaps are used.

https://issues.redhat.com/browse/PSSECAUT-905