### PR TITLE
Initial code for Garak integration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,7 @@ repos:
   # R0801: Similar lines in 2 files. Disabled because it flags any file even those which are unrelated
   # R1705: Unnecessary "elif" after "return", remove the leading "el" from "elif" (no-else-return)
   # R1710: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
+  # W0201: disable "W0201: Attribute 'state' defined outside __init__ (attribute-defined-outside-init)" until 'state' assignment in each scanner class is improved
 
   - repo: https://github.com/PyCQA/pylint
     #rev: v3.0.3
@@ -54,5 +55,5 @@ repos:
           - --max-line-length=120
           - --min-public-methods=0
           - --good-names=o,w,q,f,fp,i,e
-          - --disable=E0401,W1201,W1203,C0114,C0115,C0116,C0411,W0107,W0511,W0702,R0801,R1705,R1710
+          - --disable=E0401,W1201,W1203,C0114,C0115,C0116,C0411,W0107,W0511,W0702,R0801,R1705,R1710,W0201
         language_version: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,6 @@ repos:
   # R0801: Similar lines in 2 files. Disabled because it flags any file even those which are unrelated
   # R1705: Unnecessary "elif" after "return", remove the leading "el" from "elif" (no-else-return)
   # R1710: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
-  # W0201: disable "W0201: Attribute 'state' defined outside __init__ (attribute-defined-outside-init)" until 'state' assignment in each scanner class is improved
 
   - repo: https://github.com/PyCQA/pylint
     #rev: v3.0.3
@@ -55,5 +54,5 @@ repos:
           - --max-line-length=120
           - --min-public-methods=0
           - --good-names=o,w,q,f,fp,i,e
-          - --disable=E0401,W1201,W1203,C0114,C0115,C0116,C0411,W0107,W0511,W0702,R0801,R1705,R1710,W0201
+          - --disable=E0401,W1201,W1203,C0114,C0115,C0116,C0411,W0107,W0511,W0702,R0801,R1705,R1710
         language_version: python3

--- a/README.md
+++ b/README.md
@@ -536,7 +536,7 @@ scanners:
 
 #### Generic scanner
 
-RapiDAST can run other scanning tools as well as ZAP. It is possible to request RapiDAST to run a command and process stdout results, using the `generic` plugin.
+In addition to the scanners mentioned above, RapiDAST can run any other scanning tools. It is possible to request RapiDAST to run a command and process stdout results, using the `generic` plugin. One use case is to run your own tools or scripts and export the results to Google Cloud Storage.
 
 The following is an example to run a command or a tool in the host where a RapiDAST scan runs:
 

--- a/README.md
+++ b/README.md
@@ -524,7 +524,7 @@ scanners:
 
 #### Garak
 
-Garak is an LLM AI scanner developed by NVIDIA. It helps organizations identify and address security vulnerabilities across various systems, devices, and applications.
+Garak is an LLM AI scanner developed by NVIDIA. See https://github.com/NVIDIA/garak for more information.
 
 The following is an example to launch a scan:
 ```yaml

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ RapiDAST (Rapid DAST) is an open-source security testing tool that automates DAS
 
 RapiDAST provides:
 
-- Automated HTTP/API security scanning using ZAP
-- Kubernetes operator scanning using OOBTKUBE
+- Automated HTTP/API security scanning leveraging ZAP
+- Automated LLM AI scanning leveraging Garak
+- Kubernetes operator scanning leveraging OOBTKUBE
 - Automated vulnerability scanning using Nessus (requires a Nessus instance)
 - Command-line execution with yaml configuration, suitable for integration in CI/CD pipelines
 - Ability to run automated DAST scanning with pre-built or custom container images
@@ -120,6 +121,7 @@ See templates in the [config](./config/) directory for examples and ideas.
 - `config-template-zap-long.yaml` : describes a more extensive use of ZAP (all configuration options are presented)
 - `config-template-multi-scan.yaml` : describes how to combine multiple scanners in a single configuration
 - `config-template-generic-scan.yaml` : describes the use of the generic scanner
+- `config-template-garak.yaml` : describes the use of the Garak LLM AI scanner
 
 ### Basic Example
 
@@ -518,6 +520,18 @@ scanners:
       # timeout: 600 # timeout in seconds to complete scan
       targets:
       - 127.0.0.1
+```
+
+#### Garak
+
+Garak is an LLM AI scanner developed by NVIDIA. It helps organizations identify and address security vulnerabilities across various systems, devices, and applications.
+
+The following is an example to launch a scan:
+```yaml
+scanners:
+  garak:
+    model_type: huggingface
+    model_name: gpt2
 ```
 
 #### Generic scanner

