### PR TITLE
feat(config): Migrate ZAP miscOptions to use dataclasses

### DIFF
--- a/configmodel/models/scanners/zap.py
+++ b/configmodel/models/scanners/zap.py
@@ -118,7 +118,7 @@ class ZapMiscOptions:
     overrideConfigs: Optional[List[str]] = field(default_factory=list)
     memMaxHeap: Optional[str] = None
     updateAddons: Optional[bool] = None
-    additionalAddons: Optional[str] = None
+    additionalAddons: Optional[Union[str, List[str]]] = field(default_factory=list)
 
 
 @dataclass

--- a/tests/scanners/zap/test_setup_podman.py
+++ b/tests/scanners/zap/test_setup_podman.py
@@ -199,3 +199,15 @@ def test_podman_handling_plugins(test_config):
         "pluginB",
     ]
     assert shell == assert_shell
+
+    # additionalAddons As list
+    test_config.set("scanners.zap.miscOptions.additionalAddons", ["pluginA", "pluginB"])
+    test_zap = ZapPodman(config=test_config)
+    assert "pluginA" in test_zap.get_update_command()
+    assert "pluginB" in test_zap.get_update_command()
+
+    # no additionalAddons
+    test_config.delete("scanners.zap.miscOptions.additionalAddons")
+    test_zap = ZapPodman(config=test_config)
+    print(test_zap.get_update_command())
+    assert "-addoninstall" not in test_zap.get_update_command()


### PR DESCRIPTION
Migrates the ZAP `miscOptions` configuration from the old `my_conf` approach to the dataclass implementation