### PR TITLE
feat: Update ZAP to 2.16.1 and enhance dependency update docs

### DIFF
--- a/artifacts.lock.yaml
+++ b/artifacts.lock.yaml
@@ -1,9 +1,9 @@
 metadata:
   version: "1.0"
 artifacts:
-  - download_url: https://github.com/zaproxy/zaproxy/releases/download/v2.15.0/ZAP_2.15.0_Linux.tar.gz
+  - download_url: https://github.com/zaproxy/zaproxy/releases/download/v2.16.1/ZAP_2.16.1_Linux.tar.gz
     filename: ZAP.tar.gz
-    checksum: "sha256:6410e196baab458a9204e29aafb5745fca003a2a6c0386f2c6e5c04b67621fa7"
+    checksum: "sha256:5b2eb8319b085121a6e8ad50d69d67dbef8c867166f71a937bfc888d247a2ac1"
   - download_url: https://releases.mozilla.org/pub/firefox/releases/128.6.0esr/linux-x86_64/en-US/firefox-128.6.0esr.tar.bz2
     filename: firefox.tar.bz2
     checksum: "sha256:ab46e298a92276736e1a0b2f2fe232f4b1e9f49c84bdb6fc2565d83013bc8732"

--- a/containerize/Containerfile
+++ b/containerize/Containerfile
@@ -9,7 +9,8 @@ FROM registry.access.redhat.com/ubi9-minimal AS deps
 # They must be located at /cachi2/output/deps
 ARG PREFETCH=false
 
-# These versions should be consistent with the listed in the artifacts.lock.yaml file
+# IMPORTANT: Ensure these versions are synchronized with 'artifacts.lock.yaml'
+# Refer to the docs/DEVELOPER_GUIDE.md, "Updating Static Dependency Versions" for details
 ARG ZAP_VERSION=2.16.1
 ARG FF_VERSION=128.6.0esr
 ARG K8S_VERSION=1.32.1
@@ -56,6 +57,23 @@ RUN mkdir -p /tmp/redocly/node_modules && if [ "$PREFETCH" == "true" ]; then \
   else \
     npm install --prefix /tmp/redocly; \
   fi
+
+### Validate installed dependency versions. This is crucial when dependencies are prefetched using Cachi2
+RUN echo "Validating ZAP version..." && \
+    /opt/zap/zap.sh -cmd -nostdout -silent -version | grep "${ZAP_VERSION}" || (echo "ZAP version mismatch!" && exit 1) && \
+    echo "ZAP version validated: ${ZAP_VERSION}"
+
+RUN echo "Validating Firefox version..." && \
+    /opt/firefox/firefox -version | grep "${FF_VERSION}" || (echo "Firefox version mismatch!" && exit 1) && \
+    echo "Firefox version validated: ${FF_VERSION}"
+
+RUN echo "Validating kubectl version..." && \
+    /usr/local/bin/kubectl version --client | grep "${K8S_VERSION}" || (echo "kubectl version mismatch!" && exit 1) && \
+    echo "kubectl version validated: ${K8S_VERSION}"
+
+RUN echo "Validating Trivy version..." && \
+    /tmp/trivy/trivy version | grep "${TRIVY_VERSION}" || (echo "Trivy version mismatch!" && exit 1) && \
+    echo "Trivy version validated: ${TRIVY_VERSION}"
 
 # Copy artifacts from deps to build RapiDAST
 FROM registry.access.redhat.com/ubi9-minimal

--- a/containerize/Containerfile.garak
+++ b/containerize/Containerfile.garak
@@ -9,7 +9,8 @@ FROM registry.access.redhat.com/ubi9-minimal AS deps
 # They must be located at /cachi2/output/deps
 ARG PREFETCH=false
 
-# These versions should be consistent with the listed in the artifacts.lock.yaml file
+# IMPORTANT: Ensure these versions are synchronized with 'artifacts.lock.yaml'
+# Refer to the docs/DEVELOPER_GUIDE.md, "Updating Static Dependency Versions" for details
 ARG ZAP_VERSION=2.16.1
 ARG FF_VERSION=128.6.0esr
 ARG K8S_VERSION=1.32.1
