### PR TITLE
renovate: Attempt to enable Dependency Dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "dependencyDashboard": true,
   "minimumReleaseAge": "7 days",
   "prConcurrentLimit": 10,
   "packageRules": [


### PR DESCRIPTION
Commit a9db5f5 attempted to enable the Dependency Dashboard by extending the config:recommended preset.  However, that did not work, as the MintMaker renovate configuration differs from the default upstream Renovate configuration and excludes Dependency Dashboard from the recommended preset.

This commit replaces the directive to extend config:recommended preset (as that's already done in the default MintMaker renovate.json) and adds explicit `"dependencyDashboard": true` instead.

Reference - MintMaker's default renovate config:
https://github.com/konflux-ci/mintmaker/blob/main/config/renovate/renovate.json