### PR TITLE
Fail container build if zap could not be downloaded

### DIFF
--- a/containerize/Containerfile
+++ b/containerize/Containerfile
@@ -14,7 +14,7 @@ RUN mkdir -p /opt/zap /tmp/zap && \
   ### Update add-ons
   /opt/zap/zap.sh -cmd -silent -addonupdate && \
   ### Copy them to installation directory
-  cp /root/.ZAP/plugin/*.zap /opt/zap/plugin/ || :
+  cp /root/.ZAP/plugin/*.zap /opt/zap/plugin/
 
 ## Firefox, for Ajax
 RUN mkdir -p /opt/firefox /tmp/firefox && \


### PR DESCRIPTION
This will cause the container build to fail, however it's currently broken anyway because the v2.14.0 version of zap has been removed upstream. The container build should have failed earlier but did not.

Once the zap retrieval issue is fixed, the build should go back to green.