### PR TITLE
Add deprecation notice for the 'podman' mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ RapiDAST is for testing purposes, and should not be used on production systems.
 **Podman Mode Deprecation**
 The `podman` execution environment is deprecated and will be removed in version **2.12**
 
-If you are using `podman`, please migrate to `none` before updating to version 2.12.
+If you are using `podman` fpr the `container.type` option, please migrate to `none` before updating to version 2.12.
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ RapiDAST provides:
 
 RapiDAST is for testing purposes, and should not be used on production systems.
 
+## Deprecation Notice
+
+**Podman Mode Deprecation**  
+The `podman` execution environment is deprecated and will be removed in version **2.12**  
+
+If you are using `podman`, please migrate to `none` before updating to version 2.12.  
+
 ## Quickstart
 
 Quickly setup RapiDAST to scan a target application. See [Workflow](#workflow) for more information.
@@ -366,13 +373,12 @@ Set `general.container.type` to select an environment (default: `none`)
     - Run a RapiDAST scan with scanners that are installed on the same host OR run RapiDAST in a container (scanners are to be installed in the same container image)
     - __Warning__: without a container layer, RapiDAST may have to modify the host's file system, such as the tools configuration to fit its needs. For example: the ZAP plugin has to copy the policy file used in ZAP's user config directory (`~/.ZAP`)
 
-+ `podman`:
++ `podman` (this mode is deprecated and will be **removed** in version **2.12**):
     - Run scanners as separate containers using `podman`
     - RapiDAST must not run inside a container
     - Select the image to load from `scanner.<name>.container.image` (sensible default are provided for each scanner)
 
 It is also possible to set the container type for each scanner differently by setting `scanners.<name>.container.type` under a certain scanner configuration. Then the scanner will run from its image, regardless of the `general.container.type` value.
-
 
 ## Build a RapiDAST image
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ RapiDAST is for testing purposes, and should not be used on production systems.
 
 ## Deprecation Notice
 
-**Podman Mode Deprecation**  
-The `podman` execution environment is deprecated and will be removed in version **2.12**  
+**Podman Mode Deprecation**
+The `podman` execution environment is deprecated and will be removed in version **2.12**
 
-If you are using `podman`, please migrate to `none` before updating to version 2.12.  
+If you are using `podman`, please migrate to `none` before updating to version 2.12.
 
 ## Quickstart
 

--- a/rapidast.py
+++ b/rapidast.py
@@ -92,6 +92,10 @@ def run_scanner(name, config, args, scan_exporter):
     )
 
     typ = config.get(f"scanners.{name}.container.type", default="none")
+    
+    if typ == "podman":
+        logging.warning("Podman mode is deprecated and will be removed in version 2.12")
+        
     try:
         class_ = scanners.str_to_scanner(name, typ)
     except ModuleNotFoundError:

--- a/rapidast.py
+++ b/rapidast.py
@@ -92,10 +92,10 @@ def run_scanner(name, config, args, scan_exporter):
     )
 
     typ = config.get(f"scanners.{name}.container.type", default="none")
-    
+
     if typ == "podman":
         logging.warning("Podman mode is deprecated and will be removed in version 2.12")
-        
+
     try:
         class_ = scanners.str_to_scanner(name, typ)
     except ModuleNotFoundError:


### PR DESCRIPTION
`Podman` mode is deprecated and will be removed in version 2.12. This PR adds a warning log to notify users and updates the `README.md` with relevant info.