### PR TITLE
Update ZAP add-ons in containers

### DIFF
--- a/artifacts.lock.yaml
+++ b/artifacts.lock.yaml
@@ -13,3 +13,90 @@ artifacts:
   - download_url: https://github.com/aquasecurity/trivy/releases/download/v0.69.3/trivy_0.69.3_Linux-64bit.tar.gz
     filename: trivy.tar.gz
     checksum: "sha256:1816b632dfe529869c740c0913e36bd1629cb7688bd5634f4a858c1d57c88b75"
+  - filename: ascanrules-release-81.zap
+    download_url: https://github.com/zaproxy/zap-extensions/releases/download/ascanrules-v81/ascanrules-release-81.zap
+    checksum: "sha256:6ee3193086d04b8ff2735b3d9b1818702c9c194ecd3810150401435723585955"
+  - filename: authhelper-beta-0.38.0.zap
+    download_url: https://github.com/zaproxy/zap-extensions/releases/download/authhelper-v0.38.0/authhelper-beta-0.38.0.zap
+    checksum: "sha256:bc2b4f1f7cfb62c3a0c3e49fe269c7cccd5e02380e364770287d675fa9f0d90f"
+  - filename: automation-beta-0.59.0.zap
+    download_url: https://github.com/zaproxy/zap-extensions/releases/download/automation-v0.59.0/automation-beta-0.59.0.zap
+    checksum: "sha256:6cb28f527d1edfc5fcf7982c2632a91573d3b72fccb42a86ae200dd2b9bf3387"
+  - filename: callhome-release-0.21.0.zap
+    download_url: https://github.com/zaproxy/zap-extensions/releases/download/callhome-v0.21.0/callhome-release-0.21.0.zap
+    checksum: "sha256:656b610e7a5e2688710dabdd0da859d92802eb0922b45c2cc3d1a0ab3ec916f1"
+  - filename: client-alpha-0.22.0.zap
+    download_url: https://github.com/zaproxy/zap-extensions/releases/download/client-v0.22.0/client-alpha-0.22.0.zap
+    checksum: "sha256:55b413fc2525aeef695b18b0f2b5b4c57a642fd216c51a9fa8844b41a0435dd3"
+  - filename: commonlib-release-1.41.0.zap
+    download_url: https://github.com/zaproxy/zap-extensions/releases/download/commonlib-v1.41.0/commonlib-release-1.41.0.zap
+    checksum: "sha256:0710af7f49df0a18763c8aa6c8bc6551fc69049ee9c17ce54530fa863fa0140d"
+  - filename: domxss-release-24.zap
+    download_url: https://github.com/zaproxy/zap-extensions/releases/download/domxss-v24/domxss-release-24.zap
+    checksum: "sha256:6f99b18d4af4a9f5277369b802ecf333b337ecce4e972d7dc08827253b604108"
+  - filename: encoder-release-1.9.0.zap
+    download_url: https://github.com/zaproxy/zap-extensions/releases/download/encoder-v1.9.0/encoder-release-1.9.0.zap
+    checksum: "sha256:5f826627a98cfa368b8b7e178850bebde73447f91eec852fa7f0af81ddd6a76c"
+  - filename: exim-beta-0.19.0.zap
+    download_url: https://github.com/zaproxy/zap-extensions/releases/download/exim-v0.19.0/exim-beta-0.19.0.zap
+    checksum: "sha256:a7df97fa19363b029caabd12e0cf57f2d331e7bc77dcc9e5ad52fed2fe40fb4e"
+  - filename: graaljs-alpha-0.14.0.zap
+    download_url: https://github.com/zaproxy/zap-extensions/releases/download/graaljs-v0.14.0/graaljs-alpha-0.14.0.zap
+    checksum: "sha256:1e196453fe9f660eb92e8debd6d0e07993741b52123a920c619c3bc5013c5020"
+  - filename: graphql-alpha-0.33.0.zap
+    download_url: https://github.com/zaproxy/zap-extensions/releases/download/graphql-v0.33.0/graphql-alpha-0.33.0.zap
+    checksum: "sha256:22f1246a302ef42b7eec9af340cc732494025a5fd6a0322d717dfccb44c5b8b3"
+  - filename: insights-alpha-0.4.0.zap
+    download_url: https://github.com/zaproxy/zap-extensions/releases/download/insights-v0.4.0/insights-alpha-0.4.0.zap
+    checksum: "sha256:895aebcc28974c1b7590c67de4683e25963683f78ae1f82a6f73c66990d30752"
+  - filename: network-beta-0.26.0.zap
+    download_url: https://github.com/zaproxy/zap-extensions/releases/download/network-v0.26.0/network-beta-0.26.0.zap
+    checksum: "sha256:0cbf12aa5597c4b80e0cdff6d956c834da343aa64e08c25b00903eab1cd20523"
+  - filename: openapi-beta-55.zap
+    download_url: https://github.com/zaproxy/zap-extensions/releases/download/openapi-v55/openapi-beta-55.zap
+    checksum: "sha256:17bc5d84bfea78c7e28cd654dea6b10cfc366213c9220c97c4cefa3bb6223521"
+  - filename: pscanrules-release-73.zap
+    download_url: https://github.com/zaproxy/zap-extensions/releases/download/pscanrules-v73/pscanrules-release-73.zap
+    checksum: "sha256:f20515978794f49558d83fde0b910270c86c4cfa7351914bda05e9eebbb83ef5"
+  - filename: quickstart-release-55.zap
+    download_url: https://github.com/zaproxy/zap-extensions/releases/download/quickstart-v55/quickstart-release-55.zap
+    checksum: "sha256:1c618c5381fe85cc63e89ab64e2881c4f376a687e82f35ee08078b79e312bc92"
+  - filename: replacer-release-22.zap
+    download_url: https://github.com/zaproxy/zap-extensions/releases/download/replacer-v22/replacer-release-22.zap
+    checksum: "sha256:e2cc4478f69fb0ea3fd65f21449e09664ae128df7b3903f1a1aa3ec026ed5b51"
+  - filename: reports-release-0.44.0.zap
+    download_url: https://github.com/zaproxy/zap-extensions/releases/download/reports-v0.44.0/reports-release-0.44.0.zap
+    checksum: "sha256:f9bba543d522bdaf57c6db9b2fe3b47cadc0eca1de84ccd6304df628ea63ba64"
+  - filename: requester-beta-7.10.0.zap
+    download_url: https://github.com/zaproxy/zap-extensions/releases/download/requester-v7.10.0/requester-beta-7.10.0.zap
+    checksum: "sha256:cca0589258a1c1c2a75dbffef5abf1ff46defa970800cf2748245f8e283aba3f"
+  - filename: retire-release-0.56.0.zap
+    download_url: https://github.com/zaproxy/zap-extensions/releases/download/retire-v0.56.0/retire-release-0.56.0.zap
+    checksum: "sha256:d5b3881326703bbad85ba27ba30c9e7a5d637f38ad82b36b0030857516e9e08b"
+  - filename: scanpolicies-alpha-0.8.0.zap
+    download_url: https://github.com/zaproxy/zap-extensions/releases/download/scanpolicies-v0.8.0/scanpolicies-alpha-0.8.0.zap
+    checksum: "sha256:bb1e2e0ce2d9febd41a9fab5a73aa536e1e88002e60e41065d2d9d492e7e7d1d"
+  - filename: scripts-release-45.18.0.zap
+    download_url: https://github.com/zaproxy/zap-extensions/releases/download/scripts-v45.18.0/scripts-release-45.18.0.zap
+    checksum: "sha256:b04619536227590182cf6e290d9a2368ea91a3f48ccccf3c10d3ace64802419d"
+  - filename: selenium-release-15.47.0.zap
+    download_url: https://github.com/zaproxy/zap-extensions/releases/download/selenium-v15.47.0/selenium-release-15.47.0.zap
+    checksum: "sha256:da994c0e0414050b46cac6906cd3e13b74941bf0659f22c3bf7096e62f6f276e"
+  - filename: soap-beta-30.zap
+    download_url: https://github.com/zaproxy/zap-extensions/releases/download/soap-v30/soap-beta-30.zap
+    checksum: "sha256:a3fdd84da9506bd5fef884e37d0a50194f28d410502f5f7a6da62302b55a2a36"
+  - filename: spider-release-0.20.0.zap
+    download_url: https://github.com/zaproxy/zap-extensions/releases/download/spider-v0.20.0/spider-release-0.20.0.zap
+    checksum: "sha256:82acf7e307fdd4f46ac4d387656370ecad9c2ab940e1c81d9776768bacdedcd5"
+  - filename: spiderAjax-release-23.30.0.zap
+    download_url: https://github.com/zaproxy/zap-extensions/releases/download/spiderAjax-v23.30.0/spiderAjax-release-23.30.0.zap
+    checksum: "sha256:c165905a2532e0ff728b10c33cf3853dabe779c9147080a1ec3a1e0bb048d822"
+  - filename: webdriverlinux-release-193.zap
+    download_url: https://github.com/zaproxy/zap-extensions/releases/download/webdriverlinux-v193/webdriverlinux-release-193.zap
+    checksum: "sha256:9a840889eea9507a3afd1da925d4f9c22ac861a0e08c92776ada67fd2bec95cb"
+  - filename: websocket-release-36.zap
+    download_url: https://github.com/zaproxy/zap-extensions/releases/download/websocket-v36/websocket-release-36.zap
+    checksum: "sha256:511082258f3ba9a203182f3be933a39426bcaf352cc75f7955db7b8642d63f4f"
+  - filename: zest-beta-48.13.0.zap
+    download_url: https://github.com/zaproxy/zap-extensions/releases/download/zest-v48.13.0/zest-beta-48.13.0.zap
+    checksum: "sha256:54ea8b26a42a2eca5b526e63c81270243e6ac3db0235dcea9cac1bd1c00257ec"

