### PR TITLE
Resolve env vars before Dacite parsing + Migrate zap.replacer to dataclass

### DIFF
--- a/configmodel/__init__.py
+++ b/configmodel/__init__.py
@@ -2,7 +2,8 @@ import copy
 import logging
 import os
 from pprint import pformat
-from typing import Dict, Any
+from typing import Any
+from typing import Dict
 
 
 class RapidastConfigModel:
@@ -298,6 +299,7 @@ def deep_dict_merge(dest, merge, preserve=False):
         elif not preserve:
             dest[key] = copy.deepcopy(val)
     return dest
+
 
 def deep_traverse_and_replace_with_var_content(d: dict) -> dict:  # pylint: disable=C0103
     """

--- a/configmodel/__init__.py
+++ b/configmodel/__init__.py
@@ -2,6 +2,7 @@ import copy
 import logging
 import os
 from pprint import pformat
+from typing import Dict, Any
 
 
 class RapidastConfigModel:
@@ -297,3 +298,43 @@ def deep_dict_merge(dest, merge, preserve=False):
         elif not preserve:
             dest[key] = copy.deepcopy(val)
     return dest
+
+def deep_traverse_and_replace_with_var_content(d: dict) -> dict:  # pylint: disable=C0103
+    """
+    Recursively traverse a dictionary and replace key-value pairs where the key ends with `_from_var`
+    The value is replaced with the corresponding environment variable value if available.
+    Existing truthy values for the base key will not be overwritten.
+    """
+    suffix = "_from_var"
+    keys_to_replace = [key for key in d if isinstance(key, str) and key.endswith(suffix)]
+
+    for key in keys_to_replace:
+        new_key = key[: -len(suffix)]
+
+        try:
+            if new_key in d:
+                continue
+        except KeyError:
+            pass
+
+        try:
+            env_value = os.environ[d[key]]
+            d[new_key] = env_value
+            del d[key]
+        except KeyError:
+            logging.error(
+                f"""
+                Environment variable '{d[key]}' referenced by key '{key}' could not be found.
+                No configuration replacement will be made for this key. Please check your configuration and environment"
+                """
+            )
+
+    for key, value in d.items():
+        if isinstance(value, dict):
+            deep_traverse_and_replace_with_var_content(value)
+        elif isinstance(value, list):
+            for i, item in enumerate(value):
+                if isinstance(item, dict):
+                    value[i] = deep_traverse_and_replace_with_var_content(item)
+
+    return d

--- a/scanners/generic/generic.py
+++ b/scanners/generic/generic.py
@@ -5,6 +5,7 @@ import shutil
 
 import dacite
 
+from configmodel import deep_traverse_and_replace_with_var_content
 from configmodel.models.general import ContainerType
 from configmodel.models.scanners.generic import GenericConfig
 from scanners import RapidastScanner
@@ -55,8 +56,8 @@ class Generic(RapidastScanner):
                 ContainerType: ContainerType
             },
         )
-
-        self.cfg = dacite.from_dict(data_class=GenericConfig, data=generic_config_section, config=dacite_config)
+        processed_data = deep_traverse_and_replace_with_var_content(generic_config_section)
+        self.cfg = dacite.from_dict(data_class=GenericConfig, data=processed_data, config=dacite_config)
 
     ###############################################################
     # PUBLIC METHODS                                              #

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import dacite
 import yaml
 
+from configmodel import deep_traverse_and_replace_with_var_content
 from configmodel.models.scanners.zap import ImportUrlsFromFileType
 from configmodel.models.scanners.zap import ZapConfig
 from scanners import RapidastScanner
@@ -77,8 +78,8 @@ class Zap(RapidastScanner):
                 ImportUrlsFromFileType: ImportUrlsFromFileType,
             }
         )
-
-        self.cfg = dacite.from_dict(data_class=ZapConfig, data=zap_config_section, config=dacite_config)
+        processed_data = deep_traverse_and_replace_with_var_content(zap_config_section)
+        self.cfg = dacite.from_dict(data_class=ZapConfig, data=processed_data, config=dacite_config)
 
     ###############################################################
     # PUBLIC METHODS                                              #

--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -649,35 +649,16 @@ class Zap(RapidastScanner):
     def _setup_replacer(self):
         """Adds the replacer to the job list"""
 
-        def _validate_rule_boolean_values(rule):
-            if not isinstance(rule["matchRegex"], bool):
-                raise ValueError("The matchRegex in the replacer rule must be set to a Boolean value")
-
-            if "tokenProcessing" in rule and not isinstance(rule["tokenProcessing"], bool):
-                raise ValueError("The tokenProcessing in the replacer rule must be set to a Boolean value")
-
-        if not self.my_conf("replacer"):
+        if not self.cfg.replacer:
             return
 
-        rules = self.my_conf("replacer.rules")
-        if rules:
-            if not isinstance(rules, list):
-                raise ValueError("replacer.rules must be a list")
-
-            for item in rules:
-                _validate_rule_boolean_values(item)
-        else:
-            raise ValueError("replacer must have a rule at least")
-
-        delete_all_rules = self.my_conf("replacer.parameters.deleteAllRules", default=True)
+        rules = self.cfg.replacer.to_rules_dict_list()
 
         # replacer schema
         replacer = {
             "name": "replacer",
             "type": "replacer",
-            "parameters": {
-                "deleteAllRules": delete_all_rules,
-            },
+            "parameters": {"deleteAllRules": self.cfg.replacer.parameters.deleteAllRules},
             "rules": rules,
         }
 

--- a/tests/configmodel/models/test_generic_scanner.py
+++ b/tests/configmodel/models/test_generic_scanner.py
@@ -1,6 +1,5 @@
 import logging
 
-from configmodel.models.general import ContainerType
 from configmodel.models.scanners.generic import GenericConfig
 from configmodel.models.scanners.generic import GenericContainer
 from configmodel.models.scanners.generic import GenericContainerParameters

--- a/tests/configmodel/models/test_zap_scanner.py
+++ b/tests/configmodel/models/test_zap_scanner.py
@@ -37,9 +37,9 @@ class TestZapReplacer:
     def test_to_rules_dict_list_excludes_none(self):
         data = {
             "rules": [
-                {"description": "rule1", "matchRegex": True, "tokenProcessing": False},
-                {"description": "rule2", "tokenProcessing": True},
-                {"description": "rule3", "matchRegex": False},
+                {"matchRegex": True, "tokenProcessing": False},
+                {"tokenProcessing": True},
+                {"matchRegex": False},
             ]
         }
         instance = from_dict(data_class=ZapReplacer, data=data, config=DACITE_TEST_CONFIG)

--- a/tests/configmodel/models/test_zap_scanner.py
+++ b/tests/configmodel/models/test_zap_scanner.py
@@ -1,0 +1,62 @@
+import pytest
+from dacite import from_dict, Config, WrongTypeError
+from configmodel.models.scanners.zap import ReplacerParameters, ZapReplacer
+
+DACITE_TEST_CONFIG = Config(
+    check_types=True,
+    strict=True
+)
+
+class TestReplacerParameters:
+
+    def test_default_delete_all_rules(self):
+        """
+        Test that deleteAllRules defaults to True when not provided in the input data
+        """
+        data = {}
+        instance = from_dict(data_class=ReplacerParameters, data=data, config=DACITE_TEST_CONFIG)
+        assert instance.deleteAllRules is True
+
+    def test_invalid_type_for_delete_all_rules_raises_error(self):
+        invalid_data_str = {"deleteAllRules": "not_a_boolean"}
+        with pytest.raises(WrongTypeError):
+            from_dict(data_class=ReplacerParameters, data=invalid_data_str, config=DACITE_TEST_CONFIG)
+
+class TestZapReplacer:
+
+    def test_empty_rules_raises_value_error(self):
+        data = {"rules": []}
+        with pytest.raises(ValueError):
+            from_dict(data_class=ZapReplacer, data=data, config=DACITE_TEST_CONFIG)
+
+        data = {}
+        with pytest.raises(ValueError):
+            from_dict(data_class=ZapReplacer, data=data, config=DACITE_TEST_CONFIG)
+
+    def test_to_rules_dict_list_excludes_none(self):
+        data = {
+            "rules": [
+                {"description": "rule1", "matchRegex": True, "tokenProcessing": False},
+                {"description": "rule2", "tokenProcessing": True},
+                {"description": "rule3", "matchRegex": False}
+            ]
+        }
+        instance = from_dict(data_class=ZapReplacer, data=data, config=DACITE_TEST_CONFIG)
+
+        rules_as_dicts = instance.to_rules_dict_list()
+
+        assert isinstance(rules_as_dicts, list)
+        assert len(rules_as_dicts) == 3
+
+        assert isinstance(rules_as_dicts[0], dict)
+        assert rules_as_dicts[0] == {'matchRegex': True, 'tokenProcessing': False}
+
+        assert isinstance(rules_as_dicts[1], dict)
+        assert 'matchRegex' not in rules_as_dicts[1]
+        assert rules_as_dicts[1]['tokenProcessing'] is True
+        assert rules_as_dicts[1] == {'tokenProcessing': True}
+
+        assert isinstance(rules_as_dicts[2], dict)
+        assert rules_as_dicts[2]['matchRegex'] is False
+        assert 'tokenProcessing' not in rules_as_dicts[2]
+        assert rules_as_dicts[2] == {'matchRegex': False}

--- a/tests/configmodel/models/test_zap_scanner.py
+++ b/tests/configmodel/models/test_zap_scanner.py
@@ -1,14 +1,15 @@
 import pytest
-from dacite import from_dict, Config, WrongTypeError
-from configmodel.models.scanners.zap import ReplacerParameters, ZapReplacer
+from dacite import Config
+from dacite import from_dict
+from dacite import WrongTypeError
 
-DACITE_TEST_CONFIG = Config(
-    check_types=True,
-    strict=True
-)
+from configmodel.models.scanners.zap import ReplacerParameters
+from configmodel.models.scanners.zap import ZapReplacer
+
+DACITE_TEST_CONFIG = Config(check_types=True, strict=True)
+
 
 class TestReplacerParameters:
-
     def test_default_delete_all_rules(self):
         """
         Test that deleteAllRules defaults to True when not provided in the input data
