### PR TITLE
Update Python dependencies

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -4,8 +4,10 @@
 #
 #    pybuild-deps compile --output-file=requirements-build.txt
 #
-calver==2022.6.26
+calver==2025.10.20
     # via trove-classifiers
+cffi==2.0.0
+    # via cryptography
 cython==3.2.4
     # via pyyaml
 flit-core==3.12.0
@@ -20,7 +22,7 @@ flit-core==3.12.0
     #   pathspec
     #   typing-extensions
     #   wheel
-hatch-fancy-pypi-readme==24.1.0
+hatch-fancy-pypi-readme==25.1.0
     # via
     #   attrs
     #   jsonschema
@@ -42,78 +44,86 @@ hatchling==1.29.0
     #   referencing
     #   urllib3
 maturin==1.12.6
-    # via rpds-py
-mypy-extensions==1.1.0
-    # via mypy
-mypy==1.19.1
-    # via charset-normalizer
-packaging==24.2
+    # via
+    #   cryptography
+    #   pendulum
+    #   rpds-py
+packaging==26.0
     # via
     #   hatchling
     #   setuptools-scm
-pathspec==0.12.1
+    #   vcs-versioning
+    #   wheel
+pathspec==1.0.4
     # via hatchling
 pdm-backend==2.4.7
     # via
+    #   annotated-doc
     #   typer
     #   webcolors
 pluggy==1.6.0
     # via hatchling
-poetry-core==2.3.1
+poetry-core==2.3.2
     # via
+    #   cel-python
     #   rich
-    #   rsa
+pycparser==2.23
+    # via cffi
 semantic-version==2.10.0
     # via setuptools-rust
-setuptools-rust==1.12.0
+setuptools-rust==1.12.1
     # via maturin
-setuptools-scm==7.1.0
-    # via python-dateutil
-setuptools-scm==8.3.1
+setuptools-scm==10.0.5
     # via
-    #   charset-normalizer
     #   hatch-vcs
     #   pluggy
     #   setuptools-rust
     #   uri-template
-trove-classifiers==2025.12.1.14
+setuptools-scm==7.1.0
+    # via python-dateutil
+setuptools-scm==9.2.2
+    # via
+    #   hatch-vcs
+    #   urllib3
+trove-classifiers==2026.1.14.14
     # via hatchling
-types-psutil==7.2.2.20260130
-    # via mypy
-types-setuptools==75.8.2.20250305
-    # via mypy
 typing-extensions==4.15.0
+    # via setuptools-scm
+vcs-versioning==1.1.1
+    # via setuptools-scm
+wheel==0.46.3
     # via
-    #   mypy
-    #   setuptools-scm
-wheel==0.45.1
-    # via
-    #   cachetools
     #   google-crc32c
-    #   maturin
     #   python-dateutil
-    #   pyyaml
     #   shellingham
+    #   tzdata
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==75.9.1
+setuptools==82.0.0
+    # via charset-normalizer
+setuptools==82.0.1
     # via
-    #   cachetools
     #   calver
-    #   charset-normalizer
+    #   certifi
+    #   cffi
+    #   cryptography
     #   google-api-core
     #   google-crc32c
+    #   googleapis-common-protos
     #   maturin
-    #   mypy
     #   pathspec
     #   pluggy
     #   proto-plus
     #   pyasn1
     #   pyasn1-modules
     #   python-dateutil
+    #   python-dotenv
     #   pyyaml
     #   setuptools-rust
     #   setuptools-scm
     #   shellingham
     #   trove-classifiers
+    #   types-pyyaml
+    #   tzdata
     #   uri-template
+    #   vcs-versioning

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,11 +4,15 @@
 #
 #    pip-compile requirements-dev.in
 #
+annotated-doc==0.0.4
+    # via
+    #   -r requirements.txt
+    #   typer
 arrow==1.4.0
     # via
     #   -r requirements.txt
     #   isoduration
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   -r requirements.txt
     #   jsonschema
@@ -64,7 +68,6 @@ google-auth==2.49.1
     #   google-api-core
     #   google-cloud-core
     #   google-cloud-storage
-    #   kubernetes
 google-cloud-core==2.5.0
     # via
     #   -r requirements.txt
@@ -101,13 +104,13 @@ jsonpointer==3.0.0
     # via
     #   -r requirements.txt
     #   jsonschema