--- a/containerize/Containerfile
+++ b/containerize/Containerfile
@@ -40,6 +40,15 @@ RUN mkdir "${DEPS_DIR}" /tmp/node_modules && \
 RUN mkdir /opt/zap && \
   tar zxvf "$ZAP_FILE" --strip-components=1 -C /opt/zap
 
+## Install updated ZAP addons, replacing older bundled versions
+RUN for zap_file in "$DEPS_DIR"/*.zap; do \
+      [ -f "$zap_file" ] || continue; \
+      addon_name="${zap_file##*/}"; \
+      addon_name="${addon_name%-*-*.zap}"; \
+      rm -fv "/opt/zap/plugin/${addon_name}-"*.zap; \
+      cp -pv "$zap_file" /opt/zap/plugin/; \
+    done
+
 ## Firefox, for ZAP's SpiderAjax
 RUN mkdir -p /opt/firefox && \
   tar xavf "$FF_FILE" --strip-components=1 -C /opt/firefox

--- a/containerize/Containerfile.garak
+++ b/containerize/Containerfile.garak
@@ -40,6 +40,15 @@ RUN mkdir "${DEPS_DIR}" /tmp/node_modules && \
 RUN mkdir /opt/zap && \
   tar zxvf "$ZAP_FILE" --strip-components=1 -C /opt/zap
 
