### PR TITLE
Add test to verify passive scan can be disabled and refactor log retrieval helper

### DIFF
--- a/e2e-tests/manifests/rapidast-vapi-configmap-no-passivescan.yaml
+++ b/e2e-tests/manifests/rapidast-vapi-configmap-no-passivescan.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+data:
+  config.yaml: |+
+    config:
+      configVersion: 5
+
+    # `application` contains data related to the application, not to the scans.
+    application:
+      shortName: "v5-none-release-test"
+      url: "http://vapi:5000"
+
+    scanners:
+      zap:
+        apiScan:
+          apis:
+            apiUrl: "http://vapi:5000/docs/openapi.json"
+
+        activeScan:
+          policy: API-scan-minimal
+
+        miscOptions:
+          updateAddons: False
+
+kind: ConfigMap
+metadata:
+  name: rapidast-vapi


### PR DESCRIPTION
- Implemented a e2e test to ensure passive scanning can be disabled (this test is performed manually when ZAP is updated)
- Introduced a helper for fetching logs from pod containers and refactored existing test code to use the new helper