### PR TITLE
Cleanups for ZAP related output

### DIFF
--- a/scanners/zap/zap.py
+++ b/scanners/zap/zap.py
@@ -437,9 +437,8 @@ class Zap(RapidastScanner):
                 "type": "standalone",
                 "name": "export-site-tree-filename-global-var",
                 "engine": "ECMAScript : Graal.js",
-                "inline": f"""
-                org.zaproxy.zap.extension.script.ScriptVars.setGlobalVar('siteTreeFileName','{self.SITE_TREE_FILENAME}')
-                """,
+                # pylint: disable=line-too-long
+                "inline": f"org.zaproxy.zap.extension.script.ScriptVars.setGlobalVar('siteTreeFileName','{self.SITE_TREE_FILENAME}')",
             },
         }
         self.automation_config["jobs"].append(site_tree_file_name_add)

--- a/scanners/zap/zap_none.py
+++ b/scanners/zap/zap_none.py
@@ -119,9 +119,10 @@ class ZapNone(Zap):
             logging.info(f"The addon state file {statefile} was not created")
 
         # Now the real run
-        logging.info(f"Running ZAP with the following command:\n{self.zap_cli}")
-
         cli = ["sh", "-c", self._zap_cli_list_to_str_for_sh(self.zap_cli)]
+
+        logging.info(f"Running ZAP with the following command: {cli}")
+
         result = subprocess.run(cli, check=False)
         logging.debug(f"ZAP returned the following:\n=====\n{pp.pformat(result)}\n=====")
 
@@ -258,7 +259,7 @@ class ZapNone(Zap):
         command.extend(["-dir", self.container_home_dir])
         shell = ["sh", "-c", self._zap_cli_list_to_str_for_sh(command)]
 
-        logging.debug(f"Addons setup command: {shell}")
+        logging.info(f"Running ZAP addons setup command: {shell}")
         result = subprocess.run(shell, check=False)
         if result.returncode != 0:
             logging.warning(

--- a/scanners/zap/zap_podman.py
+++ b/scanners/zap/zap_podman.py
@@ -126,7 +126,7 @@ class ZapPodman(Zap):
         cli = self.podman.get_complete_cli(cli)
 
         # DO STUFF
-        logging.info(f"Running ZAP with the following command:\n{cli}")
+        logging.info(f"Running ZAP with the following command: {self._zap_cli_list_to_str_for_sh(cli)}")
         result = subprocess.run(cli, check=False)
         logging.debug(f"ZAP returned the following:\n=====\n{pp.pformat(result)}\n=====")
 


### PR DESCRIPTION
Few changes to clean up output produced by ZAP or by RapiDAST when running ZAP.

When logging zap.sh commands to be run, consistently log the final string produced by _zap_cli_list_to_str_for_sh() instead of sometimes logging the string and sometimes the array that is passed to subprocess.run().

Also changing the value for the export-site-tree-filename-global-var AF task to avoid extra line breaks and spaces in the output.