### PR TITLE
feat(config): top-level RapiDAST configuration with typed dataclasses

### DIFF
--- a/config/schemas/6/rapidast_schema.json
+++ b/config/schemas/6/rapidast_schema.json
@@ -352,7 +352,7 @@
                                                 "volumes": {
                                                     "type": "array",
                                                     "items": {
-                                                        "type": "integer"
+                                                        "type": "string"
                                                     }
                                                 }
                                             },

--- a/configmodel/models/application.py
+++ b/configmodel/models/application.py
@@ -1,8 +1,9 @@
 # pylint: disable=C0103
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass
 class Application:
-    url: str
+    url: Optional[str] = None
     shortName: str = "scannedApp"

--- a/configmodel/models/application.py
+++ b/configmodel/models/application.py
@@ -1,0 +1,8 @@
+# pylint: disable=C0103
+from dataclasses import dataclass
+
+
+@dataclass
+class Application:
+    url: str
+    shortName: str = "scannedApp"

--- a/configmodel/models/config.py
+++ b/configmodel/models/config.py
@@ -29,6 +29,7 @@ class DefectDojo:
     authorization: Optional[DefectDojoAuthorization]
     ssl: bool = True
 
+
 @dataclass
 class Config:
     configVersion: int

--- a/configmodel/models/config.py
+++ b/configmodel/models/config.py
@@ -1,0 +1,40 @@
+# pylint: disable=C0103
+from dataclasses import dataclass
+from typing import Optional
+from typing import Union
+
+
+@dataclass
+class Environ:
+    envFile: str
+
+
+@dataclass
+class GoogleCloudStorage:
+    keyFile: Optional[str] = None
+    bucketName: str = ""
+    directory: Optional[str] = None
+
+
+@dataclass
+class DefectDojoAuthorization:
+    username: str
+    password: str
+    token: str
+
+
+@dataclass
+class DefectDojo:
+    url: str
+    authorization: Optional[DefectDojoAuthorization]
+    ssl: bool = True
+
+@dataclass
+class Config:
+    configVersion: int
+    base_results_dir: str = "./results"
+    tls_verify_for_rapidast_downloads: Union[bool, str] = True
+
+    environ: Optional[Environ] = None
+    googleCloudStorage: Optional[GoogleCloudStorage] = None
+    defectDojo: Optional[DefectDojo] = None

--- a/configmodel/models/general.py
+++ b/configmodel/models/general.py
@@ -1,6 +1,116 @@
+# pylint: disable=C0103
+from dataclasses import dataclass
+from dataclasses import field
 from enum import Enum
+from typing import Any
+from typing import Optional
+
+from dacite import from_dict
 
 
 class ContainerType(str, Enum):
     PODMAN = "podman"
     NONE = "none"
+
+
+class AuthenticationType(str, Enum):
+    OAUTH2_RTOKEN = "oauth2_rtoken"
+    HTTP_HEADER = "http_header"
+    HTTP_BASIC = "http_basic"
+    COOKIE = "cookie"
+    BROWSER = "browser"
+
+
+@dataclass
+class Proxy:
+    proxyHost: str
+    proxyPort: str
+
+
+@dataclass
+class OAuth2RTokenParameters:
+    client_id: str
+    token_endpoint: str
+    rtoken: str
+    preauth: Optional[bool] = None
+
+
+@dataclass
+class HttpHeaderParameters:
+    value: str
+    name: str = "Authorization"
+
+
+@dataclass
+class HttpBasicParameters:
+    username: str
+    password: str
+
+
+@dataclass
+class CookieParameters:
+    name: str
+    value: str
+
+
+@dataclass
+class BrowserParameters:
+    username: str
+    password: str
+    loginPageUrl: str
+    verifyUrl: str
+    loginPageWait: Optional[int] = None
+    loggedInRegex: Optional[str] = None
+    loggedOutRegex: Optional[str] = None
+
+
+auth_param_classes = {
+    "oauth2_rtoken": OAuth2RTokenParameters,
+    "http_header": HttpHeaderParameters,
+    "http_basic": HttpBasicParameters,
+    "cookie": CookieParameters,
+    "browser": BrowserParameters,
+}
+
+
+@dataclass
+class Authentication:
+    type: AuthenticationType
+    parameters: Any = field(repr=False)  # start as raw dict
+
+    def __post_init__(self):
+        param_cls = auth_param_classes.get(self.type)
+        if param_cls is None:
+            raise ValueError(f"Unknown authentication type: {self.type}")
+
+        if isinstance(self.parameters, dict):
+            self.parameters = from_dict(param_cls, self.parameters)
+        elif not isinstance(self.parameters, param_cls):
+            raise TypeError(f"parameters must be {param_cls} or dict, got {type(self.parameters)}")
+
+
+@dataclass
+class Container:
+    type: ContainerType = ContainerType.PODMAN
+
+
+@dataclass
+class DefectDojoExportParameters:
+    product_name: Optional[str] = None
+    engagement_name: Optional[str] = None
+    engagement: Optional[int] = None
+    test_title: Optional[str] = None
+    test: Optional[int] = None
+
+
+@dataclass
+class DefectDojoExport:
+    parameters: DefectDojoExportParameters
+
+
+@dataclass
+class General:
+    proxy: Optional[Proxy] = None
+    authentication: Optional[Authentication] = None
+    container: Optional[Container] = None
+    defectDojoExport: Optional[DefectDojoExport] = None

