### PR TITLE
Make some options for browser authentication configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ This method uses firefox in the background to load a login page and fill in user
         * `loginPageWait`: The number of seconds to wait after submitting the login form before the browser is closed. (default: 2)
         * `verifyUrl`: a URL that "proves" the user is authenticated (either the full URL, or relative to the `application.url` value). This URL must return a success if the user is correctly authenticated, and an error otherwise.
         * `loggedInRegex`: Regex pattern used to identify Logged in messages (default: `\\Q 200 OK\\`)
-        * `loggedOutRegex`: Regex pattern used to identify Logged in messages (default: `\\Q 403 Forbidden\\`)
+        * `loggedOutRegex`: Regex pattern used to identify Logged Out messages (default: `\\Q 403 Forbidden\\`)
 
 ### MacOS
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,10 @@ This method uses firefox in the background to load a login page and fill in user
         * `username`
         * `password`
         * `loginPageUrl`: the URL to the login page (either the full URL, or relative to the `application.url` value)
+        * `loginPageWait`: The number of seconds to wait after submitting the login form before the browser is closed. (default: 2)
         * `verifyUrl`: a URL that "proves" the user is authenticated (either the full URL, or relative to the `application.url` value). This URL must return a success if the user is correctly authenticated, and an error otherwise.
+        * `loggedInRegex`: Regex pattern used to identify Logged in messages (default: `\\Q 200 OK\\`)
+        * `loggedOutRegex`: Regex pattern used to identify Logged in messages (default: `\\Q 403 Forbidden\\`)
 
 ### MacOS
 

--- a/config/config-template-zap-long.yaml
+++ b/config/config-template-zap-long.yaml
@@ -76,6 +76,10 @@ general:
     #  password: "mypassw0rd"
     #  loginPageUrl: "https://myapp/login"
     #  verifyUrl: "https://myapp/user/info"
+    #  loginPageWait: 2,
+    #  loggedInRegex: "\\Q 200 OK\\E"
+    #  loggedOutRegex: "\\Q 403 Forbidden\\E"
+
 
 
   container:

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -878,18 +878,22 @@ class Zap(RapidastScanner):
         if not verify_url.startswith("http"):
             verify_url = self.config.get("application.url") + verify_url
 
+        logged_in_regex = self.my_conf(f"{params_path}.loggedInRegex", "\\Q 200 OK\\E")
+        logged_out_regex = self.my_conf(f"{params_path}.loggedOutRegex", "\\Q 403 Forbidden\\E")
+        login_page_wait = self.my_conf(f"{params_path}.loginPageWait", "2")
+
         # 1- complete the context: install the form based auth, and add a user
         context_["authentication"] = {
             "method": "browser",
             "parameters": {
                 "loginPageUrl": login_page_url,
-                "loginPageWait": 2,
+                "loginPageWait": login_page_wait,
                 "browserId": "firefox-headless",
             },
             "verification": {
                 "method": "poll",
-                "loggedInRegex": "\\Q 200 OK\\E",
-                "loggedOutRegex": "\\Q 403 Forbidden\\E",
+                "loggedInRegex": logged_in_regex,
+                "loggedOutRegex": logged_out_regex,
                 "pollFrequency": 60,
                 "pollUnits": "requests",
                 "pollUrl": verify_url,

--- a/tests/scanners/zap/test_setup.py
+++ b/tests/scanners/zap/test_setup.py
@@ -202,6 +202,45 @@ def test_setup_authentication_auth_rtoken_preauth(test_config):
     assert "Invalid URL '<token retrieval URL>'" in str(e_info.value)
 
 
+def test_setup_authentication_auth_browser(test_config):
+    authentication = {
+        "type": "browser",
+        "parameters": {
+            "loginPageUrl": "http://example.com/login",
+            "verifyUrl": "/verify",
+            "username": "usern",
+            "password": "pass",
+            "loginPageWait": "3",
+            "loggedInRegex": "\\Q 200 OK\\E",
+            "loggedOutRegex": "\\Q 401 Unauthorized\\E",
+        },
+    }
+
+    test_config.set("general.authentication", authentication)
+    test_config.merge(test_config.get("general", default={}), preserve=False, root=f"scanners.zap")
+    test_zap = ZapNone(config=test_config)
+    test_zap.setup()
+
+    assert test_zap.authenticated == True
+    assert test_zap.automation_config["env"]["contexts"][0]["authentication"] == {
+        "method": "browser",
+        "parameters": {
+            "browserId": "firefox-headless",
+            "loginPageUrl": "http://example.com/login",
+            "loginPageWait": "3",
+        },
+        "verification": {
+            "loggedInRegex": "\\Q 200 OK\\E",
+            "loggedOutRegex": "\\Q 401 Unauthorized\\E",
+            "method": "poll",
+            "pollFrequency": 60,
+            "pollPostData": "",
+            "pollUnits": "requests",
+            "pollUrl": "http://example.com/verify",
+        },
+    }
+
+
 ## Testing APIs & URLs ##
 
 


### PR DESCRIPTION
This makes the following options for browser authentication which are hardcorded configurable:
- loginPageWait
- loggedInRegex
- loggedOutRegex options 