### PR TITLE
Rapidast version args

### DIFF
--- a/.tekton/rapidast-llm-pull-request.yaml
+++ b/.tekton/rapidast-llm-pull-request.yaml
@@ -32,7 +32,9 @@ spec:
   - name: skip-checks
     value: "true"
   - name: build-args
-    value: [PREFETCH=false]
+    value:
+    - PREFETCH=false
+    - COMMIT_SHA={{revision}}
   taskRunSpecs:
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:

--- a/.tekton/rapidast-llm-push.yaml
+++ b/.tekton/rapidast-llm-push.yaml
@@ -28,7 +28,9 @@ spec:
   - name: dockerfile
     value: containerize/Containerfile.garak
   - name: build-args
-    value: [PREFETCH=false]
+    value:
+    - PREFETCH=false
+    - COMMIT_SHA={{revision}}
   taskRunSpecs:
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:

--- a/.tekton/rapidast-pull-request.yaml
+++ b/.tekton/rapidast-pull-request.yaml
@@ -36,7 +36,9 @@ spec:
     - {"type": "npm", "path": "."}
     - {"type": "pip", "path": ".", "allow_binary": "true", "requirements_files": ["requirements-dev.txt"]}
   - name: build-args
-    value: [PREFETCH=true]
+    value:
+    - PREFETCH=true
+    - COMMIT_SHA={{revision}}
   taskRunSpecs:
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:

--- a/.tekton/rapidast-push.yaml
+++ b/.tekton/rapidast-push.yaml
@@ -31,7 +31,9 @@ spec:
     - {"type": "npm", "path": "."}
     - {"type": "pip", "path": ".", "allow_binary": "true", "requirements_files": ["requirements-dev.txt"]}
   - name: build-args
-    value: [PREFETCH=true]
+    value:
+    - PREFETCH=true
+    - COMMIT_SHA={{revision}}
   taskRunSpecs:
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:

--- a/containerize/Containerfile
+++ b/containerize/Containerfile
@@ -64,6 +64,9 @@ RUN mkdir -p /tmp/redocly/node_modules && if [ "$PREFETCH" == "true" ]; then \
 # Copy artifacts from deps to build RapiDAST
 FROM registry.access.redhat.com/ubi9-minimal
 
+# Specify the Git commit SHA that this image was built from
+ARG COMMIT_SHA=UNKNOWN
+
 COPY --from=deps /opt/zap /opt/zap
 COPY --from=deps /opt/firefox /opt/firefox
 COPY --from=deps /usr/local/bin/kubectl /usr/local/bin/kubectl
@@ -73,7 +76,9 @@ COPY --from=deps /tmp/redocly/node_modules /opt/redocly/node_modules
 ENV PATH $PATH:/opt/zap/:/opt/rapidast/:/opt/firefox/
 
 ## RapiDAST
-RUN mkdir /opt/rapidast
+RUN mkdir /opt/rapidast && \
+  echo "$COMMIT_SHA" > /opt/rapidast/commit_sha.txt
+
 COPY ./rapidast.py ./requirements.txt /opt/rapidast/
 COPY ./scanners/ /opt/rapidast/scanners/
 COPY ./tools/ /opt/rapidast/tools/

--- a/containerize/Containerfile.garak
+++ b/containerize/Containerfile.garak
@@ -64,6 +64,9 @@ RUN mkdir -p /tmp/redocly/node_modules && if [ "$PREFETCH" == "true" ]; then \
 # Copy artifacts from deps to build RapiDAST
 FROM registry.access.redhat.com/ubi9-minimal
 
+# Specify the Git commit SHA that this image was built from
+ARG COMMIT_SHA=UNKNOWN
+
 COPY --from=deps /opt/zap /opt/zap
 COPY --from=deps /opt/firefox /opt/firefox
 COPY --from=deps /usr/local/bin/kubectl /usr/local/bin/kubectl
@@ -73,7 +76,8 @@ COPY --from=deps /tmp/redocly/node_modules /opt/redocly/node_modules
 ENV PATH $PATH:/opt/zap/:/opt/rapidast/:/opt/firefox/
 
 ## RapiDAST
-RUN mkdir /opt/rapidast
+RUN mkdir /opt/rapidast && \
+  echo "$COMMIT_SHA" > /opt/rapidast/commit_sha.txt
 COPY ./rapidast.py ./requirements-llm.txt /opt/rapidast/
 COPY ./scanners/ /opt/rapidast/scanners/
 COPY ./tools/ /opt/rapidast/tools/

--- a/rapidast.py
+++ b/rapidast.py
@@ -446,7 +446,7 @@ def run():
         else:
             logging.info(f"scanner: '{name}' completed successfully")
 
-    sarif_properties = {"config_version": config.get("config.configVersion"), "scanner_results": scanner_results}
+    sarif_properties = generate_sarif_properties(config, scanner_results, "commit_sha.txt")
 
     merge_sarif_files(
         directory=full_result_dir_path,
@@ -531,6 +531,30 @@ def merge_sarif_files(directory: str, properties: dict, output_filename: str):
     except Exception as e:  # pylint: disable=W0718
         logging.error(f"Error writing merged SARIF file: {e}")
 
+def generate_sarif_properties(config: configmodel.RapidastConfigModel, scanner_results: dict, commit_sha_filename: str) -> dict:
+    """
+    Generates the dictionary containing properties for the SARIF output
+
+    Args:
+        config: The RapiDAST configuration object
+        scanner_results: A dictionary containing the results of each scanner
+        commit_sha_filename: The name of the file containing the commit SHA
+    """
+    commit_sha = None
+    try:
+        with open(commit_sha_filename, 'r', encoding='utf-8') as file:
+            commit_sha = file.read().strip()
+    except FileNotFoundError:
+        logging.warning(f"Error: File '{commit_sha_filename}' not found")
+    except Exception as e:  # pylint: disable=W0718
+        logging.warning(f"An error occurred while reading '{commit_sha_filename}': {e}")
+
+    sarif_properties = {
+        "config_version": config.get("config.configVersion"),
+        "scanner_results": scanner_results,
+        "commit_sha": commit_sha
+    }
+    return sarif_properties
 
 if __name__ == "__main__":
     run()

--- a/rapidast.py
+++ b/rapidast.py
@@ -545,7 +545,7 @@ def generate_sarif_properties(config: configmodel.RapidastConfigModel, scanner_r
         with open(commit_sha_filename, 'r', encoding='utf-8') as file:
             commit_sha = file.read().strip()
     except FileNotFoundError:
-        logging.warning(f"Error: File '{commit_sha_filename}' not found")
+        logging.warning(f"File '{commit_sha_filename}' not found. Falling back to `null`")
     except Exception as e:  # pylint: disable=W0718
         logging.warning(f"An error occurred while reading '{commit_sha_filename}': {e}")
 


### PR DESCRIPTION
Enhances top level SARIF output with Git commit SHAs. It adds the scan commit SHA to the top-level SARIF for easy codebase version tracking