### PR TITLE
chore(ci): update actions/setup-python to v5 to leverage caching

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,11 +16,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.9
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: "3.9"
-        #cache: 'pip' # caching pip dependencies
-        #cache-dependency-path: 'requirements-dev.txt'
+        cache: 'pip'
+        cache-dependency-path: 'requirements-dev.txt'
     - name: Install dependencies
       run: |
         python3 -m ensurepip --upgrade
@@ -35,11 +35,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.9
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: "3.9"
-        #cache: 'pip' # caching pip dependencies
-        #cache-dependency-path: 'requirements-dev.txt'
+        cache: 'pip'
+        cache-dependency-path: 'requirements-dev.txt'
     - name: Install dependencies
       run: |
         python3 -m ensurepip --upgrade


### PR DESCRIPTION
We're currently using `actions/setup-python@v3`, which relies on `actions/cache@v2`. However, `actions/cache@v2` is deprecated ([details here](https://github.com/actions/cache?tab=readme-ov-file#%EF%B8%8F-important-changes)), resulting in the pip cache being disabled.
This update upgrades to `setup-python@v5,` which uses the latest cache version and restores pip caching functionality.