### PR TITLE
garak: Added security recommended configuration files

### DIFF
--- a/config/config-template-garak-security-baseline.yaml
+++ b/config/config-template-garak-security-baseline.yaml
@@ -1,0 +1,35 @@
+config:
+  # WARNING: `configVersion` indicates the schema version of the config file.
+  # This value tells RapiDAST what schema should be used to read this configuration.
+  # Therefore you should only change it if you update the configuration to a newer schema
+  configVersion: 6
+
+  # all the results of all scanners will be stored under that location
+  # base_results_dir: "./results"
+
+# `application` contains data related to the application, not to the scans.
+application:
+  shortName: "garak-test-1.0"
+
+# `scanners' is a section that configures scanning options
+scanners:
+  garak:
+    parameters:
+      plugins:
+        model_type: huggingface                         # required, e.g. hugginngface, openai, rest
+        model_name: gpt2                                # optional, but a specific model type requires a model name or path
+        probe_spec: ansiescape.AnsiEscaped,av_spam_scanning,divergence,fileformats,grandma.Win11,leakreplay.NYTCloze,malwaregen.TopLevel,malwaregen.Evasion,malwaregen.Payload,packagehallucination.Python,promptinject.HijackLongPromptMini,suffix,xss
+        #generators:                                    # optional, providing more options for the selected model type, e.g. RestGenerator
+        #  rest:
+        #    RestGenerator:
+        #      uri:
+        #      method:
+        #      headers:
+        #      response_json_field:
+        #      req_template_json_object:
+        #      request_timeout: 1000
+      run:
+        generations: 5
+        parallel_attempts: 20
+
+    #executable_path: /usr/local/bin/garak    # default: /usr/local/bin/garak

--- a/config/config-template-garak-security-fast.yaml
+++ b/config/config-template-garak-security-fast.yaml
@@ -1,0 +1,35 @@
+config:
+  # WARNING: `configVersion` indicates the schema version of the config file.
+  # This value tells RapiDAST what schema should be used to read this configuration.
+  # Therefore you should only change it if you update the configuration to a newer schema
+  configVersion: 6
+
+  # all the results of all scanners will be stored under that location
+  # base_results_dir: "./results"
+
+# `application` contains data related to the application, not to the scans.
+application:
+  shortName: "garak-test-1.0"
+
+# `scanners' is a section that configures scanning options
+scanners:
+  garak:
+    parameters:
+      plugins:
+        model_type: huggingface                         # required, e.g. hugginngface, openai, rest
+        model_name: gpt2                                # optional, but a specific model type requires a model name or path
+        probe_spec: ansiescape.AnsiEscaped,av_spam_scanning.EICAR,divergence,fileformats,grandma.Win11,leakreplay.NYTCloze,malwaregen.TopLevel,packagehallucination.Python,promptinject.HijackLongPromptMini,suffix,xss
+        #generators:                                    # optional, providing more options for the selected model type, e.g. RestGenerator
+        #  rest:
+        #    RestGenerator:
+        #      uri:
+        #      method:
+        #      headers:
+        #      response_json_field:
+        #      req_template_json_object:
+        #      request_timeout: 1000
+      run:
+        generations: 1
+        parallel_attempts: 20
+
+    #executable_path: /usr/local/bin/garak    # default: /usr/local/bin/garak


### PR DESCRIPTION
I have added two different configuration files. These two files contain only the probes that are related to security. 

One of them (`config/config-template-garak-security-fast.yaml`) reduces the generations so it can run faster in the pipelines.
This list has been curated with the help of the AI Prodsec team. We have removed the toxicity prompts and removed probes that were duplicated and didn't add much value.
Right now running the `all` probes by default, the scan last for about 328134 seconds (around 96 hours). Our fast one lasts for around 20 minutes and the recommended around two hours