### PR TITLE
Fix Firefox extraction path

### DIFF
--- a/containerize/Containerfile
+++ b/containerize/Containerfile
@@ -39,7 +39,7 @@ RUN mkdir /opt/zap && \
 
 ## Firefox, for Ajax
 RUN mkdir -p /opt/firefox && \
-  tar xjvf "$FF_FILE" -C /opt/firefox
+  tar xjvf "$FF_FILE" --strip-components=1 -C /opt/firefox
 
 ## kubectl
 RUN install -o root -g root -m 0755 "$KCTL_FILE" /usr/local/bin/kubectl
@@ -99,6 +99,12 @@ RUN microdnf install -y --setopt=install_weak_deps=0 java-21-openjdk shadow-util
   pip3 install --no-cache-dir -r /opt/rapidast/requirements.txt && \
   microdnf clean all -y && rm -rf /var/cache/dnf /tmp/*  && \
   ln -s /opt/redocly/node_modules/@redocly/cli/bin/cli.js /usr/local/bin/redocly
+
+### Validate that required dependencies are available in the system PATH
+RUN zap.sh -cmd -version && \
+  firefox --headless -version && \
+  kubectl version --client && \
+  trivy --version
 
 RUN useradd -u 1000 -d /opt/rapidast -m -s /bin/bash rapidast && \
   chown -R 1000 /opt/rapidast && \

--- a/e2e-tests/manifests/rapidast-vapi-configmap.yaml
+++ b/e2e-tests/manifests/rapidast-vapi-configmap.yaml
@@ -27,6 +27,11 @@ data:
           parameters:
             executable: "zap.sh"
 
+        spiderAjax:
+          maxDuration: 1
+          url: "http://vapi:3000"
+          maxCrawlDepth: 1
+
         miscOptions:
           # enableUI (default: false), requires a compatible runtime (e.g.: flatpak or no containment)
           #enableUI: True


### PR DESCRIPTION
Modified the Firefox archive extraction command to strip leading directories, ensuring files are placed directly under the intended `/opt/firefox` path. Previously, the archive extracted to `/opt/firefox/firefox/`, causing the ZAP `spiderAjax` tool to fail due to the Firefox binary not being found in the expected location. This issue was introduced during the [pre-caching of dependencies](https://github.com/RedHatProductSecurity/rapidast/commit/a4984c51bc934acf68cd842a3b1eace972709644#diff-4f537bd0af274fcb1f33b92a51b7d80ee2b37d51bbc3eb352fdf2ac9468250baR45).

Additionally, I’ve added basic tests to validate dependency availability during container build, along with an E2E test to verify that `spiderAjax` is functioning correctly.
