### PR TITLE
feat: Upgrade Python to 3.12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,17 +3,17 @@ repos:
     rev: v5.0.0
     hooks:
       - id: trailing-whitespace
-        language_version: python3
+        language_version: python3.12
         exclude: \.csv$
       - id: end-of-file-fixer
       - id: debug-statements
-        language_version: python3
+        language_version: python3.12
 
   - repo: https://github.com/asottile/reorder_python_imports
     rev: v3.15.0
     hooks:
       - id: reorder-python-imports
-        language_version: python3
+        language_version: python3.12
   - repo: https://github.com/psf/black
     rev: 25.1.0
     hooks:
@@ -23,14 +23,14 @@ repos:
         - --quiet
         - --line-length
         - "120" # same as pylint below
-        language_version: python3
+        language_version: python3.12
         require_serial: true
 
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.38.4
     hooks:
       - id: pyupgrade
-        language_version: python3
+        language_version: python3.12
 
   # E0401 - import errors (Used when pylint has been unable to import a module.)
   # C0411 - wrong-import-order, disabled because of conflicts with black
@@ -56,4 +56,4 @@ repos:
           - --min-public-methods=0
           - --good-names=o,w,q,f,fp,i,e
           - --disable=E0401,W1201,W1203,C0114,C0115,C0116,C0411,W0107,W0511,W0702,R0801,R1705,R1710,W0201
-        language_version: python3
+        language_version: python3.12

--- a/.tekton/integration-test-llm.yaml
+++ b/.tekton/integration-test-llm.yaml
@@ -117,6 +117,6 @@ spec:
               yum install -y python3.12 git
               python3.12 -m ensurepip
 
-              pip3 install -r requirements-dev.txt
+              python3.12 -m pip install -r requirements-dev.txt
               pytest -s e2e-tests/test_integration_llm.py --json-report --json-report-summary --json-report-file $(results.TEST_OUTPUT.path)
               cat $(results.TEST_OUTPUT.path)

--- a/.tekton/integration-test.yaml
+++ b/.tekton/integration-test.yaml
@@ -209,7 +209,7 @@ spec:
 
               source /workspace/.tekton/scripts/setup-cachi2-env.sh
 
-              pip3 install -r requirements-dev.txt
+              python3.12 -m pip install -r requirements-dev.txt
               pytest -s e2e-tests/test_integration.py --json-report --json-report-summary --json-report-file $(results.TEST_OUTPUT.path)
               cat $(results.TEST_OUTPUT.path)
 

--- a/containerize/Containerfile
+++ b/containerize/Containerfile
@@ -111,10 +111,10 @@ COPY ./containerize/container_default_config.yaml /opt/rapidast/rapidast-default
 COPY ./containerize/path_rapidast.sh /etc/profile.d/rapidast.sh
 
 ### Install RapiDAST requirements, globally, so that it's available to any user
-RUN microdnf install -y --setopt=install_weak_deps=0 java-21-openjdk shadow-utils dbus-glib procps git nodejs npm && \
+RUN microdnf install -y --setopt=install_weak_deps=0 python3.12 java-21-openjdk shadow-utils dbus-glib procps git nodejs npm && \
   microdnf install -y gtk3 && \