+## Install updated ZAP addons, replacing older bundled versions
+RUN for zap_file in "$DEPS_DIR"/*.zap; do \
+      [ -f "$zap_file" ] || continue; \
+      addon_name="${zap_file##*/}"; \
+      addon_name="${addon_name%-*-*.zap}"; \
+      rm -fv "/opt/zap/plugin/${addon_name}-"*.zap; \
+      cp -pv "$zap_file" /opt/zap/plugin/; \
+    done
+
 ## Firefox, for ZAP's SpiderAjax
 RUN mkdir -p /opt/firefox && \
   tar xavf "$FF_FILE" --strip-components=1 -C /opt/firefox

--- a/hack/download-artifacts.py
+++ b/hack/download-artifacts.py
@@ -12,10 +12,28 @@ import tempfile
 import yaml
 
 
+def verify_checksum(dest_path, checksum, filename):
+    expected_hash = checksum.removeprefix("sha256:")
+    dest_dir = os.path.dirname(dest_path)
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".sha256", delete=False, dir=dest_dir) as chk:
+        chk.write(f"{expected_hash}  {filename}\n")
+        chk_path = chk.name
+    try:
+        result = subprocess.run(
+            ["sha256sum", "--check", "--quiet", chk_path],
+            cwd=dest_dir,
+            check=False,
+        )
+        return result.returncode == 0
+    finally:
+        os.unlink(chk_path)
+
+
 def main():
     parser = argparse.ArgumentParser(description="Download and verify artifacts from a lock file.")
     parser.add_argument("-a", required=True, help="Path to the artifacts.lock.yaml file")
     parser.add_argument("-d", required=True, help="Destination directory for downloaded files")