--- a/configmodel/models/root.py
+++ b/configmodel/models/root.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from configmodel.models.application import Application
+from configmodel.models.config import Config
+from configmodel.models.general import General
+
+
+@dataclass
+class Root:
+    config: Config
+    application: Application
+    general: Optional[General] = None
+
+
+# @TODO: We could add scanner configurations here as well.
+# However, this would require additional logic to dynamically validate dataclasses
+# based on scanner key names, which would complicate the validation process.
+# The current approach is simpler, as each scanner validates its own configuration internally upon loading.
+# scanners:

--- a/configmodel/models/scanners/generic.py
+++ b/configmodel/models/scanners/generic.py
@@ -5,7 +5,7 @@ from dataclasses import field
 from typing import List
 from typing import Optional
 
-from ..general import ContainerType
+from configmodel.models.general import ContainerType
 
 
 @dataclass

--- a/rapidast.py
+++ b/rapidast.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any
 from typing import Dict
 from typing import List
+from typing import Optional
 from urllib import request
 
 import dacite
@@ -27,6 +28,9 @@ import configmodel.converter
 import scanners
 from configmodel import deep_traverse_and_replace_with_var_content
 from configmodel.models.exclusions import Exclusions
+from configmodel.models.general import AuthenticationType
+from configmodel.models.general import ContainerType
+from configmodel.models.root import Root
 from exports.defect_dojo import DefectDojo
 from exports.google_cloud_storage import GoogleCloudStorage
 from utils import add_logging_level
@@ -294,7 +298,7 @@ def validate_config_schema(config_file) -> bool:
 
     try:
         config_version = str(config["config"]["configVersion"])
-    except KeyError:
+    except (KeyError, TypeError):
         logging.error("Missing 'configVersion' in configuration")
         return False
 
@@ -373,6 +377,12 @@ def run():
 
     # Do early: load the environment file if one is there
     load_environment(config)
+
+    root = parse_rapidast_config(config.conf)
+
+    if not root:
+        logging.error("RapiDAST config parsing failed")
+        sys.exit(1)
 
     # Check DefectDojo export configuration
     dedo_exporter = None
@@ -619,6 +629,31 @@ def generate_sarif_properties(
         "commit_sha": commit_sha,
     }
     return sarif_properties
+
+
+def parse_rapidast_config(config: dict) -> Optional[Root]:
+    root = None
+    processed_data = deep_traverse_and_replace_with_var_content(config)
+
+    dacite_config = dacite.Config(
+        # Set to False to ignore extra keys in the input data that don't match dataclass fields.
+        # This is enforced here for safety, since 'scanners' is not defined at the root level
+        # Each scanner handles its own configuration validation internally
+        strict=False,
+        type_hooks={
+            # Dacite doesn't natively support enums, so we use `type_hooks` as a workaround
+            # to properly resolve enum values
+            # https://github.com/konradhalas/dacite/issues/61
+            ContainerType: ContainerType,
+            AuthenticationType: AuthenticationType,
+        },
+    )
+    try:
+        root = dacite.from_dict(data_class=Root, data=processed_data, config=dacite_config)
+    except dacite.exceptions.DaciteError as e:
+        logging.error(f"Config parsing error: {e}")
+
+    return root
 
 
 if __name__ == "__main__":

