### PR TITLE
document requirement of python>=3.9

### DIFF
--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -44,7 +44,7 @@ Install dependencies and run RapiDAST directly on a host machine. Unless using t
 
 **Prerequisites**:
 
-- `python` >= 3.6.8 (3.7 for MacOS/Darwin)
+- `python` >= 3.9
 - `podman` >= 3.0.1
   - required when you want to run scanners from their container images, rather than installing them to your host.
 - See `requirements.txt` for a list of required python libraries

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ requires = [
 [project]
 name = "rapidast"
 dynamic = ["dependencies", "version"]
+requires-python = ">= 3.9"
 
 [tool.setuptools]
 packages = ["configmodel", "exports", "utils", "scanners"]


### PR DESCRIPTION
This PR documents the requirement for python >= 3.9
It was previously 3.6, but this is no longer sufficient.