@@ -22,8 +23,8 @@ class TestReplacerParameters:
         with pytest.raises(WrongTypeError):
             from_dict(data_class=ReplacerParameters, data=invalid_data_str, config=DACITE_TEST_CONFIG)
 
-class TestZapReplacer:
 
+class TestZapReplacer:
     def test_empty_rules_raises_value_error(self):
         data = {"rules": []}
         with pytest.raises(ValueError):
@@ -38,7 +39,7 @@ class TestZapReplacer:
             "rules": [
                 {"description": "rule1", "matchRegex": True, "tokenProcessing": False},
                 {"description": "rule2", "tokenProcessing": True},
-                {"description": "rule3", "matchRegex": False}
+                {"description": "rule3", "matchRegex": False},
             ]
         }
         instance = from_dict(data_class=ZapReplacer, data=data, config=DACITE_TEST_CONFIG)
@@ -49,14 +50,14 @@ class TestZapReplacer:
         assert len(rules_as_dicts) == 3
 
         assert isinstance(rules_as_dicts[0], dict)
-        assert rules_as_dicts[0] == {'matchRegex': True, 'tokenProcessing': False}
+        assert rules_as_dicts[0] == {"matchRegex": True, "tokenProcessing": False}
 
         assert isinstance(rules_as_dicts[1], dict)
