### PR TITLE
renovate: Group boto3 and botocore updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,11 @@
   "prConcurrentLimit": 10,
   "packageRules": [
     {
+      "description": "Group boto3 and botocore updates into a single PR",
+      "matchPackageNames": ["boto3", "botocore"],
+      "groupName": "boto"
+    },
+    {
       "description": "Automerge non-major updates in .tekton folder and pre-commit-config to development branch",
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "matchFileNames": [".tekton/**", ".pre-commit-config.yaml"],


### PR DESCRIPTION
Define renovate group for boto3 and botocore to have single PR created for their updates, as those packages need to be updated together.