### PR TITLE
e2e testing: test GCP export for ZAP

### DIFF
--- a/.tekton/integration-test.yaml
+++ b/.tekton/integration-test.yaml
@@ -108,6 +108,35 @@ spec:
         - name: ownerUid
           value: $(context.pipelineRun.uid)
 
+    - name: copy-gcs-secret
+      runAfter:
+       - provision-eaas-space
+      taskSpec:
+        steps:
+          - name: copy-gcs-secret
+            image: registry.redhat.io/openshift4/ose-cli:latest
+            env:
+            - name: KUBECONFIG
+              value: /tmp/kubeconfig
+            - name: EAAS_KUBECONFIG_VALUE
+              valueFrom:
+                secretKeyRef:
+                  name: $(tasks.provision-eaas-space.results.secretRef)
+                  key: kubeconfig
+            workingDir: /workspace
+            script: |
+              #!/bin/bash -ex
+
+              # initial request will default to in-cluster k8s config
+              oc whoami
+              oc get secret gcs-credentials -o yaml > /tmp/gcs-credentials.yaml
+              sed '/namespace:/d' /tmp/gcs-credentials.yaml > /tmp/new-secret.yaml
+
+              # second request should use newly provisioned eaas creds + namespace
+              echo "$EAAS_KUBECONFIG_VALUE" > "$KUBECONFIG"
+              oc whoami
+              oc apply -f /tmp/new-secret.yaml
+
     - name: prefetch-get-refs
       onError: continue
       taskRef:
@@ -131,7 +160,7 @@ spec:
     # so need to repeat them inline, rather than define in a separate file
     - name: run-e2e-tests
       runAfter:
-        - provision-eaas-space
+        - copy-gcs-secret
         - prefetch-get-refs
       taskSpec:
         stepTemplate:
@@ -203,6 +232,11 @@ spec:
 
               echo "$KUBECONFIG_VALUE" > "$KUBECONFIG"
               oc whoami
