### PR TITLE
Update podman run example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Run the pre-built [rapidast container image](https://quay.io/repository/redhatpr
 
 **Run**
 ```sh
-$ podman run -v ./config.yaml:/opt/rapidast/config/config.yaml:Z quay.io/redhatproductsecurity/rapidast:latest ./rapidast.py
+$ podman run -v ./config.yaml:/opt/rapidast/config/config.yaml:Z quay.io/redhatproductsecurity/rapidast:latest
 ```
 
 **Note**


### PR DESCRIPTION
Now that :latest image includes the entrypoint change, the README in the default branch (development) should be updated.