### PR TITLE
Automatic VERSION.txt generation based on Git tags

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -124,6 +124,8 @@ spec:
       value: $(params.image-expires-after)
     - name: fetchTags
       value: "true"
+    - name: refspec
+      value: "main"
     runAfter:
     - init
     taskRef:

--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -167,6 +167,24 @@ spec:
       workspace: git-auth
     - name: netrc
       workspace: netrc
+  - name: generate-version
+    runAfter:
+    - prefetch-dependencies
+    params:
+      - name: TARGET_BRANCH
+        value: "{{target_branch}}"
+    taskSpec:
+      params:
+        - name: TARGET_BRANCH
+          type: string
+      steps:
+        - name: select-tags-based-on-branch
+          image: registry.access.redhat.com/ubi9/ubi-minimal:9.5-1739420147@sha256:fb77e447ab97f3fecd15d2fa5361a99fe2f34b41422e8ebb3612eecd33922fa0
+          script: |
+            #!/bin/bash -ex
+            microdnf install -y python-pip
+            pip install -U --no-cache-dir setuptools setuptools-scm GitPython
+            python -m setuptools_scm --force-write-version-files
   - name: build-container
     params:
     - name: IMAGE
@@ -193,7 +211,7 @@ spec:
     - name: CACHI2_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     runAfter:
-    - prefetch-dependencies
+    - generate-version
     taskRef:
       params:
       - name: name

--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -122,6 +122,8 @@ spec:
       value: $(params.output-image).git
     - name: ociArtifactExpiresAfter
       value: $(params.image-expires-after)
+    - name: fetchTags
+      value: "true"
     runAfter:
     - init
     taskRef:
@@ -178,10 +180,7 @@ spec:
             #!/bin/bash -ex
             microdnf install -y python-pip
             pip install -U --no-cache-dir setuptools setuptools-scm GitPython
-            ls -R
-            cd source
             python -m setuptools_scm --force-write-version-files
-
   - name: build-container
     params:
     - name: IMAGE

--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -124,8 +124,6 @@ spec:
       value: $(params.image-expires-after)
     - name: fetchTags
       value: "true"
-    - name: refspec
-      value: "main"
     runAfter:
     - init
     taskRef:

--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -170,13 +170,7 @@ spec:
   - name: generate-version
     runAfter:
     - prefetch-dependencies
-    params:
-      - name: TARGET_BRANCH
-        value: "{{target_branch}}"
     taskSpec:
-      params:
-        - name: TARGET_BRANCH
-          type: string
       steps:
         - name: select-tags-based-on-branch
           image: registry.access.redhat.com/ubi9/ubi-minimal:9.5-1739420147@sha256:fb77e447ab97f3fecd15d2fa5361a99fe2f34b41422e8ebb3612eecd33922fa0
@@ -184,7 +178,10 @@ spec:
             #!/bin/bash -ex
             microdnf install -y python-pip
             pip install -U --no-cache-dir setuptools setuptools-scm GitPython
+            ls -R
+            cd source
             python -m setuptools_scm --force-write-version-files
+
   - name: build-container
     params:
     - name: IMAGE

--- a/containerize/Containerfile
+++ b/containerize/Containerfile
@@ -81,6 +81,7 @@ COPY ./exports/ /opt/rapidast/exports/
 COPY ./configmodel/ /opt/rapidast/configmodel/
 COPY ./utils/ /opt/rapidast/utils/
 COPY ./config/ /opt/rapidast/config/
+COPY VERSION.txt /opt/rapidast/VERSION.txt
 
 ### Add generic tools in the PATH
 COPY ./scanners/generic/tools/convert_trivy_k8s_to_sarif.py /usr/local/bin/

--- a/containerize/Containerfile.garak
+++ b/containerize/Containerfile.garak
@@ -81,6 +81,7 @@ COPY ./exports/ /opt/rapidast/exports/
 COPY ./configmodel/ /opt/rapidast/configmodel/
 COPY ./utils/ /opt/rapidast/utils/
 COPY ./config/ /opt/rapidast/config/
+COPY VERSION.txt /opt/rapidast/VERSION.txt
 
 ### Add generic tools in the PATH
 COPY ./scanners/generic/tools/convert_trivy_k8s_to_sarif.py /usr/local/bin/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ packages = ["configmodel", "exports", "utils", "scanners"]
 dependencies = { file = ["requirements.in"] }
 
 [tool.setuptools_scm]
+version_file = "VERSION.txt"
+version_scheme = "version:custom_version_scheme"
+local_scheme = "version:custom_local_scheme"
 
 [tool.ruff]
 line-length = 120