+
+              # Extract GCS credentials from the secret and set up authentication
+              export GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcs-credentials.json
+              oc get secret gcs-credentials -o jsonpath='{.data.gcs-credentials\.json}' | base64 -d > "$GOOGLE_APPLICATION_CREDENTIALS"
+              echo "GCS credentials extracted to $GOOGLE_APPLICATION_CREDENTIALS"
 
               yum install -y python3.12 git
               python3.12 -m ensurepip

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -64,6 +64,22 @@ To run single e2e test, use a command like:
 $ pytest e2e-tests/test_integration.py::TestRapiDAST::test_trivy --json-report
 ```
 
+#### GCP export test
+
+The `test_gcp_export` test requires access to a Google Cloud Storage bucket and valid GCP credentials in the cluster. It runs by default and must be explicitly excluded if GCP access is unavailable.
+
+To skip it, use pytest's `-k` flag:
+
+```bash
+$ pytest e2e-tests/test_integration.py -k "not test_gcp_export" --json-report
+```
+
+To run only the GCP export test, with a specific bucket:
+
+```bash
+$ RAPIDAST_GCP_BUCKET=my-bucket pytest e2e-tests/test_integration.py::TestRapiDAST::test_gcp_export --json-report
+```
+
 ## Structure
 
 Its structure is as follow:

--- a/e2e-tests/conftest.py
+++ b/e2e-tests/conftest.py
@@ -20,6 +20,7 @@ NAMESPACE = os.getenv("RAPIDAST_NAMESPACE", "")  # e.g. rapidast--pipeline
 SERVICEACCOUNT = os.getenv("RAPIDAST_SERVICEACCOUNT", "pipeline")  # name of ServiceAccount used in rapidast pod
 RAPIDAST_IMAGE = os.getenv("RAPIDAST_IMAGE", "quay.io/redhatproductsecurity/rapidast:development")
 RAPIDAST_LLM_IMAGE = os.getenv("RAPIDAST_IMAGE", "quay.io/redhatproductsecurity/rapidast-llm:development")
+RAPIDAST_GCP_BUCKET = os.getenv("RAPIDAST_GCP_BUCKET", "rapidast-e2e-test-bucket")  # GCS bucket for export tests
 # delete resources created by tests
 RAPIDAST_CLEANUP = os.getenv("RAPIDAST_CLEANUP", "True").lower() in ("true", "1", "t", "y", "yes")
 
@@ -121,6 +122,8 @@ def render_manifests(input_dir, output_dir):
         contents = contents.replace("${RAPIDAST_LLM_IMAGE}", RAPIDAST_LLM_IMAGE)
         contents = contents.replace("${IMAGE}", RAPIDAST_IMAGE)
         contents = contents.replace("${SERVICEACCOUNT}", SERVICEACCOUNT)
+        if RAPIDAST_GCP_BUCKET:
+            contents = contents.replace("${BUCKET_NAME}", RAPIDAST_GCP_BUCKET)
         with open(filepath, "w", encoding="utf-8") as f:
             f.write(contents)
 

--- a/e2e-tests/conftest.py
+++ b/e2e-tests/conftest.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import secrets
 import shutil
 import tempfile
 import time
@@ -21,6 +22,8 @@ SERVICEACCOUNT = os.getenv("RAPIDAST_SERVICEACCOUNT", "pipeline")  # name of Ser
 RAPIDAST_IMAGE = os.getenv("RAPIDAST_IMAGE", "quay.io/redhatproductsecurity/rapidast:development")
 RAPIDAST_LLM_IMAGE = os.getenv("RAPIDAST_IMAGE", "quay.io/redhatproductsecurity/rapidast-llm:development")
 RAPIDAST_GCP_BUCKET = os.getenv("RAPIDAST_GCP_BUCKET", "rapidast-e2e-test-bucket")  # GCS bucket for export tests
+# Randomized by default so each session uses a unique GCS path; override with RAPIDAST_GCP_APP_NAME
+GCP_RANDOM_APP_NAME = os.getenv("RAPIDAST_GCP_APP_NAME", f"gcp-test-{secrets.token_hex(8)}")
 # delete resources created by tests
 RAPIDAST_CLEANUP = os.getenv("RAPIDAST_CLEANUP", "True").lower() in ("true", "1", "t", "y", "yes")
 
@@ -124,6 +127,7 @@ def render_manifests(input_dir, output_dir):
         contents = contents.replace("${SERVICEACCOUNT}", SERVICEACCOUNT)
         if RAPIDAST_GCP_BUCKET:
             contents = contents.replace("${BUCKET_NAME}", RAPIDAST_GCP_BUCKET)
+        contents = contents.replace("${APP_SHORT_NAME}", GCP_RANDOM_APP_NAME)
         with open(filepath, "w", encoding="utf-8") as f:
             f.write(contents)
 

--- a/e2e-tests/manifests/rapidast-gcp-export-configmap.yaml
+++ b/e2e-tests/manifests/rapidast-gcp-export-configmap.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+data:
+  config.yaml: |+
+    config:
+      configVersion: 6
+      googleCloudStorage:
+        bucketName_from_var: "GCS_BUCKET_NAME"
+        directory: "e2e-test-gcp-export"
+
+    # `application` contains data related to the application, not to the scans.
+    application:
+      shortName_from_var: "APP_SHORT_NAME"
+      url: "http://localhost:8080"
+
+    scanners:
+      zap:
+      # Simple API scan against localhost
+        apiScan:
+          apis:
+            apiUrl: "http://localhost:8080/api/swagger.json"
+
+        passiveScan:
+          # Disable passive scan to speed up the test
+          disabledRules: "all"
+
+        activeScan:
+          # Use minimal policy for faster execution
+          policy: API-scan-minimal
+
+        container:
+          parameters:
+            executable: "zap.sh"
+
+        miscOptions:
+          updateAddons: False
+
+kind: ConfigMap
+metadata:
+  name: rapidast-gcp-export
+  labels:
+    app: rapidast

--- a/e2e-tests/manifests/rapidast-gcp-export-pod.yaml
+++ b/e2e-tests/manifests/rapidast-gcp-export-pod.yaml
@@ -48,6 +48,6 @@ spec:
     secret:
       secretName: gcs-credentials
       items:
-      - key: credentials
+      - key: gcs-credentials.json
         path: gcs-credentials.json
   restartPolicy: Never

--- a/e2e-tests/manifests/rapidast-gcp-export-pod.yaml
+++ b/e2e-tests/manifests/rapidast-gcp-export-pod.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+  generateName: rapidast-gcp-export-
+  labels:
+    app: rapidast
+spec:
+  initContainers:
+    # Run rapidast as initContainer
+  - image: ${IMAGE} # quay.io/redhatproductsecurity/rapidast:latest
+    imagePullPolicy: Always
+    name: rapidast
+    env:
+    - name: GOOGLE_APPLICATION_CREDENTIALS
+      value: /var/secrets/google/gcs-credentials.json
+    - name: GCS_BUCKET_NAME
+      value: ${BUCKET_NAME}
+    - name: APP_SHORT_NAME
+      value: ${APP_SHORT_NAME}
+    resources:
+      limits:
+        cpu: 1
+        memory: 2Gi
+      requests:
+        cpu: 250m
+        memory: 512Mi
+    volumeMounts:
+    - name: config-volume
+      mountPath: /opt/rapidast/config
+    - name: results
+      mountPath: /opt/rapidast/results
+    - name: gcs-credentials
+      mountPath: /var/secrets/google
+      readOnly: true
+  containers:
+    # Simple container that just completes successfully
+  - command: ["bash", "-c", "echo 'RapiDAST GCP export test completed'"]
+    image: registry.redhat.io/ubi9/ubi-micro
+    name: completion-marker
+  volumes:
+  - name: config-volume
+    configMap:
+      name: rapidast-gcp-export
+  - name: results
+    emptyDir: {}
+  - name: gcs-credentials
+    secret:
+      secretName: gcs-credentials
+      items:
+      - key: credentials
+        path: gcs-credentials.json
+  restartPolicy: Never

--- a/e2e-tests/test_integration.py
+++ b/e2e-tests/test_integration.py
@@ -157,7 +157,7 @@ class TestRapiDAST(TestBase):
         app_name = f"gcp-test-{random_suffix}"
 
         # Create the ConfigMap
-        cm = self.create_from_yaml(f"{self.tempdir}/rapidast-gcp-export-configmap.yaml")
+        self.create_from_yaml(f"{self.tempdir}/rapidast-gcp-export-configmap.yaml")
 
         # Replace APP_SHORT_NAME placeholder in the pod manifest
         # BUCKET_NAME is already replaced by render_manifests in conftest.py
@@ -168,28 +168,17 @@ class TestRapiDAST(TestBase):
         with open(pod_path, "w", encoding="utf-8") as f:
             f.write(pod_content)
 
-        # Create the pod with only volumes override
-        volumes = [
-            {"name": "config-volume", "configMap": {"name": cm.metadata.name}},
-            {"name": "results", "emptyDir": {}},
-            {
-                "name": "gcs-credentials",
-                "secret": {
-                    "secretName": "gcs-credentials",
-                    "items": [{"key": "gcs-credentials.json", "path": "gcs-credentials.json"}],
-                },
-            },
-        ]
-        pod_overrides = {"spec": {"volumes": volumes}}
-
-        p = self.create_from_yaml(pod_path, pod_overrides)
+        p = self.create_from_yaml(pod_path)
         # Wait for the pod to complete (may succeed or fail). We don't assert here because
-        # the scan is expected to fail (scanning a non-existent app), but the GCP export
-        # should still succeed. We verify the export success below.
+        # No assert: the scan is expected to fail (scanning a non-existent app).
+        # We only care that the GCP export succeeded, verified below.
         is_pod_with_field_selector_successfully_completed(
             field_selector=f"metadata.name={p.metadata.name}",
             timeout=360,
         )
+
+        logs = get_log_from_pod(self.tempdir, p.metadata.name, container="rapidast", log_format="text")
+        assert "Export to Google Cloud Storage completed successfully" in logs
 
         # Verify that RapiDAST successfully exported scan results to GCS with the expected filename
         directory = "e2e-test-gcp-export"

--- a/e2e-tests/test_integration.py
+++ b/e2e-tests/test_integration.py
@@ -3,7 +3,6 @@ import json
 import logging
 import os
 import re
-import secrets
 from typing import Optional
 from typing import Union
 
@@ -12,6 +11,7 @@ from google.cloud import storage
 from jsonschema import Draft7Validator
 from jsonschema import validate
 
+from conftest import GCP_RANDOM_APP_NAME  # pylint: disable=E0611
 from conftest import is_pod_with_field_selector_successfully_completed  # pylint: disable=E0611
 from conftest import RAPIDAST_GCP_BUCKET  # pylint: disable=E0611
 from conftest import tee_log  # pylint: disable=E0611
@@ -152,23 +152,13 @@ class TestRapiDAST(TestBase):
     def test_gcp_export(self):
         """Test GCP export"""
         # NOTE: the test itself does not necessarily succeed. Only the successful export matters
-        # Generate a random application name for unique identification
-        random_suffix = secrets.token_hex(8)
-        app_name = f"gcp-test-{random_suffix}"
+        # APP_SHORT_NAME and BUCKET_NAME are replaced by render_manifests in conftest.py
+        app_name = GCP_RANDOM_APP_NAME
 
         # Create the ConfigMap
         self.create_from_yaml(f"{self.tempdir}/rapidast-gcp-export-configmap.yaml")
 
-        # Replace APP_SHORT_NAME placeholder in the pod manifest
-        # BUCKET_NAME is already replaced by render_manifests in conftest.py
-        pod_path = f"{self.tempdir}/rapidast-gcp-export-pod.yaml"
-        with open(pod_path, "r", encoding="utf-8") as f:
-            pod_content = f.read()
-        pod_content = pod_content.replace("${APP_SHORT_NAME}", app_name)
-        with open(pod_path, "w", encoding="utf-8") as f:
-            f.write(pod_content)
-
-        p = self.create_from_yaml(pod_path)
+        p = self.create_from_yaml(f"{self.tempdir}/rapidast-gcp-export-pod.yaml")
         # Wait for the pod to complete (may succeed or fail). We don't assert here because
         # No assert: the scan is expected to fail (scanning a non-existent app).
         # We only care that the GCP export succeeded, verified below.

--- a/e2e-tests/test_integration.py
+++ b/e2e-tests/test_integration.py
@@ -1,14 +1,19 @@
+import fnmatch
 import json
 import logging
 import os
 import re
+import secrets
 from typing import Optional
 from typing import Union
 
+from google.api_core import exceptions as gcp_exceptions
+from google.cloud import storage
 from jsonschema import Draft7Validator
 from jsonschema import validate
 
 from conftest import is_pod_with_field_selector_successfully_completed  # pylint: disable=E0611
+from conftest import RAPIDAST_GCP_BUCKET  # pylint: disable=E0611
 from conftest import tee_log  # pylint: disable=E0611
 from conftest import TestBase  # pylint: disable=E0611
 from conftest import wait_until_ready  # pylint: disable=E0611
@@ -95,7 +100,7 @@ class TestRapiDAST(TestBase):
         """Test URL exclusions"""
         self._ensure_vapi_instance()
 
-        # # Verify that ZAP report does not contain alerts for URLs excluded in the scan configuration
+        # Verify that ZAP report does not contain alerts for URLs excluded in the scan configuration
         cm = self.create_from_yaml(f"{self.tempdir}/rapidast-vapi-configmap-urls-exclusions.yaml")
         volumes = [
             {"name": "config-volume", "configMap": {"name": cm.metadata.name}},
@@ -143,6 +148,57 @@ class TestRapiDAST(TestBase):
 
         results = check_zap_alert_refs(data, self.passive_scan_alertrefs)
         assert not results["found"], f"Unexpected passive scan alert references found: {results['found']}"
+
+    def test_gcp_export(self):
+        """Test GCP export"""
+        # NOTE: the test itself does not necessarily succeed. Only the successful export matters
+        # Generate a random application name for unique identification
+        random_suffix = secrets.token_hex(8)
+        app_name = f"gcp-test-{random_suffix}"
+
+        # Create the ConfigMap
+        cm = self.create_from_yaml(f"{self.tempdir}/rapidast-gcp-export-configmap.yaml")
+
+        # Replace APP_SHORT_NAME placeholder in the pod manifest
+        # BUCKET_NAME is already replaced by render_manifests in conftest.py
+        pod_path = f"{self.tempdir}/rapidast-gcp-export-pod.yaml"
+        with open(pod_path, "r", encoding="utf-8") as f:
+            pod_content = f.read()
+        pod_content = pod_content.replace("${APP_SHORT_NAME}", app_name)
+        with open(pod_path, "w", encoding="utf-8") as f:
+            f.write(pod_content)
+
+        # Create the pod with only volumes override
+        volumes = [
+            {"name": "config-volume", "configMap": {"name": cm.metadata.name}},
+            {"name": "results", "emptyDir": {}},
+            {
+                "name": "gcs-credentials",
+                "secret": {
+                    "secretName": "gcs-credentials",
+                    "items": [{"key": "gcs-credentials.json", "path": "gcs-credentials.json"}],
+                },
+            },
+        ]
+        pod_overrides = {"spec": {"volumes": volumes}}
+
+        p = self.create_from_yaml(pod_path, pod_overrides)
+        # Wait for the pod to complete (may succeed or fail). We don't assert here because
+        # the scan is expected to fail (scanning a non-existent app), but the GCP export
+        # should still succeed. We verify the export success below.
+        is_pod_with_field_selector_successfully_completed(
+            field_selector=f"metadata.name={p.metadata.name}",
+            timeout=360,
+        )
+
+        # Verify that RapiDAST successfully exported scan results to GCS with the expected filename
+        directory = "e2e-test-gcp-export"
+        # Actual upload pattern: {directory}/{timestamp}-RapiDAST-{app_name}-{random}.tgz
+        expected_pattern = f"*-RapiDAST-{app_name}-*.tgz"
+
+        verify_gcs_export_with_pattern(
+            bucket_name=RAPIDAST_GCP_BUCKET, directory=directory, app_name=app_name, expected_pattern=expected_pattern
+        )
 
     def test_trivy(self):
         self.create_from_yaml(f"{self.tempdir}/rapidast-trivy-configmap.yaml")
@@ -295,4 +351,73 @@ def validate_json_schema(data: dict, schema_path: str) -> bool:
         raise ValueError(f"Failed to parse JSON schema {schema_path}: {e}") from e
 
     validate(instance=data, schema=schema, format_checker=Draft7Validator.FORMAT_CHECKER)
+    return True
+
+
+def verify_gcs_export_with_pattern(bucket_name: str, directory: str, app_name: str, expected_pattern: str) -> bool:
+    """
+    Verify that RapiDAST successfully exported scan results to GCS with a specific filename pattern
+
+    Args:
+        bucket_name: Name of the GCS bucket to check
+        directory: Directory prefix where files should be stored
+        app_name: The application shortName used in the scan
+        expected_pattern: Expected filename pattern (e.g., "*-RapiDAST-{app_name}-*.tgz")
+
+    Returns:
+        True if the expected file matching the pattern was found and deleted
+
+    Raises:
+        AssertionError: If no files were found matching the expected pattern
+    """
+    # Use credentials from GOOGLE_APPLICATION_CREDENTIALS environment variable
+    client = storage.Client()
+
+    try:
+        bucket = client.get_bucket(bucket_name)
+    except Exception as e:
+        raise AssertionError(f"Failed to access GCS bucket '{bucket_name}': {e}") from e
+
+    # Construct the expected prefix based on the directory
+    # Actual upload pattern: {directory}/{timestamp}-RapiDAST-{app_name}-{random}.tgz
+    expected_prefix = f"{directory}/"
+    logging.info(f"Looking for files with prefix: {expected_prefix}")
+
+    # List all blobs with the expected prefix
+    blobs = list(bucket.list_blobs(prefix=expected_prefix))
+
+    logging.info(f"Found {len(blobs)} blob(s) with prefix '{expected_prefix}'")
+    for blob in blobs:
+        logging.info(f"  - {blob.name} ({blob.size} bytes)")
+
+    # Filter to files matching the pattern: *-RapiDAST-{app_name}-*.tgz
+    tgz_pattern = f"*-RapiDAST-{app_name}-*.tgz"
+    matching_files = [blob for blob in blobs if fnmatch.fnmatch(os.path.basename(blob.name), tgz_pattern)]
+
+    assert len(matching_files) > 0, (
+        f"No files matching pattern '{tgz_pattern}' found in GCS bucket '{bucket_name}' "
+        f"with prefix '{expected_prefix}'. Expected to find files matching pattern: {expected_pattern}. "
+        f"Found {len(blobs)} blob(s) total: {[b.name for b in blobs]}"
+    )
+
+    assert len(matching_files) > 0, (
+        f"No files matching pattern '{tgz_pattern}' found in GCS export. " f"Found blobs: {[b.name for b in blobs]}"
+    )
+
+    logging.info(
+        f"GCS export verification succeeded. Found {len(matching_files)} file(s) matching pattern '{tgz_pattern}' "
+        f"in bucket '{bucket_name}/{expected_prefix}'"
+    )
+    for blob in matching_files:
+        logging.info(f"  - {blob.name} ({blob.size} bytes)")
+
+    # Clean up: delete only the files matching this test run
+    logging.info(f"Cleaning up: deleting {len(matching_files)} file(s) from GCS bucket...")
+    for blob in matching_files:
+        try:
+            blob.delete()
+            logging.info(f"  - Deleted: {blob.name}")
+        except (gcp_exceptions.NotFound, gcp_exceptions.Forbidden) as e:
+            logging.warning(f"  - Failed to delete {blob.name}: {e}")
+
     return True


### PR DESCRIPTION
This commit slightly changes the main e2e rapidast/ZAP test to also send the result to GCP.
It expects:
- the `gcs-credentials` secret 
- a bucket "rapidast-ci-test-bucket", currently hardcoded.
