### PR TITLE
feat(e2e): Add ZAP URL exclusion validation test

### DIFF
--- a/config/config-template-zap-long.yaml
+++ b/config/config-template-zap-long.yaml
@@ -193,7 +193,10 @@ scanners:
     urls:
       # Optional, `includes` and `excludes` take a list of regexps.
       # includes: A URL matching that regexp will be in the scope of scanning, in addition to application.url which is already in scope
-      # excludes: A URL matching that regexp will NOT be in the scope of scanning
+      # excludes: A URL matching that regexp will NOT be in the scope of scanning.
+      #           ZAP might still contact those URLs in some cases, for example, when importing OpenAPI specs,
+      #           it requests all endpoints to build the site map and to discover the endpoints, even if those URLs are excluded from scanning.
+      #           So, while excluded URLs won’t be included in the final site map for scanning, they may still receive an initial connection
       # Note: The regular expressions MUST match the whole URL.
       #       e.g.: 'http://example.com/do-not-descend-here/' will actually descend
 

--- a/e2e-tests/conftest.py
+++ b/e2e-tests/conftest.py
@@ -225,7 +225,10 @@ class TestBase:
 
     def replace_from_yaml(self, path: str):
         self._teardowns.append(partial(os.system, f"kubectl delete -f {path} -n {NAMESPACE} --ignore-not-found"))
-        os.system(f"kubectl replace -f {path} -n {NAMESPACE}")
+        # We need to delete the existing resource and create a new one instead of replacing it,
+        # because some resources, like pods, cannot be updated in place in Openshift due to SCC
+        os.system(f"kubectl delete -f {path} -n {NAMESPACE} --ignore-not-found")
+        os.system(f"kubectl apply -f {path} -n {NAMESPACE}")
 
 
 @pytest.fixture

--- a/e2e-tests/conftest.py
+++ b/e2e-tests/conftest.py
@@ -219,9 +219,13 @@ class TestBase:
 
     def create_from_yaml(self, path: str):
         # delete resources in teardown method later
-        self._teardowns.append(partial(os.system, f"kubectl delete -f {path} -n {NAMESPACE}"))
+        self._teardowns.append(partial(os.system, f"kubectl delete -f {path} -n {NAMESPACE} --ignore-not-found"))
         o = utils.create_from_yaml(self.kclient, path, namespace=NAMESPACE, verbose=True)
         logging.debug(o)
+
+    def replace_from_yaml(self, path: str):
+        self._teardowns.append(partial(os.system, f"kubectl delete -f {path} -n {NAMESPACE} --ignore-not-found"))
+        os.system(f"kubectl replace -f {path} -n {NAMESPACE}")
 
 
 @pytest.fixture

--- a/e2e-tests/manifests/rapidast-vapi-configmap-urls-exclusions.yaml
+++ b/e2e-tests/manifests/rapidast-vapi-configmap-urls-exclusions.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+data:
+  config.yaml: |+
+    config:
+      configVersion: 5
+
+    # `application` contains data related to the application, not to the scans.
+    application:
+      shortName: "v5-none-release-test"
+      url: "http://vapi:5000"
+
+    scanners:
+      zap:
+      # define a scan through the ZAP scanner
+        apiScan:
+          apis:
+            apiUrl: "http://vapi:5000/docs/openapi.json"
+
+        passiveScan:
+          # optional list of passive rules to disable
+          disabledRules: "2,10015,10027,10096,10024,10098,10023,10105"
+
+        activeScan:
+          policy: API-scan-minimal
+
+        container:
+          parameters:
+            executable: "zap.sh"
+
+        spiderAjax:
+          maxDuration: 1
+          url: "http://vapi:3000"
+          maxCrawlDepth: 1
+
+        miscOptions:
+          # enableUI (default: false), requires a compatible runtime (e.g.: flatpak or no containment)
+          #enableUI: True
+          # Defaults to False, set True to force auto update of ZAP plugins
+          updateAddons: False
+          # additionalAddons: ascanrulesBeta
+          # If set to True and authentication is oauth2_rtoken and api.apiUrl is set, download the API outside of ZAP
+          oauth2OpenapiManualDownload: False
+
+        urls:
+          excludes:
+          - "http://vapi:5000/api/pets/id/.*"
+          - "http://vapi:3000/_next/static/css/.*.css"
+
+kind: ConfigMap
+metadata:
+  name: rapidast-vapi