-  python3 -m ensurepip --upgrade && \
-  pip3 install --no-cache-dir -r /opt/rapidast/requirements.txt && \
+  python3.12 -m ensurepip --upgrade && \
+  python3.12 -m pip install --no-cache-dir -r /opt/rapidast/requirements.txt && \
   microdnf clean all -y && rm -rf /var/cache/dnf /tmp/*  && \
   ln -s /opt/redocly/node_modules/@redocly/cli/bin/cli.js /usr/local/bin/redocly
 
@@ -134,4 +134,5 @@ RUN command -v zap.sh && \
 
 WORKDIR /opt/rapidast
 ENV HOME /opt/rapidast
-ENTRYPOINT ["./rapidast.py"]
+ENV PYTHON_VERSION python3.12
+ENTRYPOINT ["python3.12", "rapidast.py"]

--- a/containerize/Containerfile.garak
+++ b/containerize/Containerfile.garak
@@ -110,10 +110,10 @@ COPY ./containerize/container_default_config.yaml /opt/rapidast/rapidast-default
 COPY ./containerize/path_rapidast.sh /etc/profile.d/rapidast.sh
 
 ### Install RapiDAST requirements, globally, so that it's available to any user
-RUN microdnf install -y --setopt=install_weak_deps=0 java-21-openjdk shadow-utils dbus-glib procps git nodejs npm && \
-  microdnf install -y gtk3 python3.12 && \
+RUN microdnf install -y --setopt=install_weak_deps=0 python3.12 java-21-openjdk shadow-utils dbus-glib procps git nodejs npm && \
+  microdnf install -y gtk3 && \
   python3.12 -m ensurepip --upgrade && \
-  pip3.12 install --no-cache-dir -r /opt/rapidast/requirements-llm.txt && \
+  python3.12 -m pip install --no-cache-dir -r /opt/rapidast/requirements-llm.txt && \
   microdnf clean all -y && rm -rf /var/cache/dnf /tmp/*  && \
   ln -s /opt/redocly/node_modules/@redocly/cli/bin/cli.js /usr/local/bin/redocly
 

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -240,7 +240,7 @@ This project uses `pip-compile` from `pip-tools` to manage dependencies.
 
 ### Requirements
 
-Make sure you have an environment that closely matches the environment in the container build. This means it should have the same operating system and the same Python `$major.$minor` version.
+Make sure you have an environment that closely matches the environment in the container build. This means it should have the same operating system and the same Python 3.12 version.
 
 - `pip-tools`: Used for managing Python dependencies and generating `requirements.txt`
 

--- a/e2e-tests/manifests/nessus-deployment.yaml
+++ b/e2e-tests/manifests/nessus-deployment.yaml
@@ -36,8 +36,8 @@ spec:
             - |
               #!/bin/bash
 
-              # curl -ks https://0.0.0.0:8834/server/status | python3 -c 'import sys, json; json.load(sys.stdin)["code"] == 200 or sys.exit(1)'
-              curl -ks https://0.0.0.0:8834/server/status | python3 -c 'import sys, json; json.load(sys.stdin)["detailed_status"]["login_status"] == "allow" or sys.exit(1)'
+              # curl -ks https://0.0.0.0:8834/server/status | python3.12 -c 'import sys, json; json.load(sys.stdin)["code"] == 200 or sys.exit(1)'
+              curl -ks https://0.0.0.0:8834/server/status | python3.12 -c 'import sys, json; json.load(sys.stdin)["detailed_status"]["login_status"] == "allow" or sys.exit(1)'
           initialDelaySeconds: 20
           periodSeconds: 10
           failureThreshold: 32

--- a/e2e-tests/manifests/rapidast-oobtkube-configmap.yaml
+++ b/e2e-tests/manifests/rapidast-oobtkube-configmap.yaml
@@ -21,7 +21,7 @@ data:
         results: "/tmp/oobtkube.sarif.json"   # if None or "*stdout", the command's standard output is selected
         # toolDir: scanners/generic/tools
         inline: |
-          PYTHON_VERSION="${PYTHON_VERSION:-python3}"
+          PYTHON_VERSION="${PYTHON_VERSION:-python3.12}"
           $PYTHON_VERSION oobtkube.py --log-level debug -d 60 -p 6000 -i rapidast-oobtkube -f /opt/rapidast/config/cr_example.yaml | tee /tmp/oobtkube.sarif.json
   # ConfigMap is used as target because it is a default resource
   cr_example.yaml: |+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
 [project]
 name = "rapidast"
 dynamic = ["dependencies", "version"]
-requires-python = ">= 3.9"
+requires-python = ">= 3.12"
 
 [tool.setuptools]
 packages = ["configmodel", "exports", "utils", "scanners"]


### PR DESCRIPTION
This commit upgrades the project's Python version to 3.12.

The following changes were made:
- Updated all references to Python in configuration files, documentation, GH workflows and container files.
- Replaced `pip3` with `python3.12 -m pip` for better portability.