### PR TITLE
feat(scanner/generic): Remove strict mode from configuration (#403)

### DIFF
--- a/scanners/generic/generic.py
+++ b/scanners/generic/generic.py
@@ -48,7 +48,6 @@ class Generic(RapidastScanner):
             raise ValueError(f"'scanners.{ident}' section not in config")
 
         dacite_config = dacite.Config(
-            strict=True,
             type_hooks={
                 # Dacite doesn't natively support enums, so we use `type_hooks` as a workaround
                 # to properly resolve enum values

--- a/tests/scanners/generic/test_generic.py
+++ b/tests/scanners/generic/test_generic.py
@@ -46,3 +46,13 @@ def test_generic_none_tool_dir(test_config):
     scanner = GenericNone(config=test_config)
     scanner.setup()
     assert scanner.tool_dir == "/tmp/tooldir"
+
+
+def test_generic_with_unexpected_config(test_config):
+    test_config.set("scanners.generic.inline", "tmp_cmd")
+    test_config.set("scanners.generic.unexpected_option", "should_be_ignored")
+    try:
+        scanner = GenericNone(config=test_config, ident="generic")
+        scanner.setup()
+    except Exception as e:
+        pytest.fail(f"Scanner initialization failed with unexpected config: {e}")


### PR DESCRIPTION
* feat(scanner/generic): Remove strict mode from configuration

Removes the strict option from the generic scanner configuration to allow additional configuration parameters without causing validation failures. This change ensures consistency with other scanner configurations.

* test(scanner/generic): Add test for unexpected config

Adds a test case to verify that the generic scanner can handle unexpected configuration options without raising an error.