### PR TITLE
E2E cleanup

### DIFF
--- a/.tekton/integration-test.yaml
+++ b/.tekton/integration-test.yaml
@@ -118,7 +118,7 @@ spec:
           - name: credentials
             emptyDir: {}
         results:
-          - name: TEST_RESULTS
+          - name: TEST_OUTPUT
             description: e2e test results
         steps:
 
@@ -160,8 +160,8 @@ spec:
               yum install -y python3.12 git
               python3.12 -m ensurepip
               pip3 install -r requirements.txt -r requirements-dev.txt
-              pytest -s e2e-tests/test_integration.py --json-report --json-report-summary --json-report-file $(results.TEST_RESULTS.path)
-              cat $(results.TEST_RESULTS.path)
+              pytest -s e2e-tests/test_integration.py --json-report --json-report-summary --json-report-file $(results.TEST_OUTPUT.path)
+              cat $(results.TEST_OUTPUT.path)
 
     - name: run-e2e-tests-nessus
       runAfter:
@@ -171,7 +171,7 @@ spec:
           - name: credentials
             emptyDir: {}
         results:
-          - name: TEST_RESULTS
+          - name: TEST_OUTPUT
             description: e2e test results
         steps:
 
@@ -211,11 +211,8 @@ spec:
               echo "$KUBECONFIG_VALUE" > "$KUBECONFIG"
               oc whoami
 
-              # XXX temp!
-              oc get secret sfowler-nessus-pull-secret
-
               yum install -y python3.12 git
               python3.12 -m ensurepip
               pip3 install -r requirements.txt -r requirements-dev.txt
-              pytest -sv e2e-tests/test_nessus.py --json-report --json-report-summary --json-report-file $(results.TEST_RESULTS.path)
-              cat $(results.TEST_RESULTS.path)
+              pytest -sv e2e-tests/test_nessus.py --json-report --json-report-summary --json-report-file $(results.TEST_OUTPUT.path)
+              cat $(results.TEST_OUTPUT.path)

--- a/e2e-tests/conftest.py
+++ b/e2e-tests/conftest.py
@@ -147,7 +147,7 @@ def pytest_json_modifyreport(json_report: Dict):
     num_passed = json_report["summary"].get("passed", 0)
     num_failed = json_report["summary"].get("failed", 0)
     num_total = json_report["summary"]["total"]
-    timestamp = int(json_report["created"] + json_report["duration"])
+    timestamp = str(int(json_report["created"] + json_report["duration"]))
     result = "ERROR"
     if num_passed == num_total:
         result = "SUCCESS"

--- a/e2e-tests/conftest.py
+++ b/e2e-tests/conftest.py
@@ -3,7 +3,9 @@ import os
 import shutil
 import tempfile
 import time
+from datetime import datetime
 from functools import partial
+from typing import Dict
 from typing import Optional
 
 import certifi
@@ -139,6 +141,25 @@ def create_namespace(namespace_name: str):
 def new_kclient():
     config.load_config()
     return client.ApiClient()
+
+
+# XXX hook called by pytest-json-report plugin
+def pytest_json_modifyreport(json_report: Dict):
+    num_passed = json_report["summary"].get("passed", 0)
+    num_failed = json_report["summary"].get("failed", 0)
+    num_total = json_report["summary"]["total"]
+    timestamp = datetime.fromtimestamp(json_report["created"] + json_report["duration"])
+    result = "ERROR"
+    if num_passed == num_total:
+        result = "SUCCESS"
+    elif num_failed > 0:
+        result = "FAILURE"
+    json_report.clear()
+    json_report["result"] = result
+    json_report["timestamp"] = timestamp
+    json_report["successes"] = num_passed
+    json_report["failures"] = num_failed
+    json_report["warnings"] = 0
 
 
 class TestBase:

--- a/e2e-tests/conftest.py
+++ b/e2e-tests/conftest.py
@@ -3,7 +3,6 @@ import os
 import shutil
 import tempfile
 import time
-from datetime import datetime
 from functools import partial
 from typing import Dict
 from typing import Optional
@@ -148,7 +147,7 @@ def pytest_json_modifyreport(json_report: Dict):
     num_passed = json_report["summary"].get("passed", 0)
     num_failed = json_report["summary"].get("failed", 0)
     num_total = json_report["summary"]["total"]
-    timestamp = datetime.fromtimestamp(json_report["created"] + json_report["duration"])
+    timestamp = int(json_report["created"] + json_report["duration"])
     result = "ERROR"
     if num_passed == num_total:
         result = "SUCCESS"

--- a/e2e-tests/manifests/rapidast-vapi-pod.yaml
+++ b/e2e-tests/manifests/rapidast-vapi-pod.yaml
@@ -4,14 +4,11 @@ metadata:
   annotations:
   name: rapidast-vapi
 spec:
-  containers:
-  - command:
-    - bash
-    - -c
-    - "./rapidast.py && cat results/*/*/zap/zap-report.json" # ugly, but saves needing a PVC to retrieve .json file after execution
-    image: ${IMAGE} # quay.io/redhatproductsecurity/rapidast:latest
+  initContainers:
+    # Run rapidast as initContainer, second container prints the results
+  - image: ${IMAGE} # quay.io/redhatproductsecurity/rapidast:latest
     imagePullPolicy: Always
-    name: rapidast-vapi
+    name: rapidast
     resources:
       limits:
         cpu: 1
@@ -22,8 +19,20 @@ spec:
     volumeMounts:
     - name: config-volume
       mountPath: /opt/rapidast/config
+    - name: results
+      mountPath: /opt/rapidast/results
+  containers:
+    # Expects initContainer to already have created results
+  - command: ["bash", "-c", "cat /opt/rapidast/results/*/*/zap/zap-report.json"]
+    image: registry.redhat.io/ubi9/ubi-micro
+    name: results
+    volumeMounts:
+    - name: results
+      mountPath: /opt/rapidast/results
   volumes:
   - name: config-volume
     configMap:
       name: rapidast-vapi
+  - name: results
+    emptyDir: {}
   restartPolicy: Never


### PR DESCRIPTION
- Retrieve e2e test results with separate container
  - Should be cleaner than using a regex to parse json output from log file 
-  Use TEST_OUTPUT in integration tests
   - Hopefully this shows test results in konflux UI