-jsonschema[format]==4.23.0
+jsonschema[format]==4.25.1
     # via -r requirements.txt
-jsonschema-specifications==2024.10.1
+jsonschema-specifications==2025.9.1
     # via
     #   -r requirements.txt
     #   jsonschema
-kubernetes==32.0.1
+kubernetes==35.0.0
     # via -r requirements-dev.in
 lark==0.12.0
     # via
@@ -130,9 +133,7 @@ mypy-extensions==1.1.0
 nodeenv==1.10.0
     # via pre-commit
 oauthlib==3.3.1
-    # via
-    #   kubernetes
-    #   requests-oauthlib
+    # via requests-oauthlib
 packaging==24.2
     # via
     #   black
@@ -155,7 +156,7 @@ proto-plus==1.27.1
     # via
     #   -r requirements.txt
     #   google-api-core
-protobuf==5.29.6
+protobuf==6.33.6
     # via
     #   -r requirements.txt
     #   google-api-core
@@ -167,7 +168,6 @@ pyasn1==0.6.3
     # via
     #   -r requirements.txt
     #   pyasn1-modules
-    #   rsa
 pyasn1-modules==0.4.2
     # via
     #   -r requirements.txt
@@ -179,8 +179,9 @@ pycparser==2.23
 pygments==2.19.2
     # via
     #   -r requirements.txt
+    #   pytest
     #   rich
-pytest==8.4.2
+pytest==9.0.2
     # via
     #   -r requirements-dev.in
     #   pytest-json-report
@@ -198,7 +199,7 @@ python-dateutil==2.9.0.post0
     #   arrow
     #   kubernetes
     #   pendulum
-python-dotenv==1.0.1
+python-dotenv==1.2.1
     # via
     #   -r requirements-dev.in
     #   -r requirements.txt
@@ -239,19 +240,15 @@ rfc3987==1.3.8
     # via
     #   -r requirements.txt
     #   jsonschema
-rich==13.9.4
+rich==14.3.3
     # via
     #   -r requirements.txt
     #   typer
-rpds-py==0.22.3
+rpds-py==0.27.1
     # via
     #   -r requirements.txt
     #   jsonschema
     #   referencing
-rsa==4.9.1
-    # via
-    #   -r requirements.txt
-    #   google-auth
 shellingham==1.5.4
     # via
     #   -r requirements.txt
@@ -266,7 +263,7 @@ text-unidecode==1.3
     # via
     #   -r requirements.txt
     #   python-slugify
-typer==0.15.1
+typer==0.23.1
     # via
     #   -r requirements.txt
     #   py-nessus-pro
@@ -278,7 +275,6 @@ typing-extensions==4.15.0
     # via
     #   -r requirements.txt
     #   referencing
-    #   typer
 tzdata==2025.3
     # via
     #   -r requirements.txt

--- a/requirements-llm.txt
+++ b/requirements-llm.txt
@@ -17,6 +17,10 @@ aiohttp==3.11.18
     #   litellm
 aiosignal==1.3.2
     # via aiohttp
+annotated-doc==0.0.4
+    # via
+    #   -r requirements.txt
+    #   typer
 annotated-types==0.7.0
     # via pydantic
 anyio==4.8.0
@@ -28,7 +32,7 @@ arrow==1.4.0
     # via
     #   -r requirements.txt
     #   isoduration
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   -r requirements.txt
     #   aiohttp
@@ -234,11 +238,11 @@ jsonpointer==3.0.0
     #   -r requirements.txt
     #   jsonpatch
     #   jsonschema
-jsonschema[format]==4.23.0
+jsonschema[format]==4.25.1
     # via
     #   -r requirements.txt
     #   litellm
-jsonschema-specifications==2024.10.1
+jsonschema-specifications==2025.9.1
     # via
     #   -r requirements.txt
     #   jsonschema
@@ -383,7 +387,7 @@ proto-plus==1.27.1
     # via
     #   -r requirements.txt
     #   google-api-core
-protobuf==5.29.6
+protobuf==6.33.6
     # via
     #   -r requirements.txt
     #   google-api-core
@@ -401,7 +405,6 @@ pyasn1==0.6.3
     # via
     #   -r requirements.txt
     #   pyasn1-modules
