### PR TITLE
Add tests to verify ZAP scan policy and expected alert references

### DIFF
--- a/e2e-tests/manifests/rapidast-vapi-configmap.yaml
+++ b/e2e-tests/manifests/rapidast-vapi-configmap.yaml
@@ -41,6 +41,13 @@ data:
           # If set to True and authentication is oauth2_rtoken and api.apiUrl is set, download the API outside of ZAP
           oauth2OpenapiManualDownload: False
 
+          # Configure the form handler to manage and submit forms
+          overrideConfigs:
+            - formhandler.fields.field(0).fieldId=pet_id
+            - formhandler.fields.field(0).value=55
+            - formhandler.fields.field(0).fieldId=pet_name
+            - formhandler.fields.field(0).value=pet_aaaa
+
 kind: ConfigMap
 metadata:
   name: rapidast-vapi


### PR DESCRIPTION
These tests are performed manually when ZAP is updated. I've now automated them and integrated them into the existing VAPI test. I chose not to create a separate test for now, as doing so would require some redesign of the VAPI deployment process to avoid conflicts during parallel test execution. This solution should be sufficient for the time being, until we decide on a more robust approach