+    parser.add_argument("files", nargs="*", metavar="filename", help="Artifacts to download (default: all)")
     args = parser.parse_args()
 
     with open(args.a, encoding="utf-8") as f:
@@ -25,6 +43,14 @@ def main():
     if not artifacts:
         print("No artifacts found in the file.", file=sys.stderr)
         sys.exit(1)
+
+    if args.files:
+        known = {a["filename"] for a in artifacts}
+        unknown = set(args.files) - known
+        if unknown:
+            print(f"Error: unknown artifact(s): {', '.join(sorted(unknown))}", file=sys.stderr)
+            sys.exit(1)
+        artifacts = [a for a in artifacts if a["filename"] in set(args.files)]
 
     os.makedirs(args.d, exist_ok=True)
 
@@ -38,6 +64,14 @@ def main():
             print(f"Error: checksum for {filename} does not start with 'sha256:' prefix: {checksum}", file=sys.stderr)
             sys.exit(1)
 
+        if os.path.exists(dest_path):
+            print(f"File {filename} already exists, verifying checksum: {checksum}")
+            if verify_checksum(dest_path, checksum, filename):
+                print(f"Checksum OK, skipping download for {filename}")
+                continue
+            print(f"Checksum mismatch for {filename}, removing and re-downloading", file=sys.stderr)
+            os.unlink(dest_path)
+
         print(f"Downloading: {download_url}")
         result = subprocess.run(
             ["curl", "-sSfL", download_url, "-o", dest_path],
@@ -47,26 +81,11 @@ def main():
             print(f"Error: artifact download failed (exit code {result.returncode})", file=sys.stderr)
             sys.exit(1)
 
-        # Strip "sha256:" prefix from checksum
-        expected_hash = checksum.removeprefix("sha256:")
-
-        # Write a checksum file and verify with sha256sum
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".sha256", delete=False, dir=args.d) as chk:
-            chk.write(f"{expected_hash}  {filename}\n")
-            chk_path = chk.name
-
-        try:
-            print(f"Verifying checksum for {filename}: {checksum}")
-            result = subprocess.run(
-                ["sha256sum", "--check", "--quiet", chk_path],
-                cwd=args.d,
-                check=False,
-            )
-            if result.returncode != 0:
-                print(f"Error: checksum verification failed for {filename}", file=sys.stderr)
-                sys.exit(1)
-        finally:
-            os.unlink(chk_path)
+        print(f"Verifying checksum for {filename}: {checksum}")
+        if not verify_checksum(dest_path, checksum, filename):
+            os.unlink(dest_path)
+            print(f"Error: checksum verification failed for {filename}", file=sys.stderr)
+            sys.exit(1)
 
     print("All artifacts downloaded and verified successfully.")
 