--- a/config/config-template-garak.yaml
+++ b/config/config-template-garak.yaml
@@ -10,12 +10,20 @@ config:
 # `application` contains data related to the application, not to the scans.
 application:
   shortName: "garak-test-1.0"
-  # url: "<Mandatory. root URL of the application>" # unused for Garak
 
 # `scanners' is a section that configures scanning options
 scanners:
   garak:
-    model_name: gpt2
-    model_type: huggingface
-    # probe_spec: all                               # default: all, or a list of probes like "probe1,probe2"
+    model_type: huggingface                         # required, e.g. hugginngface, openai, rest
+    model_name: gpt2                                # optional, but a specific model type requires a model name or path
+    #generators:                                    # optional, providing more options for the selected model type, e.g. RestGenerator
+    #  rest:
+    #    RestGenerator:
+    #      uri:
+    #      method:
+    #      headers:
+    #      response_json_field:
+    #      req_template_json_object:
+    #      request_timeout: 60
+    #probe_spec: all                               # default: all, or a list of probes like "probe1,probe2"
     #garak_executable_path: /usr/local/bin/garak    # default: /usr/local/bin/garak

--- a/config/config-template-garak.yaml
+++ b/config/config-template-garak.yaml
@@ -1,0 +1,21 @@
+config:
+  # WARNING: `configVersion` indicates the schema version of the config file.
+  # This value tells RapiDAST what schema should be used to read this configuration.
+  # Therefore you should only change it if you update the configuration to a newer schema
+  configVersion: 6
+
+  # all the results of all scanners will be stored under that location
+  # base_results_dir: "./results"
+
+# `application` contains data related to the application, not to the scans.
+application:
+  shortName: "garak-test-1.0"
+  # url: "<Mandatory. root URL of the application>" # unused for Garak
+
+# `scanners' is a section that configures scanning options
+scanners:
+  garak:
+    model_name: gpt2
+    model_type: huggingface
+    probe_spec: dan.Dan_11_0         # default: all, or a list of probes like "probe1,probe2"
+    #garak_executable_path: /usr/local/bin/garak      # default: /usr/local/bin/garak

--- a/config/config-template-garak.yaml
+++ b/config/config-template-garak.yaml
@@ -17,5 +17,5 @@ scanners:
   garak:
     model_name: gpt2
     model_type: huggingface
-    probe_spec: dan.Dan_11_0         # default: all, or a list of probes like "probe1,probe2"
-    #garak_executable_path: /usr/local/bin/garak      # default: /usr/local/bin/garak
+    # probe_spec: all                               # default: all, or a list of probes like "probe1,probe2"
+    #garak_executable_path: /usr/local/bin/garak    # default: /usr/local/bin/garak

--- a/config/schemas/6/rapidast_schema.json
+++ b/config/schemas/6/rapidast_schema.json
@@ -645,6 +645,10 @@
                             "model_type": {
                                 "type": "string"
                             },
+                            "generators": {
+                                "type": "object",
+                                "properties": {}
+                            },
                             "probe_spec": {
                                 "type": "string"
                             },
@@ -653,7 +657,6 @@
                             }
                         },
                         "required": [
-                            "model_name",
                             "model_type"
                         ]
                     }

--- a/config/schemas/6/rapidast_schema.json
+++ b/config/schemas/6/rapidast_schema.json
@@ -634,6 +634,28 @@
                             "scan",
                             "server"
                         ]
