### PR TITLE
Test for Python 3.9 compatibility

### DIFF
--- a/.github/workflows/python39-compat-check.yml
+++ b/.github/workflows/python39-compat-check.yml
@@ -1,0 +1,28 @@
+name: Check Python 3.9 compatibility
+
+on:
+  pull_request:
+    branches: [ "main", "development" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    container:
+      image: "registry.access.redhat.com/ubi9:latest"
+
+    steps:
+      - name: Install git in the container
+        run: dnf install -y --nodocs git-core
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create Python venv
+        run: python3.9 -m venv .venv
+
+      - name: Try installing requirements
+        run: |
+          . .venv/bin/activate
+          pip install --upgrade pip
+          pip install -r requirements.txt

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -82,7 +82,7 @@ types-psutil==7.0.0.20250218
     # via mypy
 types-setuptools==75.8.2.20250305
     # via mypy
-typing-extensions==4.12.2
+typing-extensions==4.15.0
     # via
     #   mypy
     #   setuptools-scm

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -32,7 +32,7 @@ charset-normalizer==3.4.4
     # via
     #   -r requirements.txt
     #   requests
-click==8.3.1
+click==8.1.8
     # via
     #   -r requirements.txt
     #   black
@@ -172,7 +172,7 @@ pyasn1-modules==0.4.2
     # via
     #   -r requirements.txt
     #   google-auth
-pycparser==3.0
+pycparser==2.23
     # via
     #   -r requirements.txt
     #   cffi
@@ -274,7 +274,7 @@ types-pyyaml==6.0.12.20250915
     # via
     #   -r requirements.txt
     #   cel-python
-typing-extensions==4.12.2
+typing-extensions==4.15.0
     # via
     #   -r requirements.txt
     #   referencing

--- a/requirements-llm.txt
+++ b/requirements-llm.txt
@@ -68,7 +68,7 @@ charset-normalizer==3.4.4
     #   requests
 chevron==0.14.0
     # via octoai-sdk
-click==8.3.1
+click==8.1.8
     # via
     #   -r requirements.txt
     #   litellm
@@ -406,7 +406,7 @@ pyasn1-modules==0.4.2
     # via
     #   -r requirements.txt
     #   google-auth
-pycparser==3.0
+pycparser==2.23
     # via
     #   -r requirements.txt
     #   cffi
@@ -614,7 +614,7 @@ types-pyyaml==6.0.12.20250915
     #   octoai-sdk
 types-requests==2.32.0.20250306
     # via octoai-sdk
-typing-extensions==4.12.2
+typing-extensions==4.15.0
     # via
     #   -r requirements.txt
     #   anyio

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ cffi==2.0.0
     # via cryptography
 charset-normalizer==3.4.4
     # via requests
-click==8.3.1
+click==8.1.8
     # via typer
 cryptography==46.0.5
     # via google-auth
@@ -84,7 +84,7 @@ pyasn1==0.6.2
     #   rsa
 pyasn1-modules==0.4.2
     # via google-auth
-pycparser==3.0
+pycparser==2.23
     # via cffi
 pygments==2.19.2
     # via rich
@@ -134,7 +134,7 @@ typer==0.15.1
     # via py-nessus-pro
 types-pyyaml==6.0.12.20250915
     # via cel-python
-typing-extensions==4.12.2
+typing-extensions==4.15.0
     # via
     #   referencing
     #   typer


### PR DESCRIPTION
Automated check to detect when dependencies added to requirements.txt are no longer compatible with Python 3.9.  This is a temporary safeguard as there are downstream consumers that need to migrate to newer Python.

We do not need to keep requirements-llm.txt and requirements-dev.txt Python 3.9 compatible, but we will use older versions of dependencies there for dependencies also listed in requirements.txt.

This commit also downgrades few dependencies to a Python 3.9 compatible version.  Also updated typing-extensions to newer version required for pre-3.11 Python versions.