### PR TITLE
Pin external GitHub Actions to SHA references

### DIFF
--- a/.github/workflows/python39-compat-check.yml
+++ b/.github/workflows/python39-compat-check.yml
@@ -16,7 +16,7 @@ jobs:
         run: dnf install -y --nodocs git-core
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # actions/checkout@v6
 
       - name: Create Python venv
         run: python3.9 -m venv .venv

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # actions/checkout@v6
     - name: Set up Python 3.12
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # actions/setup-python@v6
       with:
         python-version: "3.12"
         cache: 'pip'
@@ -33,9 +33,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # actions/checkout@v6
     - name: Set up Python 3.12
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # actions/setup-python@v6
       with:
         python-version: "3.12"
         cache: 'pip'

--- a/.github/workflows/tag-image.yml
+++ b/.github/workflows/tag-image.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Checkout repository code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -41,7 +41,7 @@ jobs:
 
     # https://github.com/redhat-actions/podman-login
     - name: Log in to quay.io
-      uses: redhat-actions/podman-login@v1
+      uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603  # redhat-actions/podman-login@v1
       with:
         registry: ${{ env.IMAGE_REGISTRY }}
         username: ${{ env.IMAGE_REGISTRY_USER }}

--- a/.github/workflows/validate-renovate.yml
+++ b/.github/workflows/validate-renovate.yml
@@ -14,5 +14,5 @@ jobs:
   renovate-config-validation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: konflux-ci/renovate-config-validator-action@main
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # actions/checkout@v6
+      - uses: konflux-ci/renovate-config-validator-action@078d8d5e483879bcb260de0f717be30b59df010c  # konflux-ci/renovate-config-validator-action@main


### PR DESCRIPTION
Replace tag-based references with SHA-pinned references for supply chain security.  Corresponding tags are preserved as comments for easier future maintenance.