### PR TITLE
Add konflux example

### DIFF
--- a/examples/konflux/README.md
+++ b/examples/konflux/README.md
@@ -1,0 +1,17 @@
+# RapiDAST in Konflux
+
+In Konflux, the recommended approach for running RapiDAST is to use it in an IntegrationTest, where the application components built
+previously can be deployed and scanned.
+
+See the example [Pipeline](./integration-test.yaml), for an approach that uses [eaas-provision-space](https://github.com/konflux-ci/build-definitions/tree/main/task/eaas-provision-space/0.1) to obtain an environment for deploying components. This pipeline references as
+a separate, standalone [RapiDAST task](./rapidast-check.yaml), which may in the future be stored and published from a central location.
+
+## Notes
+
+- This example is suitable for lower privileged components, that do not require cluster-admin to install. Higher privileged components, like cluster Operators
+can use the [create-ephemeral-cluster stepaction](https://github.com/konflux-ci/build-definitions/tree/main/stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1).
+- This example makes use of `oc port-forward` to make deployed components accessible to RapiDAST from an remote location. This means the RAPIDAST_CONFIG_VALUE
+parameter passed to this task should only include localhost URLs, not remote URLs
+- This example uses SCAN_OUTPUT to provide UI indicators of detected issues. This is typically only used elsewhere in the clair scan tasks (not sast tasks), and
+may be removed in favour of only using TEST_OUTPUT
+- This example currently does not include a step to push SARIF results to quay.io using oras, similar to SAST related tasks. This may be added in the future

--- a/examples/konflux/README.md
+++ b/examples/konflux/README.md
@@ -6,6 +6,10 @@ previously can be deployed and scanned.
 See the example [Pipeline](./integration-test.yaml), for an approach that uses [eaas-provision-space](https://github.com/konflux-ci/build-definitions/tree/main/task/eaas-provision-space/0.1) to obtain an environment for deploying components. This pipeline references as
 a separate, standalone [RapiDAST task](./rapidast-check.yaml), which may in the future be stored and published from a central location.
 
+The example pipeline in this repo was based on this earlier example:
+
+- <https://github.com/jenculltesting/rh-trex-test/blob/main/.tekton/rapidast-scan.yaml>
+
 ## Notes
 
 - This example is suitable for lower privileged components, that do not require cluster-admin to install. Higher privileged components, like cluster Operators

--- a/examples/konflux/integration-test.yaml
+++ b/examples/konflux/integration-test.yaml
@@ -1,0 +1,153 @@
+# An example Pipeline to use in an IntegrationTest, this is for a component named "test-component"
+# which would be built an a separate build pipeline
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: rapidast-integration-test
+spec:
+  params:
+    # this SNAPSHOT should be produced by the build pipeline and contain the containerImage we want to test with rapidast
+    - name: SNAPSHOT
+      type: string
+  tasks:
+    # we need an clean environment where we have permission to deploy k8s resources
+    # this env will only provide namespace-admin, not cluster-admin. For components
+    # that require a cluster-admin, an ephemeral EaaS cluster is needed
+    - name: provision-env
+      taskRef:
+        params:
+          - name: name
+            value: eaas-provision-space
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-eaas-provision-space:0.1@sha256:8a344ed61dfeabf741f3f08892414f223ade1849f995da0db172e79c4afc21a3
+          - name: kind
+            value: task
+        resolver: bundles
+      params:
+        - name: ownerName
+          value: $(context.pipelineRun.name)
+        - name: ownerUid
+          value: $(context.pipelineRun.uid)
+
+    # use image from snapshot in new deployment in fresh environment
+    - name: deploy-app
+      params:
+        - name: SNAPSHOT
+          value: "$(params.SNAPSHOT)"
+      runAfter:
+      - provision-env
+      taskSpec:
+        params:
+          - name: SNAPSHOT
+            type: string
+        volumes:
+          - name: credentials
+            emptyDir: {}
+        steps:
+          # write the kubeconfig to a volume we can use in subsequent steps
+          # and emptyDir volume will be exist for the lifetime of a single taskRun
+          - name: get-kubeconfig
+            image: quay.io/konflux-ci/konflux-test:latest
+            env:
+              - name: KUBECONFIG
+                value: /credentials/kubeconfig.yml
+              - name: KUBECONFIG_VALUE
+                valueFrom:
+                  secretKeyRef:
+                    name: "$(tasks.provision-env.results.secretRef)"
+                    key: kubeconfig
+            volumeMounts:
+              - name: credentials
+                mountPath: /credentials
+            script: |
+              #!/bin/bash
+              set -euxo pipefail
+
+              cat <<< "$KUBECONFIG_VALUE" > "$KUBECONFIG"
+              echo "Wrote kubeconfig for new environment to $KUBECONFIG"
+
+          # we need to copy the pull secret into our fresh test environment
+          # for the SNAPSHOT image stored in a private quay repo
+          - name: copy-pull-secret
+            image: quay.io/konflux-ci/konflux-test:latest
+            env:
+              - name: DEST_KUBECONFIG
+                value: /credentials/kubeconfig.yml
+              # used to pull SNAPSHOT image, should already exist in user namespace
+              - name: PULL_SECRET
+                value: test-component-image-pull
+            volumeMounts:
+              - name: credentials
+                mountPath: /credentials
+            script: |
+              #!/bin/bash
+              set -euxo pipefail
+
+              oc get secrets $PULL_SECRET -o json | jq 'del(.metadata.creationTimestamp,
+                .metadata.uid, .metadata.resourceVersion,
+                .metadata.annotations."kubectl.kubernetes.io/last-applied-configuration",
+                .metadata.namespace)' > /tmp/pull-secret.json
+              oc --kubeconfig=$DEST_KUBECONFIG apply -f /tmp/pull-secret.json
+              oc --kubeconfig=$DEST_KUBECONFIG secret link --for=pull default $PULL_SECRET
+
+          # deploy an instance of our app using the snapshot image in our test env
+          - name: deploy-app
+            image: quay.io/konflux-ci/konflux-test:latest
+            env:
+              - name: SNAPSHOT
+                value: "$(params.SNAPSHOT)"
+              - name: KUBECONFIG
+                value: /credentials/kubeconfig.yml
+            volumeMounts:
+              - name: credentials
+                mountPath: /credentials
+            script: |
+              #!/bin/bash
+              set -euxo pipefail
+
+              IMAGE=$(echo "$SNAPSHOT" | jq -r '.components[0].containerImage')
+              echo "Extracted image: $IMAGE"
+
+              oc create deployment test-component --image=$IMAGE
+              oc wait --for=condition=Available=true deployment/test-component --timeout=120s
+
+    - name: rapidast-check
+      runAfter:
+      - deploy-app
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/redhatproductsecurity/rapidast
+            # TODO change revision after merge
+          - name: revision
+            value: konflux-example
+          - name: pathInRepo
+            value: examples/konflux/rapidast-check.yaml
+      params:
+        - name: KUBECONFIG_SECRET
+          value: "$(tasks.provision-env.results.secretRef)"
+        # this is necessary to make the target app in the remote env accessible to rapidast
+        - name: PORT_FORWARD_TARGETS
+          value: "deployment/test-component 5000:5000"
+        # all target URLs in rapidast config should be localhost, and port-forwarded
+        - name: RAPIDAST_CONFIG_VALUE
+          value: |
+            config:
+              configVersion: 6
+              results:
+                exclusions:
+                  rules:
+                    - name: "Exclude findings below a severity level of Important"
+                      cel_expression: ".result.level != 'error' && .result.level != 'warning'"
+
+            application:
+              shortName: "test-component-1.0"
+              url: "http://127.0.0.1:5000" # root URL of the application, should always point to localhost
+
+            scanners:
+              zap:
+                spider: {}
+                passiveScan: {}
+                activeScan:
+                  policy: API-scan-minimal

--- a/examples/konflux/rapidast-check.yaml
+++ b/examples/konflux/rapidast-check.yaml
@@ -1,0 +1,174 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "konflux"
+  name: rapidast-check
+spec:
+  description: >-
+    This task uses RapiDAST to scan a running application. Intended for use in an Integration Test, not a build pipeline. This task requires a KUBECONFIG_SECRET for an existing cluster/namespace
+    where the target application is running. To make this application reachable by RapiDAST from outside this environment, `oc port-forward` is used.
+  results:
+    - name: TEST_OUTPUT
+      description: Tekton task test output.
+    - name: SCAN_OUTPUT
+      description: RapiDAST scan result.
+  params:
+    - name: KUBECONFIG_SECRET
+      description: The name of a kubeconfig used to to access the test environment.
+      type: string
+    - name: RAPIDAST_CONFIG_VALUE
+      description: The contents of a rapidast config file. Target URLs for scanning should point to localhost and match PORT_FORWARD_TARGETS.
+      type: string
+    - name: PORT_FORWARD_TARGETS
+      description: Scan targets in test environment and arguments for `oc port-forward` commands. Each host:port in RAPIDAST_CONFIG_VALUE requires a respective port-forward target. Multiple values can be separated with a comma.
+      default: pod/my-pod 5000:5000
+      type: string
+      # TODO add a dotenv file argument, so users can pass in .env file with secrets etc used for scanning
+  volumes:
+    - name: shared
+      emptyDir: {}
+  sidecars:
+    - name: port-forward
+      image: quay.io/konflux-ci/konflux-test:latest
+      volumeMounts:
+        - name: shared
+          mountPath: /shared
+      env:
+        - name: KUBECONFIG
+          value: /shared/kubeconfig.yml
+        - name: KUBECONFIG_VALUE
+          valueFrom:
+            secretKeyRef:
+              name: "$(params.KUBECONFIG_SECRET)"
+              key: kubeconfig
+        - name: PORT_FORWARD_TARGETS
+          value: "$(params.PORT_FORWARD_TARGETS)"
+      script: |
+        #!/bin/bash
+        set -ex
+
+        # to share with rapidast image
+        cp utils.sh /shared
+
+        cat <<< "$KUBECONFIG_VALUE" > "$KUBECONFIG"
+        echo "Wrote kubeconfig for new environment to $KUBECONFIG"
+
+        echo "${PORT_FORWARD_TARGETS}"
+
+        check_pid_listening_port() {
+            local pid=$1
+            # checks that PID has at least one local port open
+            if ss -tlnp | grep -q "pid=${pid},"; then
+                return 0
+            fi
+            return 1
+        }
+        export -f check_pid_listening_port
+
+        # split on ",", then parse as json to handle whitespace
+        IFS="," read -ra TARGETS_ARRAY <<< "${PORT_FORWARD_TARGETS}"
+
+        for t in "${TARGETS_ARRAY[@]}"; do
+          oc port-forward --address 0.0.0.0 ${t} &
+          PID=$!
+          timeout 30s bash -c "set -x; until check_pid_listening_port ${PID}; do sleep 2s; done" || {
+            echo "oc port-foward failed to open local port"
+            exit 1
+          }
+        done
+
+        touch /shared/port-forward-ready # signal to rapidast container
+        sleep infinity
+
+  steps:
+    # perform rapidast scan
+    - name: rapidast-check
+      image: quay.io/redhatproductsecurity/rapidast
+      # TODO add a dotenv file argument, so users can pass in .env file with secrets etc used for scanning
+      env:
+        # this can be used by some rapidast generic scanners, like trivy
+        - name: KUBECONFIG
+          value: /shared/kubeconfig.yml
+      volumeMounts:
+        - name: shared
+          mountPath: /shared
+      script: |
+        #!/bin/bash
+        set -ex
+
+        # wait til sidecar container signals all port-fowarding is ready
+        timeout 5m bash -c 'until [ -f /shared/port-forward-ready ]; do sleep 2; done' || {
+          echo "[ERROR] oc port-forward commands in sidecar container not ready in time. Exiting"
+          exit 1
+        }
+
+        # helper code from konflux-test image, includes handle_error and make_result_json
+        source /shared/utils.sh
+        trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
+
+        cat > /shared/rapidast-config.yaml << EOF
+        $(params.RAPIDAST_CONFIG_VALUE)
+        EOF
+
+        rapidast.py --config /shared/rapidast-config.yaml
+
+        orig_sarif_file=$(find results -name rapidast-scan-results.sarif)
+        cp "${orig_sarif_file}" /shared/rapidast-scan-results.sarif
+
+    - name: post-process
+      image: quay.io/konflux-ci/konflux-test
+      volumeMounts:
+        - name: shared
+          mountPath: /shared
+      script: |
+        #!/bin/bash
+        set -ex
+
+        # helper code from konflux-test image, includes handle_error and make_result_json
+        source /utils.sh
+        trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
+
+        sarif_file=/shared/rapidast-scan-results.sarif
+
+        # Process SCAN_OUTPUT similar to clair scan, but don't use optional 'unpatched_vulnerabilities' field
+        scan_result='{"vulnerabilities":{"critical":0, "high":0, "medium":0, "low":0, "unknown":0}}'
+
+        if [ ! -s "$sarif_file" ]; then
+          echo "No RapiDAST SARIF file found or it's empty."
+          note="Task $(context.task.name) failed: No RapiDAST SARIF file found or it's empty. For details, check Tekton task log."
+          TEST_OUTPUT=$(make_result_json -r "ERROR" -t "$note")
+          echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          exit 0
+        fi
+
+        # SARIF level mapping: 'error' -> critical, 'warning' -> high, 'note' -> medium.
+        result=$(jq -rce \
+            '{
+                vulnerabilities:{
+                  critical: ([.runs[0].results[]? | select(.level == "error")] | length // 0),
+                  high: ([.runs[0].results[]? | select(.level == "warning")] | length // 0),
+                  medium: ([.runs[0].results[]? | select(.level == "note")] | length // 0),
+                  low: ([.runs[0].results[]? | select(.level == "none")] | length // 0),
+                  unknown: ([.runs[0].results[]? | select(.level == "unknown")] | length // 0)
+                }
+            }' "$sarif_file")
+
+        scan_result=$(jq -s -rce \
+              '.[0].vulnerabilities.critical += .[1].vulnerabilities.critical |
+              .[0].vulnerabilities.high += .[1].vulnerabilities.high |
+              .[0].vulnerabilities.medium += .[1].vulnerabilities.medium |
+              .[0].vulnerabilities.low += .[1].vulnerabilities.low |
+              .[0].vulnerabilities.unknown += .[1].vulnerabilities.unknown |
+              .[0]' <<<"$scan_result $result")
+
+        echo "$scan_result" | tee "$(results.SCAN_OUTPUT.path)"
+
+        note="Task $(context.task.name) completed: Refer to Tekton task result SCAN_OUTPUT for vulnerabilities scanned by RapiDAST."
+        TEST_OUTPUT=$(make_result_json -r "SUCCESS" -t "$note")
+        echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+
+        # TODO push SARIF result file to quay.io with oras, much like sast tasks


### PR DESCRIPTION
[PSSECAUT-1228](https://issues.redhat.com/browse/PSSECAUT-1228)

I opted not to create a separate example for ephemeral cluster, only ephemeral namespace. Users can rely on the existing EaaS docs:

https://konflux.pages.redhat.com/docs/users/testing/cluster-provisioning.html#requesting-as-eaas-space


Some screenshots of this example's result in the Konflux UI:

<img width="628" height="834" alt="rapidast-konflux" src="https://github.com/user-attachments/assets/f2d19889-fd0b-4048-9c90-8122b6bf7102" />
<img width="947" height="650" alt="rapidast-konflux-2" src="https://github.com/user-attachments/assets/ea8d1f10-327f-4057-8ba3-7f2f935a7c63" />
