### PR TITLE
fix: correct quay.io llm image URL in Tekton pipeline

### DIFF
--- a/.tekton/rapidast-llm-push.yaml
+++ b/.tekton/rapidast-llm-push.yaml
@@ -25,7 +25,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/repository/redhatproductsecurity/rapidast-llm:{{revision}}
+    value: quay.io/redhatproductsecurity/rapidast-llm:{{revision}}
   - name: dockerfile
     value: containerize/Containerfile.garak
   - name: build-args


### PR DESCRIPTION
The image URL in the Tekton pipeline was pointing to an incorrect location, causing a 401 error during the download process.