### PR TITLE
Export all the scanner results to Google Cloud Storage

### DIFF
--- a/config/schemas/6/rapidast_schema.json
+++ b/config/schemas/6/rapidast_schema.json
@@ -49,7 +49,10 @@
                         }
                     },
                     "comment": "Credentials are optional, as the client defaults to those inferred from the environment",
-                    "required": ["bucketName"]
+                    "required": [
+                        "bucketName",
+                        "directory"
+                    ]
                 },
                 "defectDojo": {
                     "type": "object",

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -256,21 +256,17 @@ This simply stores the data as a compressed tarball in a Google Cloud Storage bu
 
 ```yaml
 config:
-  # Defect dojo configuration
   googleCloudStorage:
     keyFile: "/path/to/GCS/key"                           # optional: path to the GCS key file (alternatively: use GOOGLE_APPLICATION_CREDENTIALS)
-    bucketName: "<name-of-GCS-bucket-to-export-to>"       # Mandatory
-    directory: "<override-of-default-directory>"          # Optional directory where the credentials have write access, defaults to `RapiDAST-<product>`
+    bucketName: "<name-of-GCS-bucket-to-export-to>"       # Required
+    directory: "<name-of-directory-under-bucket>"         # Required, GCS directory(folder) name where write access is granted
 ```
 
-Once this is set, scan results will be exported to the bucket automatically. The tarball file will include:
-
- 1. metadata.json - the file that contains scan_type, uuid and import_data(could be changed later. Currently this comes from the previous DefectDojo integration feature)
- 2. scans - the directory that contains scan results
+Once this is set, scan results will be exported to the bucket automatically. The tarball file will include the results in the same structure as they are stored locally.
 
 #### Exporting to DefectDojo
 
-RapiDAST supports integration with OWASP DefectDojo which is an open source vulnerability management tool.
+RapiDAST supports integration with OWASP DefectDojo which is an open source vulnerability management tool. Note that currently, only ZAP scan results and generic plugin results(via SARIF format) are supported.
 
 ##### Preamble: creating DefectDojo user
 

--- a/rapidast.py
+++ b/rapidast.py
@@ -90,7 +90,7 @@ def load_config(config_file_location: str) -> Dict[str, Any]:
 
 # pylint: disable=R0911
 # too many return statements
-def run_scanner(name, config, args, scan_exporter):
+def run_scanner(name, config, args, dedo_exporter=None):
     """given the config `config`, runs scanner `name`.
     Returns:
         0 for success
@@ -160,11 +160,14 @@ def run_scanner(name, config, args, scan_exporter):
     if not args.no_cleanup:
         scanner.cleanup()
 
-    # Part 6: export to defect dojo, if the scanner is compatible
-    if scan_exporter and hasattr(scanner, "data_for_defect_dojo"):
+    # Optional: Export the scanner result to DefectDojo if set
+    # Note: Unlike exporting to GCS, this process needs to be run for each scanner,
+    #   because DefectDojo can only process one type of scanner result at a time
+
+    if dedo_exporter and hasattr(scanner, "data_for_defect_dojo"):
         logging.info("Exporting results to the Defect Dojo service as configured")
 
-        if scan_exporter.export_scan(*scanner.data_for_defect_dojo()) == 1:
+        if dedo_exporter.export_scan(*scanner.data_for_defect_dojo()) == 1:
             logging.error("Exporting results to DefectDojo failed")
             return 1
 
@@ -323,6 +326,9 @@ def validate_config_schema(config_file) -> bool:
     return False
 
 
+# pylint: disable=R0912, R0915
+# R0912(too-many-branches)
+# R0915(too many statements)
 def run():
     parser = argparse.ArgumentParser(
         description="Runs various DAST scanners against a defined target, as configured by a configuration file."
@@ -384,17 +390,10 @@ def run():
     # Do early: load the environment file if one is there
     load_environment(config)
 
-    # Prepare an export to Defect Dojo if one is configured.
-    scan_exporter = None
-    if config.get("config.googleCloudStorage.bucketName"):
-        scan_exporter = GoogleCloudStorage(
-            bucket_name=config.get("config.googleCloudStorage.bucketName"),
-            app_name=config.get_official_app_name(),
-            directory=config.get("config.googleCloudStorage.directory", None),
-            keyfile=config.get("config.googleCloudStorage.keyFile", None),
-        )
-    elif config.get("config.defectDojo.url"):
-        scan_exporter = DefectDojo(
+    # Check DefectDojo export configuration
+    dedo_exporter = None
+    if config.get("config.defectDojo.url"):
+        dedo_exporter = DefectDojo(
             config.get("config.defectDojo.url"),
             {
                 "username": config.get("config.defectDojo.authorization.username", default=""),
@@ -404,17 +403,37 @@ def run():
             config.get("config.defectDojo.ssl", default=True),
         )
 
+    # Check GCS export configuration
+    gcs_exporter = None
+    if config.get("config.googleCloudStorage.bucketName"):
+        gcs_exporter = GoogleCloudStorage(
+            bucket_name=config.get("config.googleCloudStorage.bucketName"),
+            app_name=config.get_official_app_name(),
+            directory=config.get("config.googleCloudStorage.directory", None),
+            keyfile=config.get("config.googleCloudStorage.keyFile", None),
+        )
+
     # Run all scanners
     scan_error_count = 0
     for name in config.get("scanners"):
         logging.info(f"Next scanner: '{name}'")
 
-        ret = run_scanner(name, config, args, scan_exporter)
+        ret = run_scanner(name, config, args, dedo_exporter)
         if ret == 1:
             logging.info(f"scanner: '{name}' failed")
             scan_error_count = scan_error_count + 1
         else:
             logging.info(f"scanner: '{name}' completed successfully")
+
+    # Export all the scan results to GCS
+    # Note: This is done after all scanners have run,
+    #   unlike the DefectDojo export which needs to be done at the individual scanner level.
+    if gcs_exporter:
+        ret = gcs_exporter.export_scan(full_result_dir_path)
+        if ret == 1:
+            logging.info("exporting to GoogleCloudStorage failed")
+        else:
+            logging.info("exporting to GoogleCloudStorage completed successfully")
 
     if scan_error_count > 0:
         logging.warning(f"Number of failed scanners: {scan_error_count}")

--- a/tests/exports/test_google_cloud_storage.py
+++ b/tests/exports/test_google_cloud_storage.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 from unittest.mock import MagicMock
 from unittest.mock import Mock
 from unittest.mock import mock_open
@@ -84,11 +85,19 @@ def test_GCS_export_scan(MockRandom, MockDateTime, MockClient):
 
     gcs = GoogleCloudStorage("bucket_name", "app_name", "directory_name")
 
-    import_data = {"scan_type": "ABC", "foo": "bar"}
-
     # hack: use the pytest file itself as a scan
-    gcs.export_scan(import_data, __file__)
+    gcs.export_scan(os.path.dirname(__file__))
 
     mock_bucket.blob.assert_called_once_with("directory_name/2024-01-31T00:00:00-RapiDAST-app_name-abcdef.tgz")
 
     mock_open_method.assert_called_once_with(mode="wb")
+
+
+@patch("exports.google_cloud_storage.storage.Client")
+def test_GCS_init_unset_directory(MockClient):
+    mock_client = MagicMock()
+    MockClient.return_value = mock_client
+
+    with pytest.raises(ValueError) as e:
+        gcs = GoogleCloudStorage("bucket_name", "app_name")
+    assert str(e.value) == "Directory must be specified."


### PR DESCRIPTION
- decoupled GCS export from DefectDojo export
- export all the scanner results to GCS including the config file, in the same structure as they are stored locally
  -- no metadata.json which was used(related to DefectDojo) is produced.
- made the 'directory'(GCS folder) config required now