+                    },
+                    {
+                        "type": "object",
+                        "description": "Garak Scanner",
+                        "properties": {
+                            "model_name": {
+                                "type": "string"
+                            },
+                            "model_type": {
+                                "type": "string"
+                            },
+                            "probe_spec": {
+                                "type": "string"
+                            },
+                            "garak_executable_path": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "model_name",
+                            "model_type"
+                        ]
                     }
                 ]
             }

--- a/containerize/Containerfile.garak
+++ b/containerize/Containerfile.garak
@@ -1,0 +1,113 @@
+#####
+# Build RapiDAST image with Garak LLM AI scanner: https://github.com/NVIDIA/garak
+#####
+
+# Prepare dependencies
+FROM registry.access.redhat.com/ubi9-minimal AS deps
+
+# Indicate if dependencies were prefetched using Cachi2
+# They must be located at /cachi2/output/deps
+ARG PREFETCH=false
+
+# These versions should be consistent with the listed in the artifacts.lock.yaml file
+ARG ZAP_VERSION=2.15.0
+ARG FF_VERSION=128.6.0esr
+ARG K8S_VERSION=1.32.1
+ARG TRIVY_VERSION=0.59.0
+
+ARG DEPS_DIR=/tmp/deps
+ARG ZAP_FILE=$DEPS_DIR/ZAP.tar.gz
+ARG FF_FILE=$DEPS_DIR/firefox.tar.bz2
+ARG TRIVY_FILE=$DEPS_DIR/trivy.tar.gz
+ARG KCTL_FILE=$DEPS_DIR/kubectl
+
+RUN microdnf install -y tar gzip bzip2 java-11-openjdk nodejs
+
+RUN mkdir "${DEPS_DIR}" /tmp/node_modules && if [ "$PREFETCH" == "true" ]; then \
+    echo "PREFETCH is true: Copying dependencies from /cachi2/output/deps..." && \
+    cp -r /cachi2/output/deps/generic/* "$DEPS_DIR"; \
+  else \
+    echo "PREFETCH is false: Downloading dependencies from remote sources..." && \
+    curl -sfL "https://github.com/zaproxy/zaproxy/releases/download/v${ZAP_VERSION}/ZAP_${ZAP_VERSION}_Linux.tar.gz" -o "$ZAP_FILE"; \
+    curl -sfL "https://releases.mozilla.org/pub/firefox/releases/${FF_VERSION}/linux-x86_64/en-US/firefox-${FF_VERSION}.tar.bz2" -o "$FF_FILE"; \
+    curl -sfL "https://dl.k8s.io/release/v${K8S_VERSION}/bin/linux/amd64/kubectl" -o "$KCTL_FILE"; \
+    curl -sfL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -o "$TRIVY_FILE"; \
+  fi
+## ZAP, build and install scanners in advance (more scanners will be added)
+RUN mkdir /opt/zap && \
+  tar zxvf "$ZAP_FILE" --strip-components=1 -C /opt/zap && \
+  ### Update add-ons
+  /opt/zap/zap.sh -cmd -silent -addonupdate && \
+  ### Copy them to installation directory
+  cp /root/.ZAP/plugin/*.zap /opt/zap/plugin/
+
+## Firefox, for Ajax
+RUN mkdir -p /opt/firefox && \
+  tar xjvf "$FF_FILE" -C /opt/firefox
+
+## kubectl
+RUN install -o root -g root -m 0755 "$KCTL_FILE" /usr/local/bin/kubectl
+
+## Trivy (https://github.com/aquasecurity/trivy/)
+RUN mkdir /tmp/trivy && \
+  tar xzvf "$TRIVY_FILE" -C /tmp/trivy && \
+  chmod +x /tmp/trivy/trivy
+
+## redocly (https://github.com/Redocly/redocly-cli)
+COPY package.json package-lock.json /tmp/redocly/
+RUN mkdir -p /tmp/redocly/node_modules && if [ "$PREFETCH" == "true" ]; then \
+    npm install --offline --prefix /tmp/redocly; \
+  else \
+    npm install --prefix /tmp/redocly; \
+  fi
+
+# Copy artifacts from deps to build RapiDAST
+FROM registry.access.redhat.com/ubi9-minimal
+
+COPY --from=deps /opt/zap /opt/zap
+COPY --from=deps /opt/firefox /opt/firefox
+COPY --from=deps /usr/local/bin/kubectl /usr/local/bin/kubectl
+COPY --from=deps /tmp/trivy/trivy /usr/local/bin/trivy
+COPY --from=deps /tmp/redocly/node_modules /opt/redocly/node_modules
+
+ENV PATH $PATH:/opt/zap/:/opt/rapidast/:/opt/firefox/
+
+## RapiDAST
+RUN mkdir /opt/rapidast
+COPY ./rapidast.py ./requirements.txt /opt/rapidast/
+COPY ./scanners/ /opt/rapidast/scanners/
+COPY ./tools/ /opt/rapidast/tools/
+COPY ./exports/ /opt/rapidast/exports/
+COPY ./configmodel/ /opt/rapidast/configmodel/
+COPY ./utils/ /opt/rapidast/utils/
+COPY ./config/ /opt/rapidast/config/
+
+### Add generic tools in the PATH
+COPY ./scanners/generic/tools/convert_trivy_k8s_to_sarif.py /usr/local/bin/
+
+### Overload default config (set 'none' as default container type)
+COPY ./containerize/container_default_config.yaml /opt/rapidast/rapidast-defaults.yaml
+
+### Add /opt/{zap,rapidast}/ to the PATH (for any user and future user)
+COPY ./containerize/path_rapidast.sh /etc/profile.d/rapidast.sh
+
+### Install RapiDAST requirements, globally, so that it's available to any user
+RUN microdnf install -y --setopt=install_weak_deps=0 java-11-openjdk shadow-utils dbus-glib procps git nodejs npm && \
+  microdnf install -y gtk3 python3.12 rust cargo && \
+  python3.12 -m ensurepip --upgrade && \
+  pip3.12 install --upgrade pip && \
+  pip3.12 install --no-cache-dir -r /opt/rapidast/requirements.txt && \
+  pip3.12 install -U garak --no-cache-dir && \
+  microdnf clean all -y && rm -rf /var/cache/dnf /tmp/*  && \
+  ln -s /opt/redocly/node_modules/@redocly/cli/bin/cli.js /usr/local/bin/redocly
+
+RUN useradd -u 1000 -d /opt/rapidast -m -s /bin/bash rapidast && \
+  chown -R 1000 /opt/rapidast && \
+  # OpenShift runs containers with arbitrary user ids, belonging to root group
+  chgrp -R 0 /opt/rapidast && \
+  chmod -R g=u /opt/rapidast
+
+USER rapidast
+WORKDIR /opt/rapidast
+ENV HOME /opt/rapidast
+ENTRYPOINT ["./rapidast.py"]

--- a/scanners/garak/garak-config-template.yaml
+++ b/scanners/garak/garak-config-template.yaml
@@ -1,0 +1,39 @@
+---
+system:
+    verbose: 0
+    narrow_output: false
+    parallel_requests: false
+    parallel_attempts: false
+    lite: true
+    show_z: false
+
+run:
+    seed:
+    deprefix: true
+    eval_threshold: 0.5
+    generations: 5
+    probe_tags:
+
+plugins:
+    model_type:
+    model_name:
+    probe_spec: all
+    detector_spec: auto
+    extended_detectors: false
+    buff_spec:
+    buffs_include_original_prompt: false
+    buff_max:
+    detectors: {}
+    generators: {}
+    buffs: {}
+    harnesses: {}
+    probes:
+        encoding:
+            payloads:
+                - default
+
+reporting:
+    report_prefix:
+    taxonomy:
+    report_dir: garak_runs
+    show_100_pass_modules: true

--- a/scanners/garak/garak_none.py
+++ b/scanners/garak/garak_none.py
@@ -1,0 +1,132 @@
+import logging
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+
+import dacite
+import yaml
+
+from configmodel import RapidastConfigModel
+from scanners import RapidastScanner
+from scanners import State
+
+
+@dataclass
+class GarakConfig:
+    model_name: str
+    model_type: str
+    probe_spec: str = "all"  # all or a list of probes like "probe1,probe2"
+    garak_executable_path: str = "/usr/local/bin/garak"
+
+
+CLASSNAME = "Garak"
+
+MODULE_DIR = os.path.dirname(__file__)
+
+
+class Garak(RapidastScanner):
+    """Scanner implementation for Garak LLM security testing tool."""
+
+    GARAK_CONFIG_TEMPLATE = "garak-config-template.yaml"
+    GARAK_RUN_CONFIG_FILE = "garak-run-config.yaml"
+    TMP_REPORTS_DIRNAME = "garak_runs"
+
+    def __init__(self, config: RapidastConfigModel, ident: str = "garak"):
+        super().__init__(config, ident)  # create a temporary directory (cleaned up during cleanup)
+
+        self.work_dir = self._create_temp_dir("workdir")
+        self.work_dir_reports_dir = self.work_dir + self.TMP_REPORTS_DIRNAME
+
+        garak_config_section = config.subtree_to_dict(f"scanners.{ident}")
+        if garak_config_section is None:
+            raise ValueError("'scanners.garak' section not in config")
+
+        # XXX self.config is already a dict with raw config values
+        self.cfg = dacite.from_dict(data_class=GarakConfig, data=garak_config_section)
+
+        self.garak_cli = []
+        self.automation_config = {}
+
+    def setup(self):
+        """Set up the Garak scanner configuration."""
+        if self.state != State.UNCONFIGURED:
+            raise RuntimeError(f"Garak scanning setup encountered an unexpected state: {self.state}")
+
+        try:
+            template_path = os.path.join(MODULE_DIR, self.GARAK_CONFIG_TEMPLATE)
+            with open(template_path, "r", encoding="utf-8") as stream:
+                self.automation_config = yaml.safe_load(stream)
+
+            # Update values from the config template with user configured values
+            self.automation_config.update(
+                {
+                    "plugins": {
+                        "model_name": self.cfg.model_name,
+                        "model_type": self.cfg.model_type,
+                        "probe_spec": self.cfg.probe_spec,
+                    },
+                    "reporting": {"report_dir": self.work_dir_reports_dir},
+                }
+            )
+
+            # Write updated config
+            garak_run_conf_path = os.path.join(self.work_dir, self.GARAK_RUN_CONFIG_FILE)
+            with open(garak_run_conf_path, "w", encoding="utf-8") as f:
+                yaml.dump(self.automation_config, f)
+
+        except yaml.YAMLError as exc:
+            raise RuntimeError(f"Failed to parse config '{template_path}': {exc}") from exc
+
+        self.garak_cli = [self.cfg.garak_executable_path, "--config", garak_run_conf_path]
+
+        if self.state != State.ERROR:
+            self.state = State.READY
+
+    def run(self):
+        if self.state != State.READY:
+            raise RuntimeError(f"[Garak] unexpected state: READY != {self.state}")
+
+        logging.info(f"Running Garak with the following command:\n{self.garak_cli}")
+
+        try:
+            result = subprocess.run(self.garak_cli, check=False)
+            logging.debug(f"Garak returned the following:\n=====\n{result}\n=====")
+
+            if result.returncode == 0:
+                self.state = State.DONE
+            else:
+                logging.warning(f"The Garak process did not finish correctly, and exited with code {result.returncode}")
+                self.state = State.ERROR
+
+        except FileNotFoundError:
+            logging.error(
+                f"Garak is not found at {self.cfg.garak_executable_path}. Please ensure Garak is installed in your PATH"
+            )
+            self.state = State.ERROR
+        except subprocess.SubprocessError as e:
+            logging.error(f"Failed to run Garak process: {str(e)}")
+            self.state = State.ERROR
+
+    def postprocess(self):
+        if not self.state == State.DONE:
+            raise RuntimeError("No post-processing as Garak scanning has not successfully run yet.")
+
+        super().postprocess()
+
+        try:
+            shutil.copytree(self.work_dir_reports_dir, self.results_dir, dirs_exist_ok=True)
+        # pylint: disable=broad-exception-caught
+        except Exception as excp:
+            logging.error(f"Unable to save results: {excp}")
+            # pylint: disable=attribute-defined-outside-init
+            # it's a false positive: it's defined in the RapidastScanner class
+            self.state = State.ERROR
+
+        if not self.state == State.ERROR:
+            self.state = State.PROCESSED
+
+    def cleanup(self):
+        logging.debug("cleaning up")
+        if not self.state == State.PROCESSED:
+            raise RuntimeError(f"Unexpected state while cleaning up: PROCESSED != {self.state}")

--- a/scanners/garak/garak_none.py
+++ b/scanners/garak/garak_none.py
@@ -3,6 +3,9 @@ import os
 import shutil
 import subprocess
 from dataclasses import dataclass
+from dataclasses import field
+from typing import Any
+from typing import Dict
 
 import dacite
 import yaml
@@ -14,10 +17,11 @@ from scanners import State
 
 @dataclass
 class GarakConfig:
-    model_name: str
     model_type: str
-    probe_spec: str = "all"  # all or a list of probes like "probe1,probe2"
-    garak_executable_path: str = "/usr/local/bin/garak"
+    model_name: str = field(default="test_model")
+    probe_spec: str = field(default="all")  # all or a list of probes like "probe1,probe2"
+    garak_executable_path: str = field(default="/usr/local/bin/garak")
+    generators: Dict[str, Any] = field(default_factory=dict)
 
 
 CLASSNAME = "Garak"
@@ -65,6 +69,7 @@ class Garak(RapidastScanner):
                         "model_name": self.cfg.model_name,
                         "model_type": self.cfg.model_type,
                         "probe_spec": self.cfg.probe_spec,
+                        "generators": self.cfg.generators,
                     },
                     "reporting": {"report_dir": self.workdir_reports_dir},
                 }

--- a/scanners/garak/garak_podman.py
+++ b/scanners/garak/garak_podman.py
@@ -1,0 +1,6 @@
+CLASSNAME = "Garak"
+
+
+class Garak:
+    def __init__(self, *args):
+        raise RuntimeError("Garak scanner is not supported with 'general.container.type=podman' config option")

--- a/tests/scanners/garak/test_garak.py
+++ b/tests/scanners/garak/test_garak.py
@@ -1,0 +1,45 @@
+import os
+
+import pytest
+
+import configmodel
+import rapidast
+from scanners.garak.garak_none import Garak
+
+
+@pytest.fixture(scope="function")
+def test_config():
+    return configmodel.RapidastConfigModel()
+
+
+def test_setup_garak(test_config):
+    test_config.set("scanners.generic.inline", "tmp_cmd")
+
+    config_data = rapidast.load_config("config/config-template-garak.yaml")
+    test_config = configmodel.RapidastConfigModel(config_data)
+
+    test_model_name = "testname"
+    test_model_type = "testtype"
+    test_probe_spec = "dan.Dan_11_0"
+
+    test_garak_config_in_rapidast = {
+        "model_name": test_model_name,
+        "model_type": test_model_type,
+        "probe_spec": test_probe_spec,
+    }
+
+    test_config.set("scanners.garak", test_garak_config_in_rapidast)
+
+    test_garak = Garak(config=test_config)
+    test_garak.setup()
+
+    assert test_garak.automation_config["plugins"]["model_name"] == test_model_name
+    assert test_garak.automation_config["plugins"]["model_type"] == test_model_type
+    assert test_garak.automation_config["plugins"]["probe_spec"] == test_probe_spec
+
+    assert test_garak.garak_cli
+    assert test_garak.garak_cli[:3] == [
+        test_garak.cfg.garak_executable_path,
+        "--config",
+        os.path.join(test_garak.work_dir, test_garak.GARAK_RUN_CONFIG_FILE),
+    ]

--- a/tests/scanners/garak/test_garak.py
+++ b/tests/scanners/garak/test_garak.py
@@ -13,8 +13,6 @@ def test_config():
 
 
 def test_setup_garak(test_config):
-    test_config.set("scanners.generic.inline", "tmp_cmd")
-
     config_data = rapidast.load_config("config/config-template-garak.yaml")
     test_config = configmodel.RapidastConfigModel(config_data)
 

--- a/tests/scanners/garak/test_garak.py
+++ b/tests/scanners/garak/test_garak.py
@@ -41,5 +41,5 @@ def test_setup_garak(test_config):
     assert test_garak.garak_cli[:3] == [
         test_garak.cfg.garak_executable_path,
         "--config",
-        os.path.join(test_garak.work_dir, test_garak.GARAK_RUN_CONFIG_FILE),
+        os.path.join(test_garak.workdir, test_garak.GARAK_RUN_CONFIG_FILE),
     ]

--- a/tests/scanners/garak/test_garak.py
+++ b/tests/scanners/garak/test_garak.py
@@ -19,11 +19,19 @@ def test_setup_garak(test_config):
     test_model_name = "testname"
     test_model_type = "testtype"
     test_probe_spec = "dan.Dan_11_0"
+    test_generators = {
+        "rest": {
+            "uri": "https://stage.test.com/api/",
+            "method": "POST",
+            "response_json_field": "text",
+        }
+    }
 
     test_garak_config_in_rapidast = {
         "model_name": test_model_name,
         "model_type": test_model_type,
         "probe_spec": test_probe_spec,
+        "generators": test_generators,
     }
 
     test_config.set("scanners.garak", test_garak_config_in_rapidast)
@@ -34,6 +42,7 @@ def test_setup_garak(test_config):
     assert test_garak.automation_config["plugins"]["model_name"] == test_model_name
     assert test_garak.automation_config["plugins"]["model_type"] == test_model_type
     assert test_garak.automation_config["plugins"]["probe_spec"] == test_probe_spec
+    assert test_garak.automation_config["plugins"]["generators"] == test_generators
 
     assert test_garak.garak_cli
     assert test_garak.garak_cli[:3] == [

--- a/tests/scanners/garak/test_garak.py
+++ b/tests/scanners/garak/test_garak.py
@@ -1,4 +1,5 @@
 import os
+from unittest.mock import patch
 
 import pytest
 
@@ -12,7 +13,10 @@ def test_config():
     return configmodel.RapidastConfigModel()
 
 
-def test_setup_garak(test_config):
+# Mock the _check_garak_version method for the test to run successfully where Garak is not installed
+@patch("scanners.garak.garak_none.Garak._check_garak_version")
+def test_setup_garak(mock_check_garak_version, test_config):
+    mock_check_garak_version.return_value = None
     config_data = rapidast.load_config("config/config-template-garak.yaml")
     test_config = configmodel.RapidastConfigModel(config_data)
 


### PR DESCRIPTION
The code aims to:
* create a garak config file based on https://reference.garak.ai/en/latest/configurable.html#config-yaml. currently only support configuring model_name, model_type and probe_spec among those configs
* finally run a CLI command with the config file and get reports in the results directory
* adding a separate Containerfile to build an image that includes Garak
* update README to introduce this feature


Notes:
* Garak does not support any authentication option except for the 'rest' model_type (only a header auth using token can be configured via the specific generator config for it), so currently authentication related code has not been added yet. It would need to be considered when we support more detailed config options such as generator.
* only container.type.none is supported ('podman' mode will be deprecated soon)
* W0201 is disabled for now  due to the pylint warning, until 'state' assignment in each scanner class is improved which should be out of scope of this PR.
* 

Next:
* e2e test is to be implemented in a separate PR