--- a/e2e-tests/manifests/rapidast-vapi-configmap-urls-exclusions.yaml
+++ b/e2e-tests/manifests/rapidast-vapi-configmap-urls-exclusions.yaml
@@ -11,7 +11,6 @@ data:
 
     scanners:
       zap:
-      # define a scan through the ZAP scanner
         apiScan:
           apis:
             apiUrl: "http://vapi:5000/docs/openapi.json"
@@ -23,23 +22,13 @@ data:
         activeScan:
           policy: API-scan-minimal
 
-        container:
-          parameters:
-            executable: "zap.sh"
-
         spiderAjax:
           maxDuration: 1
           url: "http://vapi:3000"
           maxCrawlDepth: 1
 
         miscOptions:
-          # enableUI (default: false), requires a compatible runtime (e.g.: flatpak or no containment)
-          #enableUI: True
-          # Defaults to False, set True to force auto update of ZAP plugins
           updateAddons: False
-          # additionalAddons: ascanrulesBeta
-          # If set to True and authentication is oauth2_rtoken and api.apiUrl is set, download the API outside of ZAP
-          oauth2OpenapiManualDownload: False
 
         urls:
           excludes:

--- a/e2e-tests/test_integration.py
+++ b/e2e-tests/test_integration.py
@@ -60,6 +60,7 @@ class TestRapiDAST(TestBase):
             field_selector="metadata.name=rapidast-vapi", timeout=360  # llm-based image takes really long to download
         )
 
+        tee_log("rapidast-vapi", results, container="results")
         with open(results, "r", encoding="utf-8") as f:
             data = json.load(f)
 

--- a/e2e-tests/test_integration.py
+++ b/e2e-tests/test_integration.py
@@ -60,6 +60,7 @@ class TestRapiDAST(TestBase):
             field_selector="metadata.name=rapidast-vapi", timeout=360  # llm-based image takes really long to download
         )
 
+        results = os.path.join(self.tempdir, "rapidast-vapi-excluded-urls-results.json")
         tee_log("rapidast-vapi", results, container="results")
         with open(results, "r", encoding="utf-8") as f:
             data = json.load(f)

--- a/e2e-tests/test_integration.py
+++ b/e2e-tests/test_integration.py
@@ -54,8 +54,8 @@ class TestRapiDAST(TestBase):
         assert url_count > 1, f"{logfile} indicates only {url_count} URL(s) found, expected more than 1"
 
         # Verify that ZAP report does not contain alerts for URLs excluded in the scan configuration
-        self.create_from_yaml(f"{self.tempdir}/rapidast-vapi-configmap-urls-exclusions.yaml")
-        self.create_from_yaml(f"{self.tempdir}/rapidast-vapi-pod.yaml")
+        self.replace_from_yaml(f"{self.tempdir}/rapidast-vapi-configmap-urls-exclusions.yaml")
+        self.replace_from_yaml(f"{self.tempdir}/rapidast-vapi-pod.yaml")
         assert is_pod_with_field_selector_successfully_completed(
             field_selector="metadata.name=rapidast-vapi", timeout=360  # llm-based image takes really long to download
         )

--- a/e2e-tests/test_integration.py
+++ b/e2e-tests/test_integration.py
@@ -35,9 +35,10 @@ class TestRapiDAST(TestBase):
         with open(logfile, "r", encoding="utf-8") as f:
             logs = f.read()
 
-        # Verify that URLs intended for exclusion in subsequent tests are present in the report
-        # if they are not excluded (defined in rapidast-vapi-configmap-urls-exclusions.yaml)
-        excluded_urls = ["http://vapi:5000/api/pets/id/.*", "http://vapi:3000/_next/static/css/*.css"]
+        # Verify that URLs listed for exclusion in subsequent tests are present in the report.
+        # This list should be kept in sync with the configuration scanners.zap.urls.excludes in
+        # manifests/rapidast-vapi-configmap-urls-exclusions.yaml
+        excluded_urls = ["http://vapi:5000/api/pets/id/.*", "http://vapi:3000/_next/static/css/.*.css"]
 
         excluded = verify_zap_report_urls_exclusions(data, excluded_urls)
 
@@ -52,8 +53,7 @@ class TestRapiDAST(TestBase):
         url_count = int(match.group(1))
         assert url_count > 1, f"{logfile} indicates only {url_count} URL(s) found, expected more than 1"
 