-        assert 'matchRegex' not in rules_as_dicts[1]
-        assert rules_as_dicts[1]['tokenProcessing'] is True
-        assert rules_as_dicts[1] == {'tokenProcessing': True}
+        assert "matchRegex" not in rules_as_dicts[1]
+        assert rules_as_dicts[1]["tokenProcessing"] is True
+        assert rules_as_dicts[1] == {"tokenProcessing": True}
 
         assert isinstance(rules_as_dicts[2], dict)
-        assert rules_as_dicts[2]['matchRegex'] is False
-        assert 'tokenProcessing' not in rules_as_dicts[2]
-        assert rules_as_dicts[2] == {'matchRegex': False}
+        assert rules_as_dicts[2]["matchRegex"] is False
+        assert "tokenProcessing" not in rules_as_dicts[2]
+        assert rules_as_dicts[2] == {"matchRegex": False}

--- a/tests/configmodel/test_deep_tranverse_and_replace.py
+++ b/tests/configmodel/test_deep_tranverse_and_replace.py
@@ -55,12 +55,8 @@ class TestDeepTraverseAndReplace(unittest.TestCase):
 
     @patch.dict(os.environ, {"TEST_VAR": "value_from_env"})
     def test_original_value_prevents_overwrite(self):
-
         original_value = "existing_truthy_value"
