### PR TITLE
Support rapidast-llm for the main branch

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,7 +2,7 @@ name: Run tests
 
 on:
   push:
-    branches: ["development", "main"]
+    branches: ["development"] # XXX for now 'main' is removed to reduce time. It may be added again later.
   pull_request:
     branches: ["development", "main"]
 

--- a/.tekton/rapidast-llm-pull-request.yaml
+++ b/.tekton/rapidast-llm-pull-request.yaml
@@ -8,8 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "development"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && (target_branch == "development" || target_branch == "main")
   labels:
     appstudio.openshift.io/application: rapidast
     appstudio.openshift.io/component: rapidast-llm

--- a/.tekton/rapidast-llm-push.yaml
+++ b/.tekton/rapidast-llm-push.yaml
@@ -7,8 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "development"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && (target_branch == "development" || target_branch == "main")
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: rapidast


### PR DESCRIPTION
1. Support rapidast-llm for the main branch
2. Temporarily disabling the run-test github workflow on push to the 'main' branch to reduce time ( maybe added back later per discussion )
