### PR TITLE
Revert "chore(deps): update dependency typer to v0.25.1 (#602)"

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -276,7 +276,7 @@ text-unidecode==1.3
     # via
     #   -r requirements.txt
     #   python-slugify
-typer==0.25.1
+typer==0.23.1
     # via
     #   -r requirements.txt
     #   py-nessus-pro

--- a/requirements-llm.txt
+++ b/requirements-llm.txt
@@ -606,7 +606,7 @@ transformers==5.7.0
     # via garak
 triton==3.6.0
     # via torch
-typer==0.25.1
+typer==0.23.1
     # via
     #   -r requirements.txt
     #   huggingface-hub

--- a/requirements.txt
+++ b/requirements.txt
@@ -132,7 +132,7 @@ six==1.17.0
     #   rfc3339-validator
 text-unidecode==1.3
     # via python-slugify
-typer==0.25.1
+typer==0.23.1
     # via py-nessus-pro
 typing-extensions==4.15.0
     # via referencing


### PR DESCRIPTION
This reverts commit 0756f1b95d4f1497680393ced3e1d6f9c02d3681.

The above commit introduced a dependency issue due to typer requiring newer click version than the one currently listed in requirements*.txt files.

This was not caught by the CI, because click was updated to a newer version as required by type via PR #595.  Tests ran for typer after that PR was merged, and hence succeeded.  However, click was downgraded again to an older version in PR #636, due to updated litellm conflicting with newer click versions.  Tests were not re-run for the typer update PR #602 after the click downgrade, hence the issue was not detected in the PR.