-        # This step validates that the ZAP report does not contain alerts
-        # for URLs that should have been excluded in the scan configuration.
+        # Verify that ZAP report does not contain alerts for URLs excluded in the scan configuration
         self.create_from_yaml(f"{self.tempdir}/rapidast-vapi-configmap-urls-exclusions.yaml")
         self.create_from_yaml(f"{self.tempdir}/rapidast-vapi-pod.yaml")
         assert is_pod_with_field_selector_successfully_completed(

--- a/e2e-tests/test_integration.py
+++ b/e2e-tests/test_integration.py
@@ -35,6 +35,14 @@ class TestRapiDAST(TestBase):
         with open(logfile, "r", encoding="utf-8") as f:
             logs = f.read()
 
+        # Verify that URLs intended for exclusion in subsequent tests are present in the report
+        # if they are not excluded (defined in rapidast-vapi-configmap-urls-exclusions.yaml)
+        excluded_urls = ["http://vapi:5000/api/pets/id/.*", "http://vapi:3000/_next/static/css/*.css"]
+
+        excluded = verify_zap_report_urls_exclusions(data, excluded_urls)
+
+        assert all(info["found"] for info in excluded.values())
+
         # Verify that the spiderAjax job is functioning correctly
         # @TODO: Consider implementing this using ZAP's built-in monitor test framework
         #        https://www.zaproxy.org/docs/desktop/addons/automation-framework/test-monitor/
@@ -43,6 +51,21 @@ class TestRapiDAST(TestBase):
         assert match is not None, f"{logfile} does not contain a line matching 'Job spiderAjax found X URLs'"
         url_count = int(match.group(1))
         assert url_count > 1, f"{logfile} indicates only {url_count} URL(s) found, expected more than 1"
+
+        # This step validates that the ZAP report does not contain alerts
+        # for URLs that should have been excluded in the scan configuration.
+        self.create_from_yaml(f"{self.tempdir}/rapidast-vapi-configmap-urls-exclusions.yaml")
+        self.create_from_yaml(f"{self.tempdir}/rapidast-vapi-pod.yaml")
+        assert is_pod_with_field_selector_successfully_completed(
+            field_selector="metadata.name=rapidast-vapi", timeout=360  # llm-based image takes really long to download
+        )
+
+        with open(results, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        excluded = verify_zap_report_urls_exclusions(data, excluded_urls)
+
+        assert all(not info["found"] for info in excluded.values())
 
     def test_trivy(self):
         self.create_from_yaml(f"{self.tempdir}/rapidast-trivy-configmap.yaml")
@@ -77,3 +100,38 @@ class TestRapiDAST(TestBase):
         with open(logfile, "r", encoding="utf-8") as f:
             logs = f.read()
             assert expected_line in logs, f"{logfile} does not contain expected line: {expected_line}"
+
+
+def verify_zap_report_urls_exclusions(report_data: dict, excluded_urls: list[str]) -> dict:
+    """
+    Checks if any alert instance URIs from a ZAP report contain any of the specified
+    excluded URL patterns
+    """
+
+    def _get_all_instance_uris(report_data: dict) -> list[str]:
+        """
+        Helper function to extract all unique URIs from alert instances in the ZAP report
+        """
+        uris = set()
+        if "site" not in report_data or not isinstance(report_data.get("site"), list):
+            assert False, "'site' key not found in the ZAP report. No alerts to check"
+
+        for site in report_data["site"]:  # pylint: disable=R1702 too-many-nested-blocks
+            if "alerts" in site and isinstance(site.get("alerts"), list):
+                for alert in site["alerts"]:
+                    if "instances" in alert and isinstance(alert.get("instances"), list):
+                        for instance in alert["instances"]:
+                            if "uri" in instance:
+                                uris.add(instance["uri"])
+        return list(uris)
+
+    compiled_patterns = [(re.compile(pattern), pattern) for pattern in excluded_urls]
+    results = {pattern: {"found": False} for pattern in excluded_urls}
+
+    all_report_uris = _get_all_instance_uris(report_data)
+
+    for uri in all_report_uris:
+        for compiled_regex, original_pattern_str in compiled_patterns:
+            if compiled_regex.search(uri):
+                results[original_pattern_str]["found"] = True
+    return results


### PR DESCRIPTION
Adds an e2e test to confirm that ZAP's URL exclusion rules are correctly preventing unwanted URLs from appearing in scan reports

Related to: https://github.com/RedHatProductSecurity/rapidast/issues/377 