-        input_dict = {
-            "myKey": original_value,
-            "myKey_from_var": "TEST_VAR"
-        }
+        input_dict = {"myKey": original_value, "myKey_from_var": "TEST_VAR"}
 
         result = deep_traverse_and_replace_with_var_content(input_dict)
 
@@ -83,9 +79,7 @@ class TestDeepTraverseAndReplace(unittest.TestCase):
         Verifies that if `new_key` is missing AND the environment variable is not found,
         the KeyError is caught (allowing pass), and then the logging.error is triggered.
         """
-        data = {
-            "non_existent_key_from_var": "NON_EXISTENT_ENV_VAR"
-        }
+        data = {"non_existent_key_from_var": "NON_EXISTENT_ENV_VAR"}
 
         result = deep_traverse_and_replace_with_var_content(data)
 

--- a/tests/scanners/zap/test_setup.py
+++ b/tests/scanners/zap/test_setup.py
@@ -300,15 +300,6 @@ def test_setup_include_urls(test_config):
     assert "def" in find_context(test_zap.automation_config)["includePaths"]
 
 
-def test_setup_replacer_no_rule(test_config):
-    test_config.set("scanners.zap.replacer.parameters.deleteAllRules", False)
-    test_zap = ZapNone(config=test_config)
-
-    # test: not having a rule raises ValueError
-    with pytest.raises(ValueError):
-        test_zap.setup()
-
-
 def test_setup_replacer_parameter(test_config):
     test_rule = {
         "description": "test_rule1",  # String, the name of the rule
@@ -372,11 +363,11 @@ def test_setup_replacer_rules(test_config):
 
     for item in test_zap.automation_config["jobs"]:
         if item["type"] == "replacer":
-            assert item["rules"][0] is test_rule1
+            assert item["rules"][0] == test_rule1
             assert isinstance(item["rules"][0]["matchRegex"], bool)
             assert isinstance(item["rules"][0]["tokenProcessing"], bool)
 
-            assert item["rules"][1] is test_rule2
+            assert item["rules"][1] == test_rule2
             assert isinstance(item["rules"][1]["matchRegex"], bool)
 
 


### PR DESCRIPTION
This PR introduces two improvements to configuration handling using dacite:

1. Configuration values (_from_var) are now resolved from environment variables before being passed to dacite for parsing. This ensures we validate the actual values rather than just references to environment variables. This behavior is currently enabled only for the Zap and Generic scanners, as the other scanners do not support the my_conf-based approach required for this replacement

2. The my_conf-based configuration in `zap.replacer` has been replaced with a dataclass implementation. A follow-up PRs will be submitted to migrate other remaining configurations to use dataclasses as well. Some of these changes are non-trivial, so they are being split out to avoid overloading this PR


