### PR TITLE
Ensure PyYAML is installed for python3

### DIFF
--- a/containerize/Containerfile
+++ b/containerize/Containerfile
@@ -116,7 +116,7 @@ COPY ./containerize/path_rapidast.sh /etc/profile.d/rapidast.sh
 
 ### Install RapiDAST requirements, globally, so that it's available to any user
 RUN microdnf -y module enable nodejs:24 && \
-  microdnf install -y --setopt=install_weak_deps=0 --nodocs python3.12 java-21-openjdk shadow-utils dbus-glib procps git-core nodejs npm && \
+  microdnf install -y --setopt=install_weak_deps=0 --nodocs python3.12 java-21-openjdk shadow-utils dbus-glib procps git-core nodejs npm python3-pyyaml && \
   microdnf install -y --nodocs gtk3 && \
   python3.12 -m ensurepip --upgrade && \
   python3.12 -m pip install --no-cache-dir -r /opt/rapidast/requirements.txt && \

--- a/containerize/Containerfile.garak
+++ b/containerize/Containerfile.garak
@@ -116,7 +116,7 @@ COPY ./containerize/path_rapidast.sh /etc/profile.d/rapidast.sh
 
 ### Install RapiDAST requirements, globally, so that it's available to any user
 RUN microdnf -y module enable nodejs:24 && \
-  microdnf install -y --setopt=install_weak_deps=0 --nodocs python3.12 java-21-openjdk shadow-utils dbus-glib procps git-core nodejs npm && \
+  microdnf install -y --setopt=install_weak_deps=0 --nodocs python3.12 java-21-openjdk shadow-utils dbus-glib procps git-core nodejs npm python3-pyyaml && \
   microdnf install -y --nodocs gtk3 && \
   python3.12 -m ensurepip --upgrade && \
   python3.12 -m pip install --no-cache-dir -r /opt/rapidast/requirements-llm.txt && \


### PR DESCRIPTION
Install python3-pyyaml, which is needed by oobtkube.  In previous versions, in which system python3 / 3.9 was used to run RapiDAST, PyYAML was installed using pip.  After moving to Python 3.12 for RapiDAST, python3 can no longer find yaml module.

oobtkube.py currently uses python3 in its shebang line.  An alternative is to change that to use python3.12.  However, as the script has not been installed in the container with executable bit set, it's likely that any users have been running it as "python3 soobtkube.py" rather than trying to execute it directly.