### PR TITLE
Update ose-cli image to rhel9 version

### DIFF
--- a/.tekton/integration-test-llm.yaml
+++ b/.tekton/integration-test-llm.yaml
@@ -89,7 +89,7 @@ spec:
               pushd /workspace
               git checkout "$(tasks.parse-metadata.results.source-git-revision)"
           - name: test
-            image: registry.redhat.io/openshift4/ose-cli:latest
+            image: registry.redhat.io/openshift4/ose-cli-rhel9:latest
             env:
             - name: KUBECONFIG
               value: /tmp/kubeconfig
@@ -114,7 +114,7 @@ spec:
               echo "$KUBECONFIG_VALUE" > "$KUBECONFIG"
               oc whoami
 
-              yum install -y python3.12 git
+              yum install -y python3.12 git-core
               python3.12 -m ensurepip
 
               python3.12 -m pip install -r requirements-dev.txt

--- a/.tekton/integration-test.yaml
+++ b/.tekton/integration-test.yaml
@@ -67,7 +67,7 @@ spec:
       taskSpec:
         steps:
           - name: copy-nessus-secret
-            image: registry.redhat.io/openshift4/ose-cli:latest
+            image: registry.redhat.io/openshift4/ose-cli-rhel9:latest
             env:
             - name: KUBECONFIG
               value: /tmp/kubeconfig
@@ -114,7 +114,7 @@ spec:
       taskSpec:
         steps:
           - name: copy-gcs-secret
-            image: registry.redhat.io/openshift4/ose-cli:latest
+            image: registry.redhat.io/openshift4/ose-cli-rhel9:latest
             env:
             - name: KUBECONFIG
               value: /tmp/kubeconfig
@@ -208,7 +208,7 @@ spec:
                 operator: notin
                 values: [""]
           - name: test
-            image: registry.redhat.io/openshift4/ose-cli:latest
+            image: registry.redhat.io/openshift4/ose-cli-rhel9:latest
             env:
             - name: KUBECONFIG
               value: /tmp/kubeconfig
@@ -238,7 +238,7 @@ spec:
               oc get secret gcs-credentials -o jsonpath='{.data.gcs-credentials\.json}' | base64 -d > "$GOOGLE_APPLICATION_CREDENTIALS"
               echo "GCS credentials extracted to $GOOGLE_APPLICATION_CREDENTIALS"
 
-              yum install -y python3.12 git
+              yum install -y python3.12 git-core
               python3.12 -m ensurepip
 
               source /workspace/.tekton/scripts/setup-cachi2-env.sh
@@ -300,7 +300,7 @@ spec:
 #                operator: notin
 #                values: [""]
 #          - name: test
-#            image: registry.redhat.io/openshift4/ose-cli:latest
+#            image: registry.redhat.io/openshift4/ose-cli-rhel9:latest
 #            env:
 #            - name: KUBECONFIG
 #              value: /tmp/kubeconfig
@@ -325,7 +325,7 @@ spec:
 #              echo "$KUBECONFIG_VALUE" > "$KUBECONFIG"
 #              oc whoami
 #
-#              yum install -y python3.12 git
+#              yum install -y python3.12 git-core
 #              python3.12 -m ensurepip
 #
 #              source /workspace/.tekton/scripts/setup-cachi2-env.sh

--- a/e2e-tests/manifests/cm-controller-deployment.yaml
+++ b/e2e-tests/manifests/cm-controller-deployment.yaml
@@ -28,7 +28,7 @@ spec:
             sleep 1
             sh -c "$(oc get configmap/vulnerable -o=jsonpath='{.data.target}')"
           done
-        image: registry.redhat.io/openshift4/ose-cli:latest
+        image: registry.redhat.io/openshift4/ose-cli-rhel9:latest
         imagePullPolicy: Always
         name: cm-controller
       serviceAccountName: ${SERVICEACCOUNT} # required to read Tasks from API server


### PR DESCRIPTION
The ose-cli image is used to run integration tests.  Its latest tag has not been updated for 11 months now.  Integration tests are currently failing due to python3.12 pyexpat needing newer expat RPM version. There are few options to deal with this:

- Update expat RPM before running 'python3.12 -m ensurepip'.
- Switch from using the 'latest' tag to using 'v4.15'.
- Move to RHEL-9 based ose-cli-rhel9:latest.

This commit implements the third option, as rapidast images are already based on RHEL-9, so let's use that version for tests as well.

Additionally, this commits avoid installing git and only installs git-core in the test images.