### PR TITLE
Update versions of github actions

### DIFF
--- a/.github/workflows/python39-compat-check.yml
+++ b/.github/workflows/python39-compat-check.yml
@@ -16,7 +16,7 @@ jobs:
         run: dnf install -y --nodocs git-core
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create Python venv
         run: python3.9 -m venv .venv

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.12"
         cache: 'pip'
@@ -33,9 +33,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.12"
         cache: 'pip'

--- a/.github/workflows/validate-renovate.yml
+++ b/.github/workflows/validate-renovate.yml
@@ -14,5 +14,5 @@ jobs:
   renovate-config-validation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: konflux-ci/renovate-config-validator-action@main


### PR DESCRIPTION
Update versions of github actions actions/checkout and actions/setup-python to versions that use Node.js 24 rather than Node.js 20, which is being deprecated by GitHub.

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/