### PR TITLE
set rebuild=true in konflux pipelines

### DIFF
--- a/.tekton/rapidast-llm-pull-request.yaml
+++ b/.tekton/rapidast-llm-pull-request.yaml
@@ -31,6 +31,8 @@ spec:
     value: containerize/Containerfile.garak
   - name: skip-checks
     value: "true"
+  - name: rebuild
+    value: "true"
   - name: build-args
     value:
     - PREFETCH=false

--- a/.tekton/rapidast-llm-push.yaml
+++ b/.tekton/rapidast-llm-push.yaml
@@ -27,6 +27,8 @@ spec:
     value: quay.io/redhatproductsecurity/rapidast-llm:{{revision}}
   - name: dockerfile
     value: containerize/Containerfile.garak
+  - name: rebuild
+    value: "true"
   - name: build-args
     value:
     - PREFETCH=false

--- a/.tekton/rapidast-pull-request.yaml
+++ b/.tekton/rapidast-pull-request.yaml
@@ -30,6 +30,8 @@ spec:
     value: containerize/Containerfile
   - name: skip-checks
     value: "true"
+  - name: rebuild
+    value: "true"
   - name: prefetch-input
     value:
     - {"type": "generic", "path": "."}

--- a/.tekton/rapidast-push.yaml
+++ b/.tekton/rapidast-push.yaml
@@ -25,6 +25,8 @@ spec:
     value: quay.io/redhatproductsecurity/rapidast:{{revision}}
   - name: dockerfile
     value: containerize/Containerfile
+  - name: rebuild
+    value: "true"
   - name: prefetch-input
     value:
     - {"type": "generic", "path": "."}


### PR DESCRIPTION
Even though rebuild=false is in principle a nice idea to save pipeline time, in practice it doesn't work well because it skips snapshot creation, and therefore all integration tests fail. For now let's set this to true so our tests can pass.

Longer term there might be a solution in KONFLUX-6121