### PR TITLE
updated entrypoint to use python3.12

### DIFF
--- a/containerize/Containerfile.garak
+++ b/containerize/Containerfile.garak
@@ -110,4 +110,4 @@ RUN useradd -u 1000 -d /opt/rapidast -m -s /bin/bash rapidast && \
 USER rapidast
 WORKDIR /opt/rapidast
 ENV HOME /opt/rapidast
-ENTRYPOINT ["./rapidast.py"]
+ENTRYPOINT ["python3.12", "rapidast.py"]


### PR DESCRIPTION
Updated ENTRYPOINT to use python3.12.

Alternatively we could link python3 to python3.12, but for now keeping both python versions may be ok. This will be changed later as necessary.