### PR TITLE
Always enable SARIF report in ZAP scanner regardless of user config

### DIFF
--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -757,7 +757,7 @@ class Zap(RapidastScanner):
             except KeyError as exc:
                 logging.warning(f"Reports: {exc.args[0]} is not a valid format. Ignoring")
         if not appended:
-            logging.warning("No valid report formats found. Adding default JSON and SARIF reports.")
+            logging.warning("No valid report formats found. Adding default JSON and SARIF reports")
             self.automation_config["jobs"].append(self._construct_report_af(reports["json"]))
             self.automation_config["jobs"].append(self._construct_report_af(reports["sarif"]))
 

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -731,12 +731,17 @@ class Zap(RapidastScanner):
             "xml": ReportFormat("traditional-xml-plus", "zap-report.xml"),
         }
 
-        formats = self.my_conf("report.format", {"json"})
+        formats = self.my_conf("report.format", {"json", "sarif"})
         # handle case where user provides a string
         if isinstance(formats, str):
             formats = [formats]
         # remove duplicates
         formats = set(formats)
+
+        # Ensure SARIF is always enabled, regardless of the user's configuration settings
+        if "sarif" not in formats:
+            logging.debug("SARIF report format enforced by default")
+            formats.add("sarif")
 
         # DefectDojo requires XML report type
         if self._should_export_to_defect_dojo():
@@ -752,8 +757,9 @@ class Zap(RapidastScanner):
             except KeyError as exc:
                 logging.warning(f"Reports: {exc.args[0]} is not a valid format. Ignoring")
         if not appended:
-            logging.warning("Creating a default report as no valid were found")
+            logging.warning("No valid report formats found. Adding default JSON and SARIF reports.")
             self.automation_config["jobs"].append(self._construct_report_af(reports["json"]))
+            self.automation_config["jobs"].append(self._construct_report_af(reports["sarif"]))
 
     def _setup_summary(self):
         """Adds a outputSummary job"""

--- a/tests/scanners/zap/test_setup.py
+++ b/tests/scanners/zap/test_setup.py
@@ -458,17 +458,17 @@ def test_setup_graphql(test_config):
 def test_setup_report_format(test_config, result_format, expected_template):
     test_config.set("scanners.zap.report.format", [result_format])
 
-    print(test_config)
-
     test_zap = ZapNone(config=test_config)
     test_zap.setup()
 
-    for item in test_zap.automation_config["jobs"]:
-        if item["type"] == "report":
-            assert item["parameters"]["template"] == expected_template
-            break
-    else:
-        assert False
+    report_templates = [
+        job["parameters"]["template"]
+        for job in test_zap.automation_config["jobs"]
+        if job["type"] == "report"
+    ]
+
+    assert expected_template in report_templates, f"{expected_template} not found in {report_templates}"
+
 
 
 def test_setup_report_string_format(test_config):
@@ -480,23 +480,29 @@ def test_setup_report_string_format(test_config):
     count = 0
     for item in test_zap.automation_config["jobs"]:
         if item["type"] == "report":
-            assert item["parameters"]["template"] == "traditional-xml-plus"
+            assert item["parameters"]["template"] in {
+                "traditional-xml-plus",
+                "sarif-json", # Always enabled
+            }
             count += 1
 
-    assert count == 1
+    assert count == 2
 
 
-def test_setup_report_default_format(test_config):
+def test_setup_report_default_formats(test_config):
     test_zap = ZapNone(config=test_config)
     test_zap.setup()
 
     count = 0
     for item in test_zap.automation_config["jobs"]:
         if item["type"] == "report":
-            assert item["parameters"]["template"] == "traditional-json-plus"
+            assert item["parameters"]["template"] in {
+                "traditional-json-plus",
+                "sarif-json",
+            }
             count += 1
 
-    assert count == 1
+    assert count == 2
 
 
 def test_setup_report_several_formats(test_config):
@@ -510,10 +516,11 @@ def test_setup_report_several_formats(test_config):
             assert item["parameters"]["template"] in {
                 "traditional-json-plus",
                 "traditional-xml-plus",
+                "sarif-json" # Always enabled
             }
             count += 1
 
-    assert count == 2
+    assert count == 3
 
 
 # Misc tests

--- a/tests/scanners/zap/test_setup.py
+++ b/tests/scanners/zap/test_setup.py
@@ -462,13 +462,10 @@ def test_setup_report_format(test_config, result_format, expected_template):
     test_zap.setup()
 
     report_templates = [
-        job["parameters"]["template"]
-        for job in test_zap.automation_config["jobs"]
-        if job["type"] == "report"
+        job["parameters"]["template"] for job in test_zap.automation_config["jobs"] if job["type"] == "report"
     ]
 
     assert expected_template in report_templates, f"{expected_template} not found in {report_templates}"
-
 
 
 def test_setup_report_string_format(test_config):
@@ -482,7 +479,7 @@ def test_setup_report_string_format(test_config):
         if item["type"] == "report":
             assert item["parameters"]["template"] in {
                 "traditional-xml-plus",
-                "sarif-json", # Always enabled
+                "sarif-json",  # Always enabled
             }
             count += 1
 
@@ -516,7 +513,7 @@ def test_setup_report_several_formats(test_config):
             assert item["parameters"]["template"] in {
                 "traditional-json-plus",
                 "traditional-xml-plus",
-                "sarif-json" # Always enabled
+                "sarif-json",  # Always enabled
             }
             count += 1
 


### PR DESCRIPTION
This PR makes sure the ZAP scanner always creates a SARIF report, even if the user didn’t configure it in the settings. 
We want to have one single SARIF file that includes results from all scanners (like ZAP, Nessus, Garak). To do that, all scanners need to support SARIF by default