### PR TITLE
Do not install gtk3 weak dependencies

### DIFF
--- a/containerize/Containerfile
+++ b/containerize/Containerfile
@@ -115,8 +115,19 @@ COPY ./containerize/path_rapidast.sh /etc/profile.d/rapidast.sh
 
 ### Install RapiDAST requirements, globally, so that it's available to any user
 RUN microdnf -y module enable nodejs:24 && \
-  microdnf install -y --setopt=install_weak_deps=0 --nodocs python3.12 java-21-openjdk shadow-utils dbus-glib procps git-core nodejs npm && \
-  microdnf install -y --nodocs gtk3 && \
+  microdnf install -y --setopt=install_weak_deps=0 --nodocs \
+      shadow-utils procps \
+      # RapiDAST
+      python3.12 \
+      # ZAP
+      java-21-openjdk \
+      # Firefox
+      gtk3 libX11-xcb \
+      # Redocly
+      nodejs npm \
+      # user convenience
+      git-core \
+      && \
   python3.12 -m ensurepip --upgrade && \
   python3.12 -m pip install --no-cache-dir -r /opt/rapidast/requirements.txt && \
   microdnf clean all -y && rm -rf /var/cache/dnf /tmp/* && \

--- a/containerize/Containerfile.garak
+++ b/containerize/Containerfile.garak
@@ -115,8 +115,19 @@ COPY ./containerize/path_rapidast.sh /etc/profile.d/rapidast.sh
 
 ### Install RapiDAST requirements, globally, so that it's available to any user
 RUN microdnf -y module enable nodejs:24 && \
-  microdnf install -y --setopt=install_weak_deps=0 --nodocs python3.12 java-21-openjdk shadow-utils dbus-glib procps git-core nodejs npm && \
-  microdnf install -y --nodocs gtk3 && \
+  microdnf install -y --setopt=install_weak_deps=0 --nodocs \
+      shadow-utils procps \
+      # RapiDAST
+      python3.12 \
+      # ZAP
+      java-21-openjdk \
+      # Firefox
+      gtk3 libX11-xcb \
+      # Redocly
+      nodejs npm \
+      # user convenience
+      git-core \
+      && \
   python3.12 -m ensurepip --upgrade && \
   python3.12 -m pip install --no-cache-dir -r /opt/rapidast/requirements-llm.txt && \
   microdnf clean all -y && rm -rf /var/cache/dnf /tmp/* && \


### PR DESCRIPTION
Avoid installing weak dependencies for gtk3.  This improves commit 9a44070, as the only extra package that needs to be installed for firefox to run when gtk3 weak dependencies are not installed is libX11-xcb.  This change reduces container image size by ~300MB.

dbus-glib is not installed any more.  It was added in 36aa9fad as a firefox dependency, but it is not required by the current firefox version.

The microdnf install command was annotated with extra inline comments to indicate why specific package is being installed.