--- a/hack/get-artifact-version.py
+++ b/hack/get-artifact-version.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+#
+# Extract the version of an artifact listed in artifacts.lock.yaml from its download URL.
+#
+# pylint: disable=C0103
+import argparse
+import sys
+from urllib.parse import urlparse
+
+import yaml
+
+
+def version_from_github(url):
+    # .../releases/download/v<version>/...
+    parts = urlparse(url).path.split("/")
+    tag = parts[parts.index("download") + 1]
+    return tag.lstrip("v")
+
+
+def version_from_k8s(url):
+    # .../release/v<version>/...
+    parts = urlparse(url).path.split("/")
+    tag = parts[parts.index("release") + 1]
+    return tag.lstrip("v")
+
+
+def version_from_mozilla(url):
+    # .../firefox/releases/<version>/...
+    parts = urlparse(url).path.split("/")
+    return parts[parts.index("releases") + 1]
+
+
+VERSION_EXTRACTORS = {
+    "github.com": version_from_github,
+    "dl.k8s.io": version_from_k8s,
+    "releases.mozilla.org": version_from_mozilla,
+}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Extract artifact version from a lock file.")
+    parser.add_argument("-a", required=True, help="Path to the artifacts.lock.yaml file")
+    parser.add_argument("filename", help="Filename of the artifact")
+    args = parser.parse_args()
+
+    with open(args.a, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+
+    artifacts = data.get("artifacts", [])
+    if not artifacts:
+        print("No artifacts found in the file.", file=sys.stderr)
+        sys.exit(1)
+
+    artifact = next((a for a in artifacts if a["filename"] == args.filename), None)
+    if artifact is None:
+        print(f"Error: artifact '{args.filename}' not found in {args.a}", file=sys.stderr)
+        sys.exit(1)
+
+    download_url = artifact["download_url"]
+    hostname = urlparse(download_url).hostname
+
+    extractor = VERSION_EXTRACTORS.get(hostname)
+    if extractor is None:
+        print(f"Error: no version extractor for host '{hostname}'", file=sys.stderr)
+        sys.exit(1)
+
+    print(extractor(download_url))
+
+
+if __name__ == "__main__":
+    main()

--- a/hack/update-bundled-scanners.sh
+++ b/hack/update-bundled-scanners.sh
@@ -2,7 +2,12 @@
 #
 # Update scanners and other tools bundled in the RapiDAST container.
 #
-# GitHub CLI tool gh required to get information about GitHub releases.
+# GitHub CLI tool gh required to get information about GitHub releases.  jq,
+# yq, and xq tools required to parse data and update artifacts file.
+
+
+ARTIFACTS_FILE='artifacts.lock.yaml'
+ARTIFACTS_TMPDIR='tmp-artifacts'
 
 
 # check for the latest ZAP version
@@ -29,7 +34,87 @@ update_zap() {
 
 	_update_containerfiles "$varname" "$new_version"
 	_update_artifacts 'ZAP.tar.gz' "$url" "$digest"
+}
 
+
+# check for the ZAP addon updates
+update_zap_addons() {
+	local ZAP_VERSION_SHORT
+	ZAP_VERSION_SHORT=$(hack/get-artifact-version.py -a "$ARTIFACTS_FILE" 'ZAP.tar.gz' | cut -d. -f1,2)
+
+	hack/download-artifacts.py -a "$ARTIFACTS_FILE" -d "$ARTIFACTS_TMPDIR" 'ZAP.tar.gz' || return 1
+
+	local zapversions_xml="$ARTIFACTS_TMPDIR/ZapVersions-$ZAP_VERSION_SHORT.xml"
+	curl -sSL -o "$zapversions_xml" \
+		"https://github.com/zaproxy/zap-admin/raw/refs/heads/master/ZapVersions-$ZAP_VERSION_SHORT.xml"
+	if [ ! -s "$zapversions_xml" ]; then
+		echo "ERROR: Failed to download ZapVersions-$ZAP_VERSION_SHORT.xml" >&2
+		return 1
+	fi
+
+	# Build a temp artifacts file with all .zap entries stripped; we'll add back
+	# only the entries that reflect the latest versions from ZapVersions XML.
+	local tmp_artifacts="${ARTIFACTS_FILE}.tmp"
+	yq 'del(.artifacts[] | select(.filename | test("\.zap$")))' "$ARTIFACTS_FILE" > "$tmp_artifacts"
+
+	for i in $(tar tf "$ARTIFACTS_TMPDIR/ZAP.tar.gz" '*.zap' | sed 's,^.*/,,') ; do
+		local addon_name="${i%-*-*.zap}"
+		local tmp="${i%.zap}"
+		local current_status="${tmp#${addon_name}-}"; current_status="${current_status%-*}"
+		local current_version="${tmp##*-}"
+
+		local xml_version xml_status xml_file xml_url xml_hash
+
+		xml_version=$(xq -x "/ZAP/addon_${addon_name}/version" "$zapversions_xml")
+		if [ -z "$xml_version" ]; then
+			echo "$addon_name: not found in ZapVersions XML, skipping" >&2
+			continue
+		fi
+
+		xml_status=$(xq -x "/ZAP/addon_${addon_name}/status" "$zapversions_xml")
+		if [ "$xml_status" != "$current_status" ]; then
+			echo "$addon_name: status changed from $current_status to $xml_status, skipping"
+			continue
+		fi
+
+		if [ "$xml_version" = "$current_version" ]; then
+			echo "$addon_name: distribution=$current_version latest=$xml_version - no update needed"
+			continue
+		fi
+
+		local artifacts_filename artifacts_version
+		artifacts_filename=$(prefix="${addon_name}-${xml_status}-" \
+			yq '.artifacts[] | select(.filename | test("^" + env(prefix))) | .filename' "$ARTIFACTS_FILE")
+		artifacts_version="${artifacts_filename%.zap}"; artifacts_version="${artifacts_version##*-}"
+
+		if [ "$xml_version" = "$artifacts_version" ]; then
+			echo "$addon_name: distribution=$current_version latest=$xml_version artifacts=$artifacts_version - already updated"
+		else
+			echo "$addon_name: distribution=$current_version latest=$xml_version artifacts=${artifacts_version:-none} - update needed"
+		fi
+
+		xml_file=$(xq -x "/ZAP/addon_${addon_name}/file" "$zapversions_xml")
+		xml_url=$(xq -x "/ZAP/addon_${addon_name}/url" "$zapversions_xml")
+		xml_hash=$(xq -x "/ZAP/addon_${addon_name}/hash" "$zapversions_xml")
+		if [[ "$xml_hash" != SHA-256:* ]]; then
+			echo "$addon_name: unexpected hash format '$xml_hash', skipping" >&2
+			continue
+		fi
+		xml_hash="sha256:${xml_hash#SHA-256:}"
+
+		filename="$xml_file" url="$xml_url" digest="$xml_hash" \
+			yq -i '.artifacts += [{"filename": env(filename), "download_url": env(url), "checksum": env(digest)}]
+				| (.artifacts[-1].checksum) style="double"' \
+			"$tmp_artifacts"
+	done
+
+	if ! diff -q "$ARTIFACTS_FILE" "$tmp_artifacts" > /dev/null 2>&1; then
+		mv "$tmp_artifacts" "$ARTIFACTS_FILE"
+		echo "artifacts.lock.yaml updated with new ZAP addon versions"
+	else
+		rm "$tmp_artifacts"
+		echo "No ZAP addon version updates"
+	fi
 }
 
 
@@ -55,6 +140,11 @@ update_firefox() {
 	digest=`curl -sS "https://releases.mozilla.org/pub/firefox/releases/${new_version}/SHA256SUMS" \
 		| grep -F "$ff_file" \
 		| awk '{ print $1 }'`
+
+	if [ -z "$digest" ]; then
+		echo "ERROR: Failed to determine the Firefox checksum!" >&2
+		return 1
+	fi
 
 	_update_containerfiles "$varname" "$new_version"
 	_update_artifacts 'firefox.tar.xz' "$url" "sha256:$digest"
@@ -103,6 +193,11 @@ update_kubectl() {
 	url="https://dl.k8s.io/release/v$new_version/bin/linux/amd64/kubectl"
 	digest=`curl -sSL "$url.sha256"`
 
+	if [ -z "$digest" ]; then
+		echo "ERROR: Failed to determine the kubectl checksum!" >&2
+		return 1
+	fi
+
 	_update_containerfiles "$varname" "$new_version"
 	_update_artifacts 'kubectl' "$url" "sha256:$digest"
 }
@@ -122,7 +217,7 @@ _is_update_needed() {
 		echo "- no update needed"
 		return 1
 	else
-		echo "- updated needed from $current_version"
+		echo "- update needed from $current_version"
 		return 0
 	fi
 }
@@ -143,16 +238,33 @@ _update_artifacts() {
 
 	filename="$filename" url="$url" digest="$digest" \
 		yq -i '(.artifacts[] | select(.filename == env(filename)) )
-			|= ( .download_url = env(url) | .checksum = env(digest) | .checksum style="double")' artifacts.lock.yaml
+			|= ( .download_url = env(url) | .checksum = env(digest) | .checksum style="double")' "$ARTIFACTS_FILE"
 }
 
 
-if [ ! -d containerize  -o  ! -f artifacts.lock.yaml ]; then
+# ensure the script is run in the correct directory
+if [ ! -d containerize  -o  ! -f "$ARTIFACTS_FILE" ]; then
 	echo "ERROR: This script must be run from the RapiDAST repository root directory!" >&2
 	exit 1
 fi
 
-update_zap
-update_firefox
-update_trivy
-update_kubectl
+
+# scanners/tools to update can be specified as command line arguments, all are
+# updated if no argument is specified
+if [ $# -eq 0 ]; then
+	set -- zap zap-addons firefox trivy kubectl
+fi
+
+for scanner in "$@"; do
+	case "$scanner" in
+		zap)         update_zap ;;
+		zap-addons)  update_zap_addons ;;
+		firefox)     update_firefox ;;
+		trivy)       update_trivy ;;
+		kubectl)     update_kubectl ;;
+		*)
+			echo "ERROR: Unknown scanner or tool '$scanner'" >&2
+			exit 1
+			;;
+	esac
+done


