### PR TITLE
renovate: Apply config:recommended and minimum age

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "minimumReleaseAge": "7 days",
   "prConcurrentLimit": 10,
   "packageRules": [
     {


### PR DESCRIPTION
Update configuration to use the config:recommended preset: https://docs.renovatebot.com/presets-config/#configrecommended

The main motivation is to enable Dependency Dashboard: https://docs.renovatebot.com/configuration-options/#dependencydashboard

Also configure minimum release age to 7 days to avoid having dependency update PRs opened shortly after dependency packages releases: https://docs.renovatebot.com/key-concepts/minimum-release-age/ https://docs.renovatebot.com/configuration-options/#minimumreleaseage