### PR TITLE
Exclude ZAP session DB from GCS archives

### DIFF
--- a/exports/google_cloud_storage.py
+++ b/exports/google_cloud_storage.py
@@ -3,6 +3,7 @@ import datetime
 import logging
 import os
 import random
+import re
 import string
 import tarfile
 import uuid
@@ -61,10 +62,18 @@ class GoogleCloudStorage:
 
         logging.info(f"GoogleCloudStorage: sending the contents of the directory: {result_dir_name}")
 
+        # exclude certain files form being included in the archive uploaded to GCS
+        def _gcs_archive_excludes(tarinfo):
+            # ZAP's session database
+            if re.search(r"/zap(_[^/]*)?/session.tar.gz", tarinfo.name) is not None:
+                return None
+            else:
+                return tarinfo
+
         # create a tar containing the directory and its contents
         tar_stream = BytesIO()
         with tarfile.open(fileobj=tar_stream, mode="w:gz") as tar:
-            tar.add(name=result_dir_name, arcname=f"{os.path.basename(result_dir_name)}")
+            tar.add(name=result_dir_name, arcname=f"{os.path.basename(result_dir_name)}", filter=_gcs_archive_excludes)
         tar_stream.seek(0)
 
         # generate the blob filename


### PR DESCRIPTION
Stop including session.tar.gz file form ZAP scanner evidence to archives uploaded to GCS.  These archives include file already included outside of the session.tar.gz (such as ZAP report files), but also ZAP session database.  While this session database can be useful for troubleshooting scan problems, it's not well suitable for long term evidence storage - both because it can be of significant size for certain scans, and because it may include potentially sensitive information such as authentication credentials included.

The exclusion was tested in configurations using single "zap" scanner instance as well as multiple "zap_*" scanner instances, and both using none and podman container modes.