--- a/tests/configmodel/models/test_general.py
+++ b/tests/configmodel/models/test_general.py
@@ -1,0 +1,116 @@
+import pytest
+from dacite import Config
+from dacite import from_dict
+
+from configmodel.models.general import Authentication
+from configmodel.models.general import AuthenticationType
+from configmodel.models.general import BrowserParameters
+from configmodel.models.general import CookieParameters
+from configmodel.models.general import HttpBasicParameters
+from configmodel.models.general import HttpHeaderParameters
+from configmodel.models.general import OAuth2RTokenParameters
+
+dacite_config = Config(
+    # strict=True,
+    type_hooks={
+        # Dacite doesn't natively support enums, so we use `type_hooks` as a workaround
+        # to properly resolve enum values
+        # https://github.com/konradhalas/dacite/issues/61
+        AuthenticationType: AuthenticationType
+    },
+)
+
+
+@pytest.mark.parametrize(
+    "cls, data",
+    [
+        (
+            OAuth2RTokenParameters,
+            {"client_id": "client", "token_endpoint": "https://token.url", "rtoken": "RTOKEN", "preauth": True},
+        ),
+        (HttpHeaderParameters, {"name": "Authorization", "value": "Bearer abc"}),
+        (HttpBasicParameters, {"username": "user", "password": "pass"}),
+        (CookieParameters, {"name": "session", "value": "abc123"}),
+        (
+            BrowserParameters,
+            {
+                "username": "user",
+                "password": "pass",
+                "loginPageUrl": "https://login.url",
+                "verifyUrl": "https://verify.url",
+                "loginPageWait": 2,
+                "loggedInRegex": "200 OK",
+                "loggedOutRegex": "403 Forbidden",
+            },
+        ),
+    ],
+)
+def test_auth_parameter_dataclasses(cls, data):
+    """
+    Validate that all supported parameter dataclasses correctly accept and store input values.
+    """
+    obj = from_dict(data_class=cls, data=data)
+    for k, v in data.items():
+        assert getattr(obj, k) == v
+
+
+@pytest.mark.parametrize(
+    "auth_type, params_class, params_dict",
+    [
+        (
+            "oauth2_rtoken",
+            OAuth2RTokenParameters,
+            {"client_id": "abc", "token_endpoint": "https://example.com/token", "rtoken": "RTOKEN", "preauth": False},
+        ),
+        ("http_header", HttpHeaderParameters, {"name": "Authorization", "value": "Bearer token"}),
+        ("http_basic", HttpBasicParameters, {"username": "admin", "password": "secret"}),
+        ("cookie", CookieParameters, {"name": "sessionid", "value": "xyz"}),
+        (
+            "browser",
+            BrowserParameters,
+            {
+                "username": "user",
+                "password": "pass",
+                "loginPageUrl": "https://login.page",
+                "verifyUrl": "https://verify.page",
+                "loginPageWait": 2,
+                "loggedInRegex": "200 OK",
+                "loggedOutRegex": "403 Forbidden",
+            },
+        ),
+    ],
+)
+def test_authentication_deserialization(auth_type, params_class, params_dict):
+    """
+    Test that Authentication parses its `parameters` field into the correct subclass
+    based on the declared `type`.
+    """
+    raw_data = {"type": auth_type, "parameters": params_dict}
+
+    auth = from_dict(data_class=Authentication, data=raw_data, config=dacite_config)
+    assert auth.type == auth_type
+    assert isinstance(auth.parameters, params_class)
+
+    for key, value in params_dict.items():
+        assert getattr(auth.parameters, key) == value
+
+
+def test_authentication_unknown_type_raises():
+    """
+    Ensure that if an unsupported authentication type is passed, a ValueError is raised.
+    """
+    raw_data = {"type": "invalid_auth_type", "parameters": {}}
+
+    with pytest.raises(ValueError):
+        from_dict(data_class=Authentication, data=raw_data, config=dacite_config)
+
+
+def test_authentication_wrong_parameters_type():
+    """
+    Ensure that a non-dict parameters input raises a TypeError
+    (since parameters must be a dictionary).
+    """
+    raw_data = {"type": "http_basic", "parameters": "this should be a dict"}
+
+    with pytest.raises(TypeError):
+        from_dict(data_class=Authentication, data=raw_data, config=dacite_config)


### PR DESCRIPTION
This PR introduces dataclasses for parsing and validating the RapiDAST YAML top-level configuration.

**Notes**: 
- This PR focuses primarily on parsing and validating the configuration. Existing usage of `config.get()` and `config.set()` for config access is still in place to avoid making this PR overly complex. Refactoring those will be addressed in a follow-up.
- The `scanners` configuration is not included in the top-level configuration schema. Supporting this would require additional logic to dynamically map scanner keys to their specific dataclass definitions. Instead, each scanner continues to validate its own configuration internally when loaded, keeping the validation logic simpler for now.

Related: https://github.com/RedHatProductSecurity/rapidast/pull/368