### PR TITLE
Fix incorrect field name in ZAP scanner config schema

### DIFF
--- a/config/schemas/6/rapidast_schema.json
+++ b/config/schemas/6/rapidast_schema.json
@@ -343,7 +343,7 @@
                                                 "image": {
                                                     "type": "string"
                                                 },
-                                                "command": {
+                                                "executable": {
                                                     "type": "string"
                                                 },
                                                 "podName": {


### PR DESCRIPTION
The "executable" field was mistakenly defined as "command" in the configuration schema. See:
https://github.com/RedHatProductSecurity/rapidast/blob/2.10.0/config/config-template-zap-long.yaml#L186