### PR DESCRIPTION
ZAP release model is currently built around less frequent updates of the main application, and regular updates of add-ons, which implement parts of the ZAP functionality.

ZAP included in RapiDAST containers has been the GA version with no updated add-ons.  In the past, `zap.sh -cmd -silent -addonupdate` was run as part of the container build, but that step was removed in eef7bbc and is not compatible with hermetic builds.  RapiDAST can also be configured to run ZAP add-on update at the beginning of each scan.

This commit makes it possible to bundle updated add-ons in the RapiDAST containers, reducing the need to run update during each scan, or at least reducing the number of updates that need to be downloaded.  This is achieved by parsing current add-on versions from the ZapVersions-X.Y.xml file from the zaproxy/zap-admin GitHub repository.

Following tools where changed in this commit:

* hack/download-artifacts.py
  - Changed to accept optional arguments which indicate which artifacts to download rather than downloading all artifacts.
  - If artifact is already available in the target directory, do not re-download it.  Mostly useful for testing / development purposes.

* hack/get-artifact-version.py
  - A new script to extra current artifact version from artifacts.lock.yaml.  Allows extracting ZAP, Firefox, Trivy, or kubectl version.
  - Currently used by hack/update-bundled-scanners.sh to get current ZAP version, expected to be used in Containerfiles as well to avoid having hard-coded dependency versions there.

* hack/update-bundled-scanners.sh
  - Changed to accept optional arguments which indicate which scanner or tool should be updated - zap, firefox, trivy, kubectl
  - Added zap-addons "target", which looks for updated ZAP add-ons and notes them in artifacts.lock.yaml.

* containerize/Containerfile(s)
  - Read the list of ZAP add-ons updates from artifacts.lock.yaml file during container build and replace versions included in the ZAP tarball with updated versions.

artifacts.lock.yaml was update to list current add-on updates for ZAP 2.17.

Assisted-By: Claude Code / Claude Sonnet 4.6