### PR TITLE
Add renovate.json to configure mintmaker

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "prConcurrentLimit": 3,
+  "packageRules": [
+    {
+      "description": "Automerge non-major updates in .tekton folder and pre-commit-config to development branch",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "matchFileNames": [".tekton/**", ".pre-commit-config.yaml"],
+      "matchBaseBranches": "development",
+      "automerge": true
+    }
+  ]
+}


### PR DESCRIPTION
- limit open conccurrent open PRs by mintmaker to 3
- automerge minor updates in .tekton dir to development branch
    
This is an attempt to reduce maintenance overhead by automerging low-risk changes, and reducing the noise from too-many open PRs. Note that changes will only be auto-merged if test pipelines succeed:

https://konflux.pages.redhat.com/docs/users/mintmaker/user.html#automerge
    
