### PR TITLE
fix: include Trivy contrib/ templates in container image

### DIFF
--- a/containerize/Containerfile
+++ b/containerize/Containerfile
@@ -97,6 +97,7 @@ COPY --from=deps /opt/zap /opt/zap
 COPY --from=deps /opt/firefox /opt/firefox
 COPY --from=deps /usr/local/bin/kubectl /usr/local/bin/kubectl
 COPY --from=deps /tmp/trivy/trivy /usr/local/bin/trivy
+COPY --from=deps /tmp/trivy/contrib /usr/local/share/trivy/templates
 COPY --from=deps /tmp/redocly/node_modules /opt/redocly/node_modules
 
 ENV PATH $PATH:/opt/zap/:/opt/rapidast/:/opt/firefox/

--- a/containerize/Containerfile.garak
+++ b/containerize/Containerfile.garak
@@ -97,6 +97,7 @@ COPY --from=deps /opt/zap /opt/zap
 COPY --from=deps /opt/firefox /opt/firefox
 COPY --from=deps /usr/local/bin/kubectl /usr/local/bin/kubectl
 COPY --from=deps /tmp/trivy/trivy /usr/local/bin/trivy
+COPY --from=deps /tmp/trivy/contrib /usr/local/share/trivy/templates
 COPY --from=deps /tmp/redocly/node_modules /opt/redocly/node_modules
 
 ENV PATH $PATH:/opt/zap/:/opt/rapidast/:/opt/firefox/


### PR DESCRIPTION
The Containerfile only copies the Trivy binary (`/usr/local/bin/trivy`) to the final image but not the default template files (`html.tpl`, `junit.tpl`, etc.).

This causes HTML report generation to fail:

```
FATAL  unable to write results: failed to initialize template writer:
  error retrieving template from path: open html: no such file or directory
```

JSON, SARIF, and table outputs work correctly -- only HTML is affected.

### Fix

Add a `COPY` instruction to both Containerfile variants to include the default templates, installed to `/usr/local/share/trivy/templates` to match the Trivy RPM convention:

```dockerfile
COPY --from=deps /tmp/trivy/contrib /usr/local/share/trivy/templates
```

### Tested

Verified inside the container image:

```
--template @/usr/local/share/trivy/templates/html.tpl  →  works
--template @html.tpl                                   →  does not work
--template @html                                       →  does not work
```

PSSECAUT-1573