-    #   rsa
 pyasn1-modules==0.4.2
     # via
     #   -r requirements.txt
@@ -443,7 +446,7 @@ python-dateutil==2.9.0.post0
     #   octoai-sdk
     #   pandas
     #   pendulum
-python-dotenv==1.0.1
+python-dotenv==1.2.1
     # via
     #   -r requirements.txt
     #   litellm
@@ -519,20 +522,16 @@ rfc3987==1.3.8
     # via
     #   -r requirements.txt
     #   jsonschema
-rich==13.9.4
+rich==14.3.3
     # via
     #   -r requirements.txt
     #   fschat
     #   typer
-rpds-py==0.22.3
+rpds-py==0.27.1
     # via
     #   -r requirements.txt
     #   jsonschema
     #   referencing
-rsa==4.9.1
-    # via
-    #   -r requirements.txt
-    #   google-auth
 s3transfer==0.11.4
     # via boto3
 safetensors==0.5.3
@@ -603,7 +602,7 @@ transformers==4.49.0
     # via garak
 triton==3.2.0
     # via torch
-typer==0.15.1
+typer==0.23.1
     # via
     #   -r requirements.txt
     #   py-nessus-pro
@@ -630,7 +629,6 @@ typing-extensions==4.15.0
     #   replicate
     #   sqlalchemy
     #   torch
-    #   typer
 tzdata==2025.3
     # via
     #   -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,11 @@
 #
 #    pip-compile requirements.in
 #
+annotated-doc==0.0.4
+    # via typer
 arrow==1.4.0
     # via isoduration
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   jsonschema
     #   referencing
@@ -55,9 +57,9 @@ isoduration==20.11.0
     # via jsonschema
 jsonpointer==3.0.0
     # via jsonschema
-jsonschema[format]==4.23.0
+jsonschema[format]==4.25.1
     # via -r requirements.in
-jsonschema-specifications==2024.10.1
+jsonschema-specifications==2025.9.1
     # via jsonschema
 lark==0.12.0
     # via cel-python
@@ -71,7 +73,7 @@ pendulum==3.2.0
     # via cel-python
 proto-plus==1.27.1
     # via google-api-core
-protobuf==5.29.6
+protobuf==6.33.6
     # via
     #   google-api-core
     #   googleapis-common-protos
@@ -79,9 +81,7 @@ protobuf==5.29.6
 py-nessus-pro @ git+https://github.com/sfowl/py-nessus-pro.git@bce7f027eab36da822f190afadf1f2dda7ba5f4f
     # via -r requirements.in
 pyasn1==0.6.3
-    # via
-    #   pyasn1-modules
-    #   rsa
+    # via pyasn1-modules
 pyasn1-modules==0.4.2
     # via google-auth
 pycparser==2.23
@@ -92,7 +92,7 @@ python-dateutil==2.9.0.post0
     # via
     #   arrow
     #   pendulum
-python-dotenv==1.0.1
+python-dotenv==1.2.1
     # via -r requirements.in
 python-slugify==8.0.4
     # via py-nessus-pro
@@ -114,14 +114,12 @@ rfc3339-validator==0.1.4
     # via jsonschema
 rfc3987==1.3.8
     # via jsonschema
-rich==13.9.4
+rich==14.3.3
     # via typer
-rpds-py==0.22.3
+rpds-py==0.27.1
     # via
     #   jsonschema
     #   referencing
-rsa==4.9.1
-    # via google-auth
 shellingham==1.5.4
     # via typer
 six==1.17.0
@@ -130,14 +128,12 @@ six==1.17.0
     #   rfc3339-validator
 text-unidecode==1.3
     # via python-slugify
-typer==0.15.1
+typer==0.23.1
     # via py-nessus-pro
 types-pyyaml==6.0.12.20250915
     # via cel-python
 typing-extensions==4.15.0
-    # via
-    #   referencing
-    #   typer
+    # via referencing
 tzdata==2025.3
     # via
     #   arrow


### PR DESCRIPTION
Update multiple Python dependencies in requirements.txt.  This is primarily done to help renovate handle cases where multiple dependencies need to be updated at the same time.  Python 3.9 compatibility is preserved for now.

requirements-llm.txt, requirements-dev.txt, and requirements-build.txt were re-compiled after the main requirements.txt update.