@@ -56,6 +57,23 @@ RUN mkdir -p /tmp/redocly/node_modules && if [ "$PREFETCH" == "true" ]; then \
   else \
     npm install --prefix /tmp/redocly; \
   fi
+
+### Validate installed dependency versions. This is crucial when dependencies are prefetched using Cachi2
+RUN echo "Validating ZAP version..." && \
+    /opt/zap/zap.sh -cmd -nostdout -silent -version | grep "${ZAP_VERSION}" || (echo "ZAP version mismatch!" && exit 1) && \
+    echo "ZAP version validated: ${ZAP_VERSION}"
+
+RUN echo "Validating Firefox version..." && \
+    /opt/firefox/firefox -version | grep "${FF_VERSION}" || (echo "Firefox version mismatch!" && exit 1) && \
+    echo "Firefox version validated: ${FF_VERSION}"
+
+RUN echo "Validating kubectl version..." && \
+    /usr/local/bin/kubectl version --client | grep "${K8S_VERSION}" || (echo "kubectl version mismatch!" && exit 1) && \
+    echo "kubectl version validated: ${K8S_VERSION}"
+
+RUN echo "Validating Trivy version..." && \
+    /tmp/trivy/trivy version | grep "${TRIVY_VERSION}" || (echo "Trivy version mismatch!" && exit 1) && \
+    echo "Trivy version validated: ${TRIVY_VERSION}"
 
 # Copy artifacts from deps to build RapiDAST
 FROM registry.access.redhat.com/ubi9-minimal

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -194,6 +194,46 @@ RapiDAST, when loading the configuration from file, will update the schema, vers
 
 Note: it is possible for a converter function to warn the user, if necessary. As a last resort, if there is no conversion possible, it is also possible to output an error **BUT** the error should clearly express a methodology to manually update the configuration to the newest version
 
+## Updating Static Dependency Versions
+
+When updating a static dependency (like ZAP, Firefox, kubectl, or Trivy) used in RapiDAST, you need to update the version numbers in both the `Containerfile` and `Containerfile.garak`, as well as in the `artifacts.lock.yaml` file.
+
+**Steps to Update a Dependency:**
+
+1.  **Identify the New Version**: Determine the desired new version for the dependency you wish to update (e.g., ZAP `2.16.1`, Firefox `129.0esr`)
+
+2.  **Update the `Containerfile(s)`**:
+    * Open `Containerfile` and `Containerfile.garak`
+    * Locate the `ARG` declarations for the specific dependency you are updating. For example:
+        ```dockerfile
+        ARG ZAP_VERSION=2.15.0
+        ```
+    * Change the version number to the new desired version:
+        ```dockerfile
+        ARG ZAP_VERSION=2.16.1
+        ```
+    * Save the changes
+
+3.  **Update `artifacts.lock.yaml`**:
+    * Open `artifacts.lock.yaml`.
+    * Find the entry for the dependency you are updating
+    * **Update the `download_url`**: Modify the URL to reflect the new version number. For example, if updating ZAP, change:
+        ```yaml
+        download_url: https://github.com/zaproxy/zaproxy/releases/download/v2.15.0/ZAP_2.15.0_Linux.tar.gz
+        ```
+        to:
+        ```yaml
+        download_url: https://github.com/zaproxy/zaproxy/releases/download/v2.16.1/ZAP_2.16.1_Linux.tar.gz
+        ```
+    * **Update the `checksum` hash**:
+        * **How to get the SHA256**: Check the following pages:
+             1. For ZAP: https://github.com/zaproxy/zaproxy/releases/tag/v${ZAP_VERSION}
+             2. For firefox: https://releases.mozilla.org/pub/firefox/releases/${FF_VERSION}$/SHA256SUMS
+             3. For kubectl: https://dl.k8s.io/release/${K8S_VERSION}/bin/linux/amd64/kubectl.sha256
+             4. For trivy: https://github.com/zaproxy/zaproxy/releases/tag/v${TRIVY_VERSION}
+
+    * Save the changes to `artifacts.lock.yaml`
+
 ## Python Requirements Management
 
 This project uses `pip-compile` from `pip-tools` to manage dependencies.


### PR DESCRIPTION
Updates ZAP_VERSION to 2.16.1 in artifacts.lock.yaml Adds documentation to README.md for updating static dependencies, including synchronization with artifacts.lock.yaml.