### PR TITLE
Refactor Teardown for OOBKube and fix Nessus integration test

### DIFF
--- a/e2e-tests/conftest.py
+++ b/e2e-tests/conftest.py
@@ -8,6 +8,7 @@ from typing import Dict
 from typing import Optional
 
 import certifi
+import pytest
 from kubernetes import client
 from kubernetes import config
 from kubernetes import utils
@@ -215,11 +216,15 @@ class TestBase:
             for func in cls._teardowns:
                 logging.debug(f"calling {func}")
                 func()
-        # XXX oobtukbe does not clean up after itself
-        os.system(f"kubectl delete ConfigMap/vulnerable -n {NAMESPACE}")
 
     def create_from_yaml(self, path: str):
         # delete resources in teardown method later
         self._teardowns.append(partial(os.system, f"kubectl delete -f {path} -n {NAMESPACE}"))
         o = utils.create_from_yaml(self.kclient, path, namespace=NAMESPACE, verbose=True)
         logging.debug(o)
+
+
+@pytest.fixture
+def _setup_teardown_for_oobkube():
+    yield
+    os.system(f"kubectl delete ConfigMap/vulnerable -n {NAMESPACE}")

--- a/e2e-tests/manifests/rapidast-nessus-configmap.yaml
+++ b/e2e-tests/manifests/rapidast-nessus-configmap.yaml
@@ -5,7 +5,7 @@ data:
       # WARNING: `configVersion` indicates the schema version of the config file.
       # This value tells RapiDAST what schema should be used to read this configuration.
       # Therefore you should only change it if you update the configuration to a newer schema
-      configVersion: 5
+      configVersion: 6
 
       # all the results of all scanners will be stored under that location
       # base_results_dir: "./results"
@@ -14,22 +14,6 @@ data:
     application:
       shortName: "nessus-test-1.0"
       # url: "<Mandatory. root URL of the application>" # XXX unused for nessus
-
-    # `general` is a section that will be applied to all scanners.
-    # Any scanner can override a value by creating an entry of the same name in their own configuration
-    general:
-      # container:
-      #   type: podman
-
-      # remove `authentication` entirely for unauthenticated connection
-      authentication:
-        type: "oauth2_rtoken"
-        parameters:
-          client_id: "cloud-services"
-          token_endpoint: "<token retrieval URL>"
-          # rtoken_from_var: "RTOKEN"     # referring to a env defined in general.environ.envFile
-          #preauth: false  # set to true to pregenerate a token, and stick to it (no refresh)
-
     # `scanners' is a section that configures scanning options
     scanners:
       nessus_foobar:

--- a/e2e-tests/test_integration.py
+++ b/e2e-tests/test_integration.py
@@ -46,7 +46,7 @@ class TestRapiDAST(TestBase):
             logs = f.read()
             assert expected_line in logs, f"{logfile} does not contain expected line: {expected_line}"
 
-    def test_oobtkube(self):
+    def test_oobtkube(self, _setup_teardown_for_oobkube):
         self.create_from_yaml(f"{self.tempdir}/cm-controller-deployment.yaml")
 
         self.create_from_yaml(f"{self.tempdir}/rapidast-oobtkube-configmap.yaml")

--- a/e2e-tests/test_nessus.py
+++ b/e2e-tests/test_nessus.py
@@ -15,10 +15,7 @@ class TestNessus(TestBase):
 
         self.create_from_yaml(f"{self.tempdir}/rapidast-nessus-configmap.yaml")
         self.create_from_yaml(f"{self.tempdir}/rapidast-nessus-pod.yaml")
-        # @FIX: We don't assert the container's successful completion because it
-        # ends up in an 'Error' status. This happens because the configuration provided
-        # defines authentication, but the Nessus scanner doesn't support authentication
-        is_pod_with_field_selector_successfully_completed(
+        assert is_pod_with_field_selector_successfully_completed(
             field_selector="metadata.name=rapidast-nessus", timeout=360  # llm-based image takes really long to download
         )
 


### PR DESCRIPTION
Introduce a teardown for only the OOBKube integration test, replacing the previous teardown that applied to all tests. It should resolve errors such as `Error from server (NotFound): configmaps "vulnerable" not found'` by removing the configMap without affecting unrelated tests

Remove authentication block from configuration in the integration tests, since the Nessus scanner does not support authentication.