--- a/version.py
+++ b/version.py
@@ -1,0 +1,57 @@
+import os
+from git import Repo
+from setuptools_scm import version as _version, ScmVersion
+
+def get_current_branch():
+    """Gets the name of the current Git branch"""
+    try:
+        repo_path = os.getcwd()
+        repo = Repo(repo_path)
+        return repo.active_branch.name
+    except Exception as e:
+        print(f"Error getting current branch: {e}")
+        return None
+
+
+def get_latest_main_tag() -> str:
+    """Gets the latest tag name from the "main" branch"""
+    try:
+        repo_path = os.getcwd()
+        repo = Repo(repo_path)
+        current_branch = get_current_branch()
+        main_branch = repo.heads.main
+        repo.git.checkout(main_branch)
+        tags = sorted(repo.tags, key=lambda t: t.commit.committed_date, reverse=True)
+        repo.git.checkout(current_branch)
+
+        if tags:
+            return str(tags[0])
+        return None
+
+    except Exception as e:
+        print(f"Error getting latest tag info: {e}")
+        return None
+
+
+def custom_local_scheme(version: ScmVersion)-> str:
+    if version.branch == "main":
+        return ""
+
+    return f"+{version.node[1:8]}-{version.node_date.strftime('%Y%m%d')}"
+
+
+def custom_version_scheme(version: ScmVersion)-> str:
+
+    latest_tag_name = get_latest_main_tag()
+
+    fallback_tag = "0.1.0"
+
+    if latest_tag_name:
+        version.tag = latest_tag_name
+    else:
+        return f"{fallback_tag}"
+
+    if version.branch == "main":
+        return f"{version.format_with(latest_tag_name)}"
+
+    return f"{version.format_next_version(_version.guess_next_simple_semver, retain=_version.SEMVER_PATCH, fmt='{guessed}')}"

--- a/version.py
+++ b/version.py
@@ -1,6 +1,9 @@
 import os
+
 from git import Repo
-from setuptools_scm import version as _version, ScmVersion
+from setuptools_scm import ScmVersion
+from setuptools_scm import version as _version
+
 
 def get_current_branch():
     """Gets the name of the current Git branch"""
@@ -8,7 +11,7 @@ def get_current_branch():
         repo_path = os.getcwd()
         repo = Repo(repo_path)
         return repo.active_branch.name
-    except Exception as e:
+    except Exception as e:  # pylint: disable=W0718
         print(f"Error getting current branch: {e}")
         return None
 
@@ -28,20 +31,19 @@ def get_latest_main_tag() -> str:
             return str(tags[0])
         return None
 
-    except Exception as e:
+    except Exception as e:  # pylint: disable=W0718
         print(f"Error getting latest tag info: {e}")
         return None
 
 
-def custom_local_scheme(version: ScmVersion)-> str:
+def custom_local_scheme(version: ScmVersion) -> str:
     if version.branch == "main":
         return ""
 
     return f"+{version.node[1:8]}-{version.node_date.strftime('%Y%m%d')}"
 
 
-def custom_version_scheme(version: ScmVersion)-> str:
-
+def custom_version_scheme(version: ScmVersion) -> str:
     latest_tag_name = get_latest_main_tag()
 
     fallback_tag = "0.1.0"
@@ -54,4 +56,4 @@ def custom_version_scheme(version: ScmVersion)-> str:
     if version.branch == "main":
         return f"{version.format_with(latest_tag_name)}"
 
-    return f"{version.format_next_version(_version.guess_next_simple_semver, retain=_version.SEMVER_PATCH, fmt='{guessed}')}"
+    return version.format_next_version(_version.guess_next_simple_semver, retain=_version.SEMVER_PATCH, fmt="{guessed}")


### PR DESCRIPTION
This is the first try of adding an automated mechanism to generate the `VERSION.txt` file for RapiDAST based on the Git tags present in the `main` branch.

How it works:
- **Non-main branch versioning**: When RapiDAST is built from a branch other than `main`, the generated `VERSION.txt `will be based on the latest tag found in the main branch. The patch version will be incremented by one, and the commit hash along with the current date will be appended to the version string (e.g., 2.10.1+eed5b74-20250507).
- **main branch versioning**: When RapiDAST is built from the `main` branch, the generated `VERSION.txt `will be the latest tag found in the main branch (e.g., 2.10.0). The current approach for building RapiDAST from the `main` branch requires a revision of the release process. Currently, the build happens from a merge commit, and the repository is tagged after the build. This results in the `VERSION.txt` containing the tag from the previous release, not the newly created one.
To ensure the `VERSION.txt` on the main branch reflects the correct release tag, we would need to re-trigger the build process on the main branch before pushing the tags to quay.io. This step is necessary to update the newly created tag in the generated `VERSION.txt` (This is not part of this PR, I would like to get your feedback on this).

This implementation uses `setuptools_scm`. It was chosen because it is a standard tool for managing Python package versions from Git metadata and can be used for packaging RapiDAST as a Python package in the future. However, alternative proposals for achieving this functionality are welcome.