### PR TITLE
preflight task renamed check-container -> app-check in v0.2

### DIFF
--- a/.tekton/rapidast-pull-request.yaml
+++ b/.tekton/rapidast-pull-request.yaml
@@ -38,7 +38,7 @@ spec:
   taskRunSpecs:
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
-        - name: check-container
+        - name: app-check
           computeResources:
             requests:
               memory: 512Mi

--- a/.tekton/rapidast-push.yaml
+++ b/.tekton/rapidast-push.yaml
@@ -27,7 +27,7 @@ spec:
   taskRunSpecs:
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
-        - name: check-container
+        - name: app-check
           computeResources:
             requests:
               memory: 512Mi


### PR DESCRIPTION
Task step was renamed in version update, so ecosystem-preflight check is now failing:

https://github.com/RedHatProductSecurity/rapidast/runs/36929036979