### PR TITLE
Recompile requirements-dev.txt to reflect updated dependencies

### DIFF
--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -218,6 +218,13 @@ To add a new dependency, follow these steps:
 
    This will regenerate `requirements.txt` with the newly added dependency and its pinned versions.
 
+3. **IMPORTANT: Prefetching will not reflect new dependencies unless this step is completed**.
+    Recompile `requirements-dev.txt` to update development dependencies that rely on `requirements.txt`.
+    Run the following command:
+
+   ```sh
+   pip-compile requirements-dev.in
+   ```
 ### Installing a new development only dependency
 
 To add a new dependency, follow these steps:


### PR DESCRIPTION
Right now, prefetching dependencies uses `requirements-dev.txt`. So, when we add a new dependency to `requirements.txt`, we also need to update the dev file. If we don’t, the system might use old dependencies.

One idea to improve this is to use both files separately and prefetch from both. But this could cause problems if the files are not updated together and have incompatible dependencies.

Until we decide on a better way to handle this, this note should help avoid unexpected issues.