### PR TITLE
Use .sarif.json suffix with nessus scans

### DIFF
--- a/scanners/nessus/nessus_none.py
+++ b/scanners/nessus/nessus_none.py
@@ -174,7 +174,7 @@ class Nessus(RapidastScanner):
             sarif_output = convert_csv_to_sarif(path.join(scan_reports, file))
             # Save sarif file
             with open(
-                path.join(scan_reports, file.replace(".csv", "-sarif.json")),
+                path.join(scan_reports, file.replace(".csv", ".sarif.json")),
                 "w",
                 encoding="utf-8",
             ) as output:


### PR DESCRIPTION
Current suffix of `-sarif.json` meant that this report was not consolidated into the top-level:

https://github.com/RedHatProductSecurity/rapidast/blob